### PR TITLE
feat(aggregator): multi-path support for parallel Marcus instances

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -99,22 +99,33 @@ if HISTORICAL_MODE_AVAILABLE and ProjectHistoryAggregator and ProjectHistoryQuer
         logger.error(f"Failed to initialize historical analysis components: {e}")
         HISTORICAL_MODE_AVAILABLE = False
 
-# Load Marcus data path from config (for live mode aggregator)
+# Load Marcus data path(s) from config (for live mode aggregator)
 config_path = Path(__file__).parent.parent / "config.json"
 marcus_data_path_root = None
+_extra_marcus_roots: list[Path] = []
 try:
     with open(config_path, "r") as f:
         config = json.load(f)
-        marcus_data_path = config.get("marcus_data_path")
-        if marcus_data_path:
-            marcus_data_path_root = Path(marcus_data_path).parent
-            logger.info(f"Using Marcus data path from config: {marcus_data_path_root}")
+        # Multi-path support: marcus_data_paths overrides marcus_data_path
+        multi_paths = config.get("marcus_data_paths")
+        if multi_paths:
+            _extra_marcus_roots = [Path(p).parent for p in multi_paths]
+            marcus_data_path_root = _extra_marcus_roots[0]
+            logger.info(
+                f"Using {len(_extra_marcus_roots)} Marcus data paths from config"
+            )
         else:
-            marcus_data_path_root = None
-            logger.info("No Marcus data path in config, using auto-detection")
+            marcus_data_path = config.get("marcus_data_path")
+            if marcus_data_path:
+                marcus_data_path_root = Path(marcus_data_path).parent
+                _extra_marcus_roots = [marcus_data_path_root]
+                logger.info(
+                    f"Using Marcus data path from config: {marcus_data_path_root}"
+                )
+            else:
+                logger.info("No Marcus data path in config, using auto-detection")
 except Exception as e:
     logger.warning(f"Could not load config.json: {e}, using auto-detection")
-    marcus_data_path_root = None
 
 # Initialize FastAPI app
 app = FastAPI(
@@ -132,8 +143,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Initialize aggregator for snapshot API
-aggregator = Aggregator(marcus_root=marcus_root)
+# Initialize aggregator for snapshot API — multi-root if configured
+aggregator = (
+    Aggregator(marcus_roots=_extra_marcus_roots)
+    if _extra_marcus_roots
+    else Aggregator(marcus_root=marcus_root)
+)
 
 # Simple in-memory cache for snapshots (60s TTL for better performance)
 snapshot_cache: Dict[str, tuple[Dict[str, Any], datetime]] = {}

--- a/cato_src/core/aggregator.py
+++ b/cato_src/core/aggregator.py
@@ -831,6 +831,18 @@ class Aggregator:
                             filtered_tasks = [
                                 t for t in all_tasks if t.get("project_id") in match_ids
                             ]
+                            # Also include subtasks whose parent was matched
+                            matched_ids = {str(t.get("id", "")) for t in filtered_tasks}
+                            for task in all_tasks:
+                                parent_id = str(task.get("parent_task_id") or "")
+                                task_id = str(task.get("id", ""))
+                                if (
+                                    parent_id
+                                    and parent_id in matched_ids
+                                    and task_id not in matched_ids
+                                ):
+                                    filtered_tasks.append(task)
+                                    matched_ids.add(task_id)
                             logger.info(
                                 f"Fallback filtering: "
                                 f"{len(filtered_tasks)}"
@@ -922,6 +934,20 @@ class Aggregator:
                                             parent_id = task_id_str.split("_sub_")[0]
                                             parent_ids_to_include.add(parent_id)
                                         break
+
+                        # Include subtasks from subtasks.json whose parent was matched
+                        # (hex UUID subtask IDs fail the Planka numeric filter above)
+                        matched_ids = {str(t.get("id", "")) for t in filtered_tasks}
+                        for task in all_tasks:
+                            parent_id = str(task.get("parent_task_id") or "")
+                            if not parent_id:
+                                continue
+                            task_id = str(task.get("id", ""))
+                            if parent_id in matched_ids and task_id not in matched_ids:
+                                filtered_tasks.append(task)
+                                matched_ids.add(task_id)
+                                if "_sub_" in task_id:
+                                    parent_ids_to_include.add(parent_id)
 
                         # Collect dependency IDs from matched tasks
                         dependency_ids_to_include: set[str] = set()

--- a/cato_src/core/aggregator.py
+++ b/cato_src/core/aggregator.py
@@ -127,20 +127,35 @@ class Aggregator:
     single aggregation function.
     """
 
-    def __init__(self, marcus_root: Optional[Path] = None):
+    def __init__(
+        self,
+        marcus_root: Optional[Path] = None,
+        marcus_roots: Optional[List[Path]] = None,
+    ):
         """
         Initialize the aggregator.
 
         Parameters
         ----------
         marcus_root : Optional[Path]
-            Path to Marcus root directory. If None, auto-detects from current location.
+            Single Marcus root directory (backward-compatible form).
+        marcus_roots : Optional[List[Path]]
+            Multiple Marcus root directories for parallel experiments.
+            When provided, takes precedence over marcus_root. The first
+            entry becomes self.marcus_root for backward compatibility.
         """
-        if marcus_root is None:
-            # Auto-detect Marcus root (assumes viz is a subdirectory of Marcus)
-            self.marcus_root = Path(__file__).parent.parent.parent
+        # Resolve the list of roots: plural arg wins, else wrap singular
+        if marcus_roots is not None:
+            self.marcus_roots: List[Path] = [Path(r) for r in marcus_roots]
+        elif marcus_root is not None:
+            self.marcus_roots = [Path(marcus_root)]
         else:
-            self.marcus_root = Path(marcus_root)
+            # Auto-detect: assumes viz is a subdirectory of Marcus
+            auto_root = Path(__file__).parent.parent.parent
+            self.marcus_roots = [auto_root]
+
+        # Primary root (backward compat attribute)
+        self.marcus_root: Path = self.marcus_roots[0]
 
         self.persistence_dir = self.marcus_root / "data" / "marcus_state"
         self.conversation_logs_dir = self.marcus_root / "logs" / "conversations"
@@ -149,12 +164,15 @@ class Aggregator:
         self.project_matcher = ProjectMatcher(tolerance=20)
         self.snapshot_version_counter = 0
 
+        # Maps project_id → its source marcus_root (populated by _load_projects)
+        self._project_root: Dict[str, Path] = {}
+
         # Cache for projects data to avoid repeated file I/O
         self._projects_cache: Optional[List[Dict[str, Any]]] = None
         self._projects_cache_time: Optional[datetime] = None
         self._projects_cache_ttl = 60  # Cache for 60 seconds
 
-        logger.info(f"Initialized Aggregator with root: {self.marcus_root}")
+        logger.info(f"Initialized Aggregator with roots: {self.marcus_roots}")
 
     def create_snapshot(
         self,
@@ -378,7 +396,12 @@ class Aggregator:
         return snapshot
 
     def _load_projects(self) -> List[Dict[str, Any]]:
-        """Load projects from projects.json with caching."""
+        """Load projects from all marcus_roots with caching.
+
+        Merges projects.json from every root in self.marcus_roots. Roots
+        with no projects.json are silently skipped. Each project's source
+        root is recorded in self._project_root for downstream use.
+        """
         # Check cache first
         now = datetime.now(timezone.utc)
         if (
@@ -389,31 +412,33 @@ class Aggregator:
         ):
             return self._projects_cache
 
-        # Cache miss - load from file
-        projects_file = self.persistence_dir / "projects.json"
-        if not projects_file.exists():
-            logger.warning(f"Projects file not found: {projects_file}")
-            return []
+        all_projects: List[Dict[str, Any]] = []
+        project_root_map: Dict[str, Path] = {}
 
-        try:
-            with open(projects_file, "r") as f:
-                data = json.load(f)
-                # Extract actual projects (skip metadata like "active_project")
-                projects = []
+        for root in self.marcus_roots:
+            projects_file = root / "data" / "marcus_state" / "projects.json"
+            if not projects_file.exists():
+                logger.debug(f"Projects file not found (skipping): {projects_file}")
+                continue
+            try:
+                with open(projects_file, "r") as f:
+                    data = json.load(f)
                 for key, value in data.items():
                     if key != "active_project" and isinstance(value, dict):
                         if "id" in value:
-                            projects.append(value)
+                            all_projects.append(value)
+                            project_root_map[value["id"]] = root
+            except Exception as e:
+                logger.error(f"Error loading projects from {projects_file}: {e}")
 
-                # Update cache
-                self._projects_cache = projects
-                self._projects_cache_time = now
+        self._project_root = project_root_map
+        self._projects_cache = all_projects
+        self._projects_cache_time = now
 
-                logger.info(f"Loaded {len(projects)} projects")
-                return projects
-        except Exception as e:
-            logger.error(f"Error loading projects: {e}")
-            return []
+        logger.info(
+            f"Loaded {len(all_projects)} projects from {len(self.marcus_roots)} root(s)"
+        )
+        return all_projects
 
     def get_active_project_id(self) -> Optional[str]:
         """

--- a/cato_src/core/aggregator.py
+++ b/cato_src/core/aggregator.py
@@ -1125,8 +1125,56 @@ class Aggregator:
             logger.error(f"Error loading tasks: {e}")
             return []
 
+    @staticmethod
+    def _normalize_realtime_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize a realtime_*.jsonl entry to conversation log format.
+
+        realtime logs use {type, source, target, agent_id, ...} while the
+        aggregator expects {from_agent_id, to_agent_id, message_type, ...}.
+        This method adds the expected fields without removing originals.
+
+        Parameters
+        ----------
+        entry : Dict[str, Any]
+            Raw entry from a realtime_*.jsonl file.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Entry with added from_agent_id, to_agent_id, message_type fields.
+        """
+        normalized = dict(entry)
+        event_type = entry.get("type", "")
+
+        normalized["message_type"] = event_type
+
+        if event_type == "task_assignment":
+            normalized["to_agent_id"] = entry.get("agent_id") or entry.get("target")
+            normalized.setdefault("from_agent_id", entry.get("source"))
+        elif event_type in {
+            "task_request",
+            "task_progress",
+            "task_completion",
+            "task_blocked",
+        }:
+            normalized["from_agent_id"] = (
+                entry.get("agent_id") or entry.get("worker_id") or entry.get("source")
+            )
+            normalized.setdefault("to_agent_id", entry.get("target"))
+        else:
+            # Non-agent events (server_startup, ping_*) get None agent IDs
+            normalized.setdefault("from_agent_id", None)
+            normalized.setdefault("to_agent_id", None)
+
+        return normalized
+
     def _load_messages(self) -> List[Dict[str, Any]]:
-        """Load conversation messages from logs."""
+        """Load conversation messages from logs.
+
+        Loads both conversations_*.jsonl and realtime_*.jsonl files.
+        Realtime entries are normalized to the aggregator's expected field
+        names via _normalize_realtime_entry().
+        """
         messages: List[Dict[str, Any]] = []
         if not self.conversation_logs_dir.exists():
             logger.warning(
@@ -1135,11 +1183,17 @@ class Aggregator:
             return messages
 
         for log_file in self.conversation_logs_dir.glob("*.jsonl"):
+            is_realtime = log_file.name.startswith("realtime_")
             try:
                 with open(log_file, "r") as f:
                     for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
                         try:
-                            entry = json.loads(line.strip())
+                            entry = json.loads(line)
+                            if is_realtime and "from_agent_id" not in entry:
+                                entry = self._normalize_realtime_entry(entry)
                             messages.append(entry)
                         except json.JSONDecodeError:
                             continue

--- a/checklist.md
+++ b/checklist.md
@@ -4,6 +4,7 @@
 
 ### Bugs
 - [ ] [Active tasks not appearing in dashboard due to timing enrichment filter](https://github.com/lwgray/cato/issues/3) (#3)
+- [ ] [SQLite projects with all-digit ID prefixes take wrong filtering path, missing tasks on DAG](https://github.com/lwgray/cato/issues/21) (#21)
 
 ### Technical Debt
 - [ ] [Remove remaining historical analysis code from visualizationStore](https://github.com/lwgray/cato/issues/6) (#6)
@@ -27,4 +28,4 @@
 - [x] Fix: Active project not appearing in dashboard when it has no enriched tasks (#2)
 
 ---
-*Last updated: 2025-12-06*
+*Last updated: 2026-04-07*

--- a/config.json
+++ b/config.json
@@ -6,5 +6,11 @@
   "frontend": {
     "port": 5173
   },
-  "marcus_data_path": "/Users/lwgray/dev/marcus/data"
+  "marcus_data_path": "/Users/lwgray/dev/marcus/data",
+  "_comment_marcus_data_paths": "Uncomment to watch multiple parallel Marcus instances (overrides marcus_data_path)",
+  "_marcus_data_paths_example": [
+    "/Users/lwgray/dev/marcus/data",
+    "/tmp/parallel_exp_1/data",
+    "/tmp/parallel_exp_2/data"
+  ]
 }

--- a/dashboard/public/board-mockup.html
+++ b/dashboard/public/board-mockup.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Board Mockup</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: #0f172a;
+    color: #e2e8f0;
+    font-family: system-ui, sans-serif;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* ---- Fake header ---- */
+  .header {
+    background: #1e293b;
+    border-bottom: 1px solid #334155;
+    padding: 0.75rem 1rem;
+    font-size: 0.85rem;
+    color: #94a3b8;
+    flex-shrink: 0;
+  }
+
+  /* ---- THE BOARD: exact same CSS I put in BoardView.css ---- */
+  .board-view {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    background: #0f172a;
+    overflow: hidden;
+  }
+
+  .board-columns {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    gap: 0.75rem;
+    padding: 1rem 1rem 0.5rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .board-column {
+    flex: 1 1 0;
+    min-width: 220px;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    background: #1e293b;
+    border-radius: 0.5rem;
+    overflow: hidden;
+  }
+
+  .column-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 3px solid;
+    flex-shrink: 0;
+  }
+  .column-label { font-weight: 600; font-size: 0.875rem; flex: 1; }
+  .column-count {
+    font-size: 0.75rem; font-weight: 700; color: #0f172a;
+    padding: 0.125rem 0.5rem; border-radius: 999px;
+  }
+
+  /* THIS is the scrollable area */
+  .column-cards {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;    /* <-- scrollbar lives here */
+    padding: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .column-cards::-webkit-scrollbar { width: 5px; }
+  .column-cards::-webkit-scrollbar-thumb { background: #475569; border-radius: 3px; }
+
+  /* ---- Cards ---- */
+  .card {
+    background: #0f172a;
+    border-left: 4px solid #334155;
+    border-radius: 0.375rem;
+    padding: 0.625rem 0.75rem;
+    flex-shrink: 0;
+  }
+  .card-id   { font-size: 0.7rem; color: #64748b; font-family: monospace; }
+  .card-name { font-size: 0.825rem; font-weight: 600; color: #e2e8f0; margin: 0.2rem 0; }
+  .card-meta { font-size: 0.7rem; color: #38bdf8; }
+
+  /* ---- Parent group ---- */
+  .parent-group {
+    border-radius: 0.375rem;
+    border: 1px solid #334155;
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+  .parent-group-header {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.5rem;
+    background: #162032;
+  }
+  .parent-group-name {
+    font-size: 0.72rem; font-weight: 600; color: #94a3b8;
+    flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .parent-group-badge {
+    font-size: 0.65rem; font-weight: 700;
+    padding: 0.0625rem 0.375rem;
+    background: #1e3a5f; color: #60a5fa;
+    border-radius: 999px; border: 1px solid #3b82f644;
+    white-space: nowrap; flex-shrink: 0;
+  }
+  .parent-group-badge.all-done { background: #14532d; color: #4ade80; border-color: #16a34a44; }
+  .pbar { height: 2px; background: #0f172a; }
+  .pbar-fill { height: 100%; background: #3b82f6; }
+  .group-cards {
+    padding: 0.375rem 0.375rem 0.375rem 0.75rem;
+    background: #162032;
+    display: flex; flex-direction: column; gap: 0.375rem;
+  }
+  .group-cards .card { background: #1a2744; }
+
+  .expand-btn {
+    display: block;
+    width: calc(100% - 0.75rem);
+    margin: 0.25rem 0 0.375rem 0.375rem;
+    padding: 0.3rem 0;
+    background: none;
+    border: 1px dashed #334155;
+    border-radius: 4px;
+    color: #60a5fa;
+    font-size: 0.72rem; font-weight: 600;
+    cursor: pointer; text-align: center;
+  }
+  .expand-btn:hover { background: #1e3a5f33; border-color: #3b82f6; }
+
+  /* ---- Summary bar ---- */
+  .board-summary {
+    display: flex; align-items: center; justify-content: center;
+    gap: 0.5rem; padding: 0.625rem 1rem;
+    background: #1e293b; border-top: 1px solid #334155;
+    font-size: 0.825rem; color: #94a3b8;
+    flex-shrink: 0;
+  }
+  .board-summary strong { color: #e2e8f0; }
+  .sum-done strong { color: #10b981; }
+  .sum-agents strong { color: #3b82f6; }
+
+  /* ---- Annotations ---- */
+  .arrow-note {
+    position: absolute;
+    background: #f59e0b;
+    color: #0f172a;
+    font-size: 0.7rem; font-weight: 700;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    white-space: nowrap;
+    pointer-events: none;
+  }
+</style>
+</head>
+<body>
+
+<div class="header">Cato Dashboard — Board View Mockup &nbsp;|&nbsp; Columns scroll individually &nbsp;|&nbsp; Subtask groups truncate at 3</div>
+
+<div class="board-view">
+  <div class="board-columns">
+
+    <!-- BACKLOG: 6 cards, doesn't fit → should scroll -->
+    <div class="board-column">
+      <div class="column-header" style="border-bottom-color:#eab308">
+        <span>📋</span>
+        <span class="column-label">Backlog</span>
+        <span class="column-count" style="background:#eab308">10</span>
+      </div>
+      <div class="column-cards">
+
+        <!-- standalone card -->
+        <div class="card" style="border-left-color:#eab308">
+          <div class="card-id">#3c5c2c10</div>
+          <div class="card-name">Standalone task A</div>
+          <div class="card-meta">agent_unicorn_1 · 30m</div>
+        </div>
+
+        <!-- parent group: 5 subtasks, shows 3 + expand -->
+        <div class="parent-group">
+          <div class="parent-group-header">
+            <span class="parent-group-name">Implement Widget Display System</span>
+            <span class="parent-group-badge">0/5 ✓</span>
+          </div>
+          <div class="pbar"><div class="pbar-fill" style="width:0%"></div></div>
+          <div class="group-cards">
+            <div class="card"><div class="card-id">#88b51df6</div><div class="card-name">Implement responsive grid layout</div><div class="card-meta">agent_unicorn_1 · 30m</div></div>
+            <div class="card"><div class="card-id">#88b51df6</div><div class="card-name">Build widget rendering engine</div><div class="card-meta">agent_unicorn_1 · 30m</div></div>
+            <div class="card"><div class="card-id">#88b51df6</div><div class="card-name">Implement dashboard config</div><div class="card-meta">agent_unicorn_1 · 30m</div></div>
+          </div>
+          <!-- "Show 2 more" because 5 total, 3 shown -->
+          <button class="expand-btn">▾  Show 2 more tasks…</button>
+        </div>
+
+        <!-- another group -->
+        <div class="parent-group">
+          <div class="parent-group-header">
+            <span class="parent-group-name">Implement External Data Integration</span>
+            <span class="parent-group-badge">0/5 ✓</span>
+          </div>
+          <div class="pbar"><div class="pbar-fill" style="width:0%"></div></div>
+          <div class="group-cards">
+            <div class="card"><div class="card-id">#a0bdfd97</div><div class="card-name">Implement Weather Data Models</div><div class="card-meta">agent_unicorn_2 · 30m</div></div>
+            <div class="card"><div class="card-id">#a0bdfd97</div><div class="card-name">Build Weather API Client</div><div class="card-meta">agent_unicorn_2 · 45m</div></div>
+            <div class="card"><div class="card-id">#a0bdfd97</div><div class="card-name">Implement Weather Data Cache</div><div class="card-meta">agent_unicorn_2 · 30m</div></div>
+          </div>
+          <button class="expand-btn">▾  Show 2 more tasks…</button>
+        </div>
+
+        <!-- more standalone to force scroll -->
+        <div class="card" style="border-left-color:#eab308"><div class="card-id">#aaaa0001</div><div class="card-name">Standalone task B</div><div class="card-meta">agent_unicorn_1 · 60m</div></div>
+        <div class="card" style="border-left-color:#eab308"><div class="card-id">#aaaa0002</div><div class="card-name">Standalone task C</div><div class="card-meta">agent_unicorn_2 · 30m</div></div>
+        <div class="card" style="border-left-color:#eab308"><div class="card-id">#aaaa0003</div><div class="card-name">Standalone task D — only visible by scrolling ↑</div><div class="card-meta">agent_unicorn_2 · 45m</div></div>
+        <div class="card" style="border-left-color:#eab308"><div class="card-id">#aaaa0004</div><div class="card-name">Standalone task E — only visible by scrolling ↑</div><div class="card-meta">agent_unicorn_1 · 30m</div></div>
+
+      </div><!-- /column-cards -->
+    </div><!-- /backlog column -->
+
+    <!-- IN PROGRESS: 1 card -->
+    <div class="board-column">
+      <div class="column-header" style="border-bottom-color:#3b82f6">
+        <span>⚡</span>
+        <span class="column-label">In Progress</span>
+        <span class="column-count" style="background:#3b82f6">1</span>
+      </div>
+      <div class="column-cards">
+        <div class="card" style="border-left-color:#3b82f6">
+          <div class="card-id">#66e6751a</div>
+          <div class="card-name">Documentation &amp; Development Environment Setup</div>
+          <div class="card-meta">agent_unicorn_2 · 30m</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- BLOCKED: 0 -->
+    <div class="board-column">
+      <div class="column-header" style="border-bottom-color:#ef4444">
+        <span>🚫</span>
+        <span class="column-label">Blocked</span>
+        <span class="column-count" style="background:#ef4444">0</span>
+      </div>
+      <div class="column-cards">
+        <div style="color:#475569;font-size:0.8rem;text-align:center;padding:1rem;font-style:italic">No tasks</div>
+      </div>
+    </div>
+
+    <!-- DONE: 16 cards, definitely needs scroll -->
+    <div class="board-column">
+      <div class="column-header" style="border-bottom-color:#10b981">
+        <span>✓</span>
+        <span class="column-label">Done</span>
+        <span class="column-count" style="background:#10b981">16</span>
+      </div>
+      <div class="column-cards">
+
+        <div class="card" style="border-left-color:#10b981"><div class="card-id">#3c5c2c10</div><div class="card-name">Design System &amp; Visual Tokens</div><div class="card-meta">agent_unicorn_2 · 180m</div></div>
+        <div class="card" style="border-left-color:#10b981"><div class="card-id">#planning</div><div class="card-name">Marcus Planning: dashboard-v102</div><div class="card-meta">Marcus · planning</div></div>
+
+        <!-- group: 5 done subtasks, shows 3 + expand -->
+        <div class="parent-group">
+          <div class="parent-group-header">
+            <span class="parent-group-name">Shared Tech Foundation &amp; Project Setup</span>
+            <span class="parent-group-badge all-done">4/5 ✓</span>
+          </div>
+          <div class="pbar"><div class="pbar-fill" style="width:80%"></div></div>
+          <div class="group-cards">
+            <div class="card"><div class="card-id">#66e6751a</div><div class="card-name">TypeScript &amp; Build Configuration</div><div class="card-meta">agent_unicorn_1 · 60m</div></div>
+            <div class="card"><div class="card-id">#66e6751a</div><div class="card-name">Testing Infrastructure &amp; Jest Config</div><div class="card-meta">agent_unicorn_1 · 60m</div></div>
+            <div class="card"><div class="card-id">#66e6751a</div><div class="card-name">Project Directory Structure</div><div class="card-meta">agent_unicorn_1 · 30m</div></div>
+          </div>
+          <button class="expand-btn">▾  Show 2 more tasks…</button>
+        </div>
+
+        <!-- more done cards to force scroll -->
+        <div class="card" style="border-left-color:#10b981"><div class="card-id">#bbf20d33</div><div class="card-name">Define Widget Base Component Interface</div><div class="card-meta">agent_unicorn_2 · 45m</div></div>
+        <div class="card" style="border-left-color:#10b981"><div class="card-id">#bbf20d33</div><div class="card-name">Implement Widget Base Component</div><div class="card-meta">agent_unicorn_2 · 60m</div></div>
+        <div class="card" style="border-left-color:#10b981"><div class="card-id">#bbf20d33</div><div class="card-name">Create Widget Layout Container</div><div class="card-meta">agent_unicorn_2 · 45m</div></div>
+        <div class="card" style="border-left-color:#10b981"><div class="card-id">#bbf20d33</div><div class="card-name">Create Widget Documentation</div><div class="card-meta">agent_unicorn_1 · 30m</div></div>
+        <div class="card" style="border-left-color:#10b981"><div class="card-id">#3b82f6aa</div><div class="card-name">Build weather data fetcher — scroll to see ↑</div><div class="card-meta">agent_unicorn_2 · 60m</div></div>
+        <div class="card" style="border-left-color:#10b981"><div class="card-id">#3b82f6bb</div><div class="card-name">Create Weather Widget — scroll to see ↑</div><div class="card-meta">agent_unicorn_1 · 45m</div></div>
+        <div class="card" style="border-left-color:#10b981"><div class="card-id">#3b82f6cc</div><div class="card-name">Create dashboard layout — scroll to see ↑</div><div class="card-meta">agent_unicorn_2 · 30m</div></div>
+
+      </div><!-- /column-cards -->
+    </div><!-- /done column -->
+
+  </div><!-- /board-columns -->
+
+  <div class="board-summary">
+    <span><strong>27</strong> tasks</span>
+    <span style="color:#475569">·</span>
+    <span class="sum-done"><strong>37%</strong> complete</span>
+    <span style="color:#475569">·</span>
+    <span class="sum-agents"><strong>1</strong> agent active</span>
+  </div>
+</div>
+
+</body>
+</html>

--- a/dashboard/public/dag-grouping-options.html
+++ b/dashboard/public/dag-grouping-options.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Final Options Mockup</title>
+<style>
+  body { background: #0f172a; color: #e2e8f0; font-family: system-ui, sans-serif; margin: 0; padding: 2rem; }
+  h1 { color: #94a3b8; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 0.4rem 0; }
+  .section { margin-bottom: 3rem; }
+  .row { display: flex; gap: 2.5rem; align-items: flex-start; flex-wrap: wrap; }
+  .panel { }
+  .panel-label { font-size: 0.8rem; font-weight: 700; color: #60a5fa; margin-bottom: 0.35rem; }
+  .panel-desc { font-size: 0.72rem; color: #64748b; margin-bottom: 0.75rem; line-height: 1.5; max-width: 280px; }
+  svg { display: block; border-radius: 0.75rem; background: #1e293b; border: 1px solid #334155; }
+  .divider { border: none; border-top: 1px solid #334155; margin: 2.5rem 0; }
+</style>
+</head>
+<body>
+
+<!-- ===================== PROBLEM 2 ===================== -->
+<div class="section">
+  <h1>Problem 2 — Board: Max 3 cards + "Show all" expand</h1>
+  <p style="font-size:0.75rem;color:#64748b;margin:0.25rem 0 1.25rem">Groups show first 3 cards. A button at the bottom expands the group in-place to show all. No nested scroll.</p>
+  <div class="row">
+
+    <!-- STATE 1: collapsed to 3 -->
+    <div class="panel">
+      <div class="panel-label">State 1 — Max 3 visible</div>
+      <div class="panel-desc">Group header + progress bar + first 3 cards + "Show 2 more" button. Clean, short column.</div>
+      <svg width="280" height="480" viewBox="0 0 280 480">
+        <!-- column shell -->
+        <rect x="0" y="0" width="280" height="480" rx="10" fill="#1e293b" stroke="#334155"/>
+        <!-- header -->
+        <rect x="0" y="0" width="280" height="44" rx="10" fill="#1e293b"/>
+        <rect x="0" y="40" width="280" height="4" fill="#eab308"/>
+        <text x="16" y="27" fill="#e2e8f0" font-size="13" font-weight="700">📋  Backlog</text>
+        <rect x="228" y="14" width="36" height="18" rx="9" fill="#eab308"/>
+        <text x="246" y="27" fill="#0f172a" font-size="11" font-weight="700" text-anchor="middle">5</text>
+
+        <!-- group header -->
+        <rect x="8" y="52" width="264" height="26" rx="5" fill="#162032" stroke="#334155" stroke-width="0.75"/>
+        <text x="18" y="68" fill="#94a3b8" font-size="10.5" font-weight="600">▾  Integration verification...</text>
+        <rect x="220" y="57" width="44" height="16" rx="8" fill="#1e3a5f" stroke="#3b82f644"/>
+        <text x="242" y="68" fill="#60a5fa" font-size="9" font-weight="700" text-anchor="middle">0/5 ✓</text>
+
+        <!-- progress bar (0%) -->
+        <rect x="8" y="78" width="264" height="3" rx="1" fill="#0f172a"/>
+
+        <!-- card 1 -->
+        <rect x="16" y="83" width="248" height="62" rx="5" fill="#1a2744" stroke="#334155" stroke-width="0.5"/>
+        <rect x="16" y="83" width="4" height="62" rx="2 0 0 2" fill="#3b82f6"/>
+        <text x="26" y="99" fill="#64748b" font-size="8">#a0bdfd97</text>
+        <text x="26" y="113" fill="#e2e8f0" font-size="10.5" font-weight="600">Read contract and inspect...</text>
+        <text x="26" y="128" fill="#64748b" font-size="8.5" font-style="italic">Inspect project structure for integration</text>
+        <text x="26" y="141" fill="#38bdf8" font-size="9">agent_unicorn_2   30m</text>
+
+        <!-- card 2 -->
+        <rect x="16" y="149" width="248" height="62" rx="5" fill="#1a2744" stroke="#334155" stroke-width="0.5"/>
+        <rect x="16" y="149" width="4" height="62" rx="2 0 0 2" fill="#3b82f6"/>
+        <text x="26" y="165" fill="#64748b" font-size="8">#a0bdfd97</text>
+        <text x="26" y="179" fill="#e2e8f0" font-size="10.5" font-weight="600">Install dependencies and run tests</text>
+        <text x="26" y="194" fill="#64748b" font-size="8.5" font-style="italic">npm install, run test suite</text>
+        <text x="26" y="207" fill="#38bdf8" font-size="9">agent_unicorn_2   30m</text>
+
+        <!-- card 3 -->
+        <rect x="16" y="215" width="248" height="62" rx="5" fill="#1a2744" stroke="#334155" stroke-width="0.5"/>
+        <rect x="16" y="215" width="4" height="62" rx="2 0 0 2" fill="#3b82f6"/>
+        <text x="26" y="231" fill="#64748b" font-size="8">#a0bdfd97</text>
+        <text x="26" y="245" fill="#e2e8f0" font-size="10.5" font-weight="600">Build project and start app</text>
+        <text x="26" y="260" fill="#64748b" font-size="8.5" font-style="italic">Run build, launch dev server</text>
+        <text x="26" y="273" fill="#38bdf8" font-size="9">agent_unicorn_2   30m</text>
+
+        <!-- "Show 2 more" button -->
+        <rect x="16" y="281" width="248" height="28" rx="5" fill="#0f172a" stroke="#334155" stroke-dasharray="4,3"/>
+        <text x="140" y="299" fill="#60a5fa" font-size="10" font-weight="600" text-anchor="middle">▾  Show 2 more tasks…</text>
+
+        <!-- next group or standalone below -->
+        <rect x="8" y="317" width="264" height="26" rx="5" fill="#162032" stroke="#334155" stroke-width="0.75"/>
+        <text x="18" y="333" fill="#94a3b8" font-size="10.5" font-weight="600">▾  Shared Widget Base Comp...</text>
+        <rect x="220" y="321" width="44" height="16" rx="8" fill="#14532d" stroke="#16a34a44"/>
+        <text x="242" y="332" fill="#4ade80" font-size="9" font-weight="700" text-anchor="middle">4/5 ✓</text>
+        <rect x="8" y="343" width="264" height="3" rx="1" fill="#0f172a"/>
+        <rect x="8" y="343" width="211" height="3" rx="1" fill="#3b82f6"/>
+
+        <rect x="16" y="348" width="248" height="58" rx="5" fill="#1a2744" stroke="#334155" stroke-width="0.5"/>
+        <rect x="16" y="348" width="4" height="58" rx="2 0 0 2" fill="#10b981"/>
+        <text x="26" y="364" fill="#64748b" font-size="8">#bbf20d33</text>
+        <text x="26" y="378" fill="#e2e8f0" font-size="10.5" font-weight="600">Define Widget Base Component...</text>
+        <text x="26" y="398" fill="#38bdf8" font-size="9">agent_unicorn_2   45m</text>
+
+        <text x="140" y="460" fill="#4ade80" font-size="11" font-weight="600" text-anchor="middle">✓ Column stays short</text>
+      </svg>
+    </div>
+
+    <!-- STATE 2: expanded to show all -->
+    <div class="panel">
+      <div class="panel-label">State 2 — After clicking "Show 2 more"</div>
+      <div class="panel-desc">Group expands in-place. All 5 cards visible. Button becomes "Show less". No scroll needed.</div>
+      <svg width="280" height="600" viewBox="0 0 280 600">
+        <rect x="0" y="0" width="280" height="600" rx="10" fill="#1e293b" stroke="#334155"/>
+        <rect x="0" y="0" width="280" height="44" rx="10" fill="#1e293b"/>
+        <rect x="0" y="40" width="280" height="4" fill="#eab308"/>
+        <text x="16" y="27" fill="#e2e8f0" font-size="13" font-weight="700">📋  Backlog</text>
+        <rect x="228" y="14" width="36" height="18" rx="9" fill="#eab308"/>
+        <text x="246" y="27" fill="#0f172a" font-size="11" font-weight="700" text-anchor="middle">5</text>
+
+        <!-- group header -->
+        <rect x="8" y="52" width="264" height="26" rx="5" fill="#162032" stroke="#334155" stroke-width="0.75"/>
+        <text x="18" y="68" fill="#94a3b8" font-size="10.5" font-weight="600">▾  Integration verification...</text>
+        <rect x="220" y="57" width="44" height="16" rx="8" fill="#1e3a5f" stroke="#3b82f644"/>
+        <text x="242" y="68" fill="#60a5fa" font-size="9" font-weight="700" text-anchor="middle">0/5 ✓</text>
+        <rect x="8" y="78" width="264" height="3" rx="1" fill="#0f172a"/>
+
+        <!-- all 5 cards -->
+        <rect x="16" y="83" width="248" height="58" rx="5" fill="#1a2744" stroke="#334155" stroke-width="0.5"/>
+        <rect x="16" y="83" width="4" height="58" rx="2 0 0 2" fill="#3b82f6"/>
+        <text x="26" y="99" fill="#64748b" font-size="8">#read</text>
+        <text x="26" y="113" fill="#e2e8f0" font-size="10.5" font-weight="600">Read contract and inspect...</text>
+        <text x="26" y="133" fill="#38bdf8" font-size="9">agent_unicorn_2   30m</text>
+
+        <rect x="16" y="145" width="248" height="58" rx="5" fill="#1a2744" stroke="#334155" stroke-width="0.5"/>
+        <rect x="16" y="145" width="4" height="58" rx="2 0 0 2" fill="#3b82f6"/>
+        <text x="26" y="161" fill="#64748b" font-size="8">#install</text>
+        <text x="26" y="175" fill="#e2e8f0" font-size="10.5" font-weight="600">Install dependencies and run tests</text>
+        <text x="26" y="195" fill="#38bdf8" font-size="9">agent_unicorn_2   30m</text>
+
+        <rect x="16" y="207" width="248" height="58" rx="5" fill="#1a2744" stroke="#334155" stroke-width="0.5"/>
+        <rect x="16" y="207" width="4" height="58" rx="2 0 0 2" fill="#3b82f6"/>
+        <text x="26" y="223" fill="#64748b" font-size="8">#build</text>
+        <text x="26" y="237" fill="#e2e8f0" font-size="10.5" font-weight="600">Build project and start app</text>
+        <text x="26" y="257" fill="#38bdf8" font-size="9">agent_unicorn_2   30m</text>
+
+        <rect x="16" y="269" width="248" height="58" rx="5" fill="#1a2744" stroke="#334155" stroke-width="0.5"/>
+        <rect x="16" y="269" width="4" height="58" rx="2 0 0 2" fill="#3b82f6"/>
+        <text x="26" y="285" fill="#64748b" font-size="8">#verify</text>
+        <text x="26" y="299" fill="#e2e8f0" font-size="10.5" font-weight="600">Verify component wiring...</text>
+        <text x="26" y="319" fill="#38bdf8" font-size="9">agent_unicorn_2   45m</text>
+
+        <rect x="16" y="331" width="248" height="58" rx="5" fill="#1a2744" stroke="#334155" stroke-width="0.5"/>
+        <rect x="16" y="331" width="4" height="58" rx="2 0 0 2" fill="#3b82f6"/>
+        <text x="26" y="347" fill="#64748b" font-size="8">#fix</text>
+        <text x="26" y="361" fill="#e2e8f0" font-size="10.5" font-weight="600">Fix issues and re-verify</text>
+        <text x="26" y="381" fill="#38bdf8" font-size="9">agent_unicorn_2   30m</text>
+
+        <!-- "show less" button -->
+        <rect x="16" y="393" width="248" height="26" rx="5" fill="#0f172a" stroke="#334155" stroke-dasharray="4,3"/>
+        <text x="140" y="410" fill="#475569" font-size="10" text-anchor="middle">▴  Show less</text>
+
+        <text x="140" y="460" fill="#4ade80" font-size="11" font-weight="600" text-anchor="middle">✓ All cards visible, no scroll</text>
+      </svg>
+    </div>
+
+  </div>
+</div>
+
+<hr class="divider"/>
+
+<!-- ===================== PROBLEM 1 ===================== -->
+<div class="section">
+  <h1>Problem 1 — DAG: Hover-only Highlight</h1>
+  <p style="font-size:0.75rem;color:#64748b;margin:0.25rem 0 1.25rem">No persistent grouping marks. Graph is clean at rest. Hover any node → all siblings in the same parent group glow and non-siblings dim.</p>
+  <div class="row">
+
+    <!-- AT REST -->
+    <div class="panel">
+      <div class="panel-label">At Rest — No grouping marks</div>
+      <div class="panel-desc">Plain nodes, no boxes, no rings. Graph is uncluttered. All nodes equal weight visually.</div>
+      <svg width="400" height="440" viewBox="0 0 400 440">
+        <defs>
+          <marker id="a0" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+            <path d="M0,0 L6,3 L0,6 Z" fill="#475569"/>
+          </marker>
+        </defs>
+
+        <!-- dep edges -->
+        <line x1="80" y1="88" x2="155" y2="148" stroke="#475569" stroke-width="1.3" marker-end="url(#a0)"/>
+        <line x1="160" y1="88" x2="230" y2="148" stroke="#475569" stroke-width="1.3" marker-end="url(#a0)"/>
+        <line x1="290" y1="88" x2="310" y2="148" stroke="#475569" stroke-width="1.3" marker-end="url(#a0)"/>
+        <line x1="80" y1="178" x2="100" y2="238" stroke="#475569" stroke-width="1.3" marker-end="url(#a0)"/>
+        <line x1="175" y1="178" x2="160" y2="238" stroke="#475569" stroke-width="1.3" marker-end="url(#a0)"/>
+        <line x1="250" y1="178" x2="240" y2="238" stroke="#475569" stroke-width="1.3" marker-end="url(#a0)"/>
+        <line x1="320" y1="178" x2="310" y2="238" stroke="#475569" stroke-width="1.3" marker-end="url(#a0)"/>
+        <line x1="120" y1="268" x2="190" y2="328" stroke="#475569" stroke-width="1.3" marker-end="url(#a0)"/>
+        <line x1="260" y1="268" x2="260" y2="328" stroke="#475569" stroke-width="1.3" marker-end="url(#a0)"/>
+
+        <!-- row 1 nodes -->
+        <circle cx="80" cy="74" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5"/>
+        <text x="80" y="78" fill="white" font-size="9" font-weight="700" text-anchor="middle">100%</text>
+        <text x="80" y="112" fill="#94a3b8" font-size="8.5" text-anchor="middle">Design System</text>
+
+        <circle cx="160" cy="74" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5"/>
+        <text x="160" y="78" fill="white" font-size="9" font-weight="700" text-anchor="middle">100%</text>
+        <text x="160" y="112" fill="#94a3b8" font-size="8.5" text-anchor="middle">TypeScript...</text>
+
+        <circle cx="290" cy="74" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5"/>
+        <text x="290" y="78" fill="white" font-size="9" font-weight="700" text-anchor="middle">100%</text>
+        <text x="290" y="112" fill="#94a3b8" font-size="8.5" text-anchor="middle">Impl. dashboard</text>
+
+        <!-- row 2 nodes -->
+        <circle cx="80" cy="164" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5"/>
+        <text x="80" y="168" fill="white" font-size="9" font-weight="700" text-anchor="middle">100%</text>
+        <text x="80" y="202" fill="#94a3b8" font-size="8.5" text-anchor="middle">Testing Infra</text>
+
+        <circle cx="175" cy="164" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5"/>
+        <text x="175" y="168" fill="white" font-size="9" font-weight="700" text-anchor="middle">100%</text>
+        <text x="175" y="202" fill="#94a3b8" font-size="8.5" text-anchor="middle">Proj. Directory</text>
+
+        <circle cx="250" cy="164" r="26" fill="#3b82f6" stroke="#0f172a" stroke-width="2.5"/>
+        <text x="250" y="168" fill="white" font-size="9" font-weight="700" text-anchor="middle">60%</text>
+        <text x="250" y="202" fill="#94a3b8" font-size="8.5" text-anchor="middle">Weather API</text>
+
+        <circle cx="320" cy="164" r="26" fill="#64748b" stroke="#0f172a" stroke-width="2.5"/>
+        <text x="320" y="168" fill="white" font-size="9" font-weight="700" text-anchor="middle">0%</text>
+        <text x="320" y="202" fill="#94a3b8" font-size="8.5" text-anchor="middle">Define Widget</text>
+
+        <!-- row 3 nodes -->
+        <circle cx="120" cy="254" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5"/>
+        <text x="120" y="258" fill="white" font-size="9" font-weight="700" text-anchor="middle">100%</text>
+        <text x="120" y="292" fill="#94a3b8" font-size="8.5" text-anchor="middle">Build Weather</text>
+
+        <circle cx="260" cy="254" r="26" fill="#64748b" stroke="#0f172a" stroke-width="2.5"/>
+        <text x="260" y="258" fill="white" font-size="9" font-weight="700" text-anchor="middle">0%</text>
+        <text x="260" y="292" fill="#94a3b8" font-size="8.5" text-anchor="middle">Impl. Widget</text>
+
+        <!-- row 4 -->
+        <circle cx="200" cy="344" r="26" fill="#64748b" stroke="#0f172a" stroke-width="2.5"/>
+        <text x="200" y="348" fill="white" font-size="9" font-weight="700" text-anchor="middle">0%</text>
+        <text x="200" y="382" fill="#94a3b8" font-size="8.5" text-anchor="middle">Verify wiring</text>
+
+        <circle cx="280" cy="344" r="26" fill="#64748b" stroke="#0f172a" stroke-width="2.5"/>
+        <text x="280" y="348" fill="white" font-size="9" font-weight="700" text-anchor="middle">0%</text>
+        <text x="280" y="382" fill="#94a3b8" font-size="8.5" text-anchor="middle">Fix &amp; re-verify</text>
+
+        <text x="200" y="420" fill="#64748b" font-size="11" text-anchor="middle">← Clean. No grouping marks visible at rest.</text>
+      </svg>
+    </div>
+
+    <!-- HOVERED: group A siblings glow -->
+    <div class="panel">
+      <div class="panel-label">On Hover — "Testing Infra" hovered</div>
+      <div class="panel-desc">Hovering a node highlights all siblings (same parent). Non-siblings dim. Tooltip names the parent group + progress. Cursor moves away → resets.</div>
+      <svg width="400" height="440" viewBox="0 0 400 440">
+        <defs>
+          <marker id="a1" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+            <path d="M0,0 L6,3 L0,6 Z" fill="#334155"/>
+          </marker>
+          <marker id="a1hi" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+            <path d="M0,0 L6,3 L0,6 Z" fill="#8b5cf6"/>
+          </marker>
+          <filter id="glow">
+            <feGaussianBlur stdDeviation="5" result="blur"/>
+            <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+          </filter>
+        </defs>
+
+        <!-- dim edges (non-highlighted) -->
+        <line x1="80" y1="88" x2="155" y2="148" stroke="#334155" stroke-width="1" marker-end="url(#a1)" opacity="0.3"/>
+        <line x1="160" y1="88" x2="230" y2="148" stroke="#334155" stroke-width="1" marker-end="url(#a1)" opacity="0.3"/>
+        <line x1="290" y1="88" x2="310" y2="148" stroke="#334155" stroke-width="1" marker-end="url(#a1)" opacity="0.3"/>
+        <line x1="175" y1="178" x2="160" y2="238" stroke="#334155" stroke-width="1" marker-end="url(#a1)" opacity="0.3"/>
+        <line x1="250" y1="178" x2="240" y2="238" stroke="#334155" stroke-width="1" marker-end="url(#a1)" opacity="0.3"/>
+        <line x1="320" y1="178" x2="310" y2="238" stroke="#334155" stroke-width="1" marker-end="url(#a1)" opacity="0.3"/>
+        <line x1="120" y1="268" x2="190" y2="328" stroke="#334155" stroke-width="1" marker-end="url(#a1)" opacity="0.3"/>
+        <line x1="260" y1="268" x2="260" y2="328" stroke="#334155" stroke-width="1" marker-end="url(#a1)" opacity="0.3"/>
+
+        <!-- highlighted sibling edges -->
+        <line x1="80" y1="178" x2="100" y2="238" stroke="#8b5cf6" stroke-width="1.5" marker-end="url(#a1hi)" opacity="0.6"/>
+
+        <!-- DIM nodes (non-siblings) -->
+        <circle cx="80" cy="74" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5" opacity="0.2"/>
+        <text x="80" y="78" fill="white" font-size="9" font-weight="700" text-anchor="middle" opacity="0.2">100%</text>
+
+        <circle cx="160" cy="74" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5" opacity="0.2"/>
+        <text x="160" y="78" fill="white" font-size="9" font-weight="700" text-anchor="middle" opacity="0.2">100%</text>
+
+        <circle cx="290" cy="74" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5" opacity="0.2"/>
+        <text x="290" y="78" fill="white" font-size="9" font-weight="700" text-anchor="middle" opacity="0.2">100%</text>
+
+        <circle cx="175" cy="164" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5" opacity="0.2"/>
+        <text x="175" y="168" fill="white" font-size="9" font-weight="700" text-anchor="middle" opacity="0.2">100%</text>
+
+        <circle cx="250" cy="164" r="26" fill="#3b82f6" stroke="#0f172a" stroke-width="2.5" opacity="0.2"/>
+        <text x="250" y="168" fill="white" font-size="9" font-weight="700" text-anchor="middle" opacity="0.2">60%</text>
+
+        <circle cx="320" cy="164" r="26" fill="#64748b" stroke="#0f172a" stroke-width="2.5" opacity="0.2"/>
+        <text x="320" y="168" fill="white" font-size="9" font-weight="700" text-anchor="middle" opacity="0.2">0%</text>
+
+        <circle cx="260" cy="254" r="26" fill="#64748b" stroke="#0f172a" stroke-width="2.5" opacity="0.2"/>
+        <text x="260" y="258" fill="white" font-size="9" font-weight="700" text-anchor="middle" opacity="0.2">0%</text>
+
+        <circle cx="200" cy="344" r="26" fill="#64748b" stroke="#0f172a" stroke-width="2.5" opacity="0.2"/>
+        <text x="200" y="348" fill="white" font-size="9" font-weight="700" text-anchor="middle" opacity="0.2">0%</text>
+
+        <circle cx="280" cy="344" r="26" fill="#64748b" stroke="#0f172a" stroke-width="2.5" opacity="0.2"/>
+        <text x="280" y="348" fill="white" font-size="9" font-weight="700" text-anchor="middle" opacity="0.2">0%</text>
+
+        <!-- HIGHLIGHTED siblings (group: "Shared Tech Foundation") -->
+        <!-- glow halos -->
+        <circle cx="80" cy="164" r="34" fill="#8b5cf6" opacity="0.18"/>
+        <circle cx="120" cy="254" r="34" fill="#8b5cf6" opacity="0.18"/>
+
+        <!-- sibling 1: hovered node -->
+        <circle cx="80" cy="164" r="26" fill="#10b981" stroke="#8b5cf6" stroke-width="3" filter="url(#glow)"/>
+        <text x="80" y="168" fill="white" font-size="9" font-weight="700" text-anchor="middle">100%</text>
+        <text x="80" y="202" fill="#a78bfa" font-size="8.5" font-weight="600" text-anchor="middle">Testing Infra</text>
+        <!-- cursor indicator -->
+        <text x="60" y="155" fill="#f8fafc" font-size="14">↖</text>
+
+        <!-- sibling 2 -->
+        <circle cx="120" cy="254" r="26" fill="#10b981" stroke="#8b5cf6" stroke-width="3" filter="url(#glow)"/>
+        <text x="120" y="258" fill="white" font-size="9" font-weight="700" text-anchor="middle">100%</text>
+        <text x="120" y="292" fill="#a78bfa" font-size="8.5" font-weight="600" text-anchor="middle">Build Weather</text>
+
+        <!-- tooltip -->
+        <rect x="100" y="118" width="205" height="34" rx="6" fill="#1e293b" stroke="#8b5cf6" stroke-width="1.5"/>
+        <text x="113" y="132" fill="#a78bfa" font-size="9.5" font-weight="700">Shared Tech Foundation &amp; P...</text>
+        <text x="113" y="146" fill="#60a5fa" font-size="9">2 / 5 subtasks done</text>
+        <!-- connector -->
+        <line x1="100" y1="135" x2="88" y2="150" stroke="#8b5cf6" stroke-width="1" stroke-dasharray="3,2"/>
+
+        <text x="200" y="420" fill="#4ade80" font-size="11" text-anchor="middle">✓ Clean at rest. Informative on hover.</text>
+      </svg>
+    </div>
+
+    <!-- HOVERED: different group -->
+    <div class="panel">
+      <div class="panel-label">On Hover — different node, different group</div>
+      <div class="panel-desc">Hovering "Define Widget" highlights its 3 siblings in a different color. Each parent group gets a consistent hue (assigned at load, not per-status).</div>
+      <svg width="400" height="440" viewBox="0 0 400 440">
+        <defs>
+          <marker id="a2" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+            <path d="M0,0 L6,3 L0,6 Z" fill="#334155"/>
+          </marker>
+          <marker id="a2hi" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+            <path d="M0,0 L6,3 L0,6 Z" fill="#06b6d4"/>
+          </marker>
+          <filter id="glow2">
+            <feGaussianBlur stdDeviation="5" result="blur"/>
+            <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+          </filter>
+        </defs>
+
+        <!-- all edges dim -->
+        <line x1="80" y1="88" x2="155" y2="148" stroke="#334155" stroke-width="1" opacity="0.25"/>
+        <line x1="160" y1="88" x2="230" y2="148" stroke="#334155" stroke-width="1" opacity="0.25"/>
+        <line x1="290" y1="88" x2="310" y2="148" stroke="#334155" stroke-width="1" opacity="0.25"/>
+        <line x1="80" y1="178" x2="100" y2="238" stroke="#334155" stroke-width="1" opacity="0.25"/>
+        <line x1="175" y1="178" x2="160" y2="238" stroke="#334155" stroke-width="1" opacity="0.25"/>
+        <line x1="250" y1="178" x2="240" y2="238" stroke="#334155" stroke-width="1" opacity="0.25"/>
+        <line x1="120" y1="268" x2="190" y2="328" stroke="#334155" stroke-width="1" opacity="0.25"/>
+        <line x1="260" y1="268" x2="260" y2="328" stroke="#334155" stroke-width="1" opacity="0.25"/>
+
+        <!-- highlighted edges (group: Integration verification) -->
+        <line x1="290" y1="88" x2="310" y2="148" stroke="#06b6d4" stroke-width="1.5" opacity="0.7"/>
+        <line x1="260" y1="268" x2="260" y2="328" stroke="#06b6d4" stroke-width="1.5" opacity="0.7"/>
+
+        <!-- DIM nodes -->
+        <circle cx="80" cy="74" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5" opacity="0.18"/>
+        <circle cx="160" cy="74" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5" opacity="0.18"/>
+        <circle cx="80" cy="164" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5" opacity="0.18"/>
+        <circle cx="175" cy="164" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5" opacity="0.18"/>
+        <circle cx="250" cy="164" r="26" fill="#3b82f6" stroke="#0f172a" stroke-width="2.5" opacity="0.18"/>
+        <circle cx="120" cy="254" r="26" fill="#10b981" stroke="#0f172a" stroke-width="2.5" opacity="0.18"/>
+        <circle cx="200" cy="344" r="26" fill="#64748b" stroke="#0f172a" stroke-width="2.5" opacity="0.18"/>
+        <circle cx="280" cy="344" r="26" fill="#64748b" stroke="#0f172a" stroke-width="2.5" opacity="0.18"/>
+
+        <!-- HIGHLIGHTED siblings (group: Integration verification → cyan) -->
+        <circle cx="290" cy="74" r="34" fill="#06b6d4" opacity="0.15"/>
+        <circle cx="320" cy="164" r="34" fill="#06b6d4" opacity="0.15"/>
+        <circle cx="260" cy="254" r="34" fill="#06b6d4" opacity="0.15"/>
+
+        <circle cx="290" cy="74" r="26" fill="#10b981" stroke="#06b6d4" stroke-width="3" filter="url(#glow2)"/>
+        <text x="290" y="78" fill="white" font-size="9" font-weight="700" text-anchor="middle">100%</text>
+        <text x="290" y="112" fill="#22d3ee" font-size="8.5" font-weight="600" text-anchor="middle">Impl. dashboard</text>
+
+        <circle cx="320" cy="164" r="26" fill="#64748b" stroke="#06b6d4" stroke-width="3" filter="url(#glow2)"/>
+        <text x="320" y="168" fill="white" font-size="9" font-weight="700" text-anchor="middle">0%</text>
+        <text x="320" y="202" fill="#22d3ee" font-size="8.5" font-weight="600" text-anchor="middle">Define Widget</text>
+        <!-- cursor -->
+        <text x="302" y="155" fill="#f8fafc" font-size="14">↖</text>
+
+        <circle cx="260" cy="254" r="26" fill="#64748b" stroke="#06b6d4" stroke-width="3" filter="url(#glow2)"/>
+        <text x="260" y="258" fill="white" font-size="9" font-weight="700" text-anchor="middle">0%</text>
+        <text x="260" y="292" fill="#22d3ee" font-size="8.5" font-weight="600" text-anchor="middle">Impl. Widget</text>
+
+        <!-- tooltip -->
+        <rect x="130" y="118" width="215" height="34" rx="6" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5"/>
+        <text x="143" y="132" fill="#22d3ee" font-size="9.5" font-weight="700">Integration verification f...</text>
+        <text x="143" y="146" fill="#60a5fa" font-size="9">0 / 5 subtasks done</text>
+        <line x1="320" y1="152" x2="335" y2="152" stroke="#06b6d4" stroke-width="1" stroke-dasharray="3,2"/>
+
+        <text x="200" y="420" fill="#4ade80" font-size="11" text-anchor="middle">✓ Different group → different hue</text>
+      </svg>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -176,6 +176,7 @@
 
 .visualization-container.full-width {
   padding: 0;
+  overflow: hidden;
 }
 
 /* Metrics panel will be styled in its own component */

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -177,6 +177,7 @@
 .visualization-container.full-width {
   padding: 0;
   overflow: hidden;
+  position: relative;
 }
 
 /* Metrics panel will be styled in its own component */

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -163,6 +163,7 @@
 
 .app-content {
   flex: 1;
+  min-height: 0;
   display: flex;
   overflow: hidden;
 }
@@ -178,6 +179,7 @@
   padding: 0;
   overflow: hidden;
   position: relative;
+  height: 100%;
 }
 
 /* Metrics panel will be styled in its own component */

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -90,7 +90,7 @@ function App() {
       </header>
 
       <div className="app-content">
-        <div className={`visualization-container ${currentLayer === 'quality' ? 'full-width' : ''}`}>
+        <div className={`visualization-container ${currentLayer === 'quality' || currentLayer === 'board' ? 'full-width' : ''}`}>
           {/* Live mode views */}
           {currentLayer === 'network' && <NetworkGraphView />}
           {currentLayer === 'swimlanes' && <AgentSwimLanesView />}

--- a/dashboard/src/components/AgentSwimLanesView.css
+++ b/dashboard/src/components/AgentSwimLanesView.css
@@ -252,6 +252,76 @@
   color: #8b5cf6;
 }
 
+/* ---- Parent context lanes ---- */
+
+.parent-context-section {
+  margin-top: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px dashed #334155;
+}
+
+.parent-context-lane {
+  display: flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 2px 0;
+}
+
+.parent-context-info {
+  width: 200px;
+  padding-right: 1rem;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.parent-context-name {
+  font-size: 0.7rem;
+  color: #60a5fa;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.parent-context-badge {
+  font-size: 0.625rem;
+  font-weight: 700;
+  padding: 0.0625rem 0.3rem;
+  background-color: #1e3a5f;
+  color: #60a5fa;
+  border-radius: 999px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  border: 1px solid #3b82f644;
+}
+
+.parent-context-badge.all-done {
+  background-color: #14532d;
+  color: #4ade80;
+  border-color: #16a34a44;
+}
+
+.parent-context-timeline {
+  flex: 1;
+  position: relative;
+  height: 20px;
+}
+
+.parent-context-bar {
+  position: absolute;
+  height: 6px;
+  top: 7px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #1e40af 0%, #3b82f6 100%);
+  opacity: 0.5;
+  min-width: 4px;
+}
+
+/* ---- Design task bars ---- */
+
 .design-task-bar {
   background-color: transparent !important;
   border-width: 2px;

--- a/dashboard/src/components/AgentSwimLanesView.tsx
+++ b/dashboard/src/components/AgentSwimLanesView.tsx
@@ -13,7 +13,6 @@ const AgentSwimLanesView = () => {
   const selectAgent = useVisualizationStore((state) => state.selectAgent);
   const selectTask = useVisualizationStore((state) => state.selectTask);
 
-  // Local state for lifecycle panel
   const [lifecycleTask, setLifecycleTask] = useState<SnapshotTask | null>(null);
 
   if (!snapshot || !snapshot.start_time || !snapshot.end_time) {
@@ -31,12 +30,10 @@ const AgentSwimLanesView = () => {
   const totalDuration = endTime - startTime;
   const currentAbsTime = startTime + currentTime;
 
-  // Collect structural (design) tasks for the planning lane
   const designTasks = snapshot.tasks.filter(
-    (t) => (t.display_role === 'structural')
+    (t) => t.display_role === 'structural'
   );
 
-  // Group work tasks by agent — exclude structural (planning lane) and context (info drawer)
   const agentTasks = snapshot.agents
     .map((agent) => {
       const tasks = snapshot.tasks.filter(
@@ -47,19 +44,14 @@ const AgentSwimLanesView = () => {
     .filter(({ tasks }) => tasks.length > 0);
 
   const getTaskPosition = (task: SnapshotTask) => {
-    // Use started_at if available (when task actually began execution),
-    // otherwise fall back to created_at (when task was created/planned)
-    // This matches the logic in getTaskStateAtTime to ensure alignment
     const taskStart = task.started_at
       ? new Date(task.started_at).getTime()
       : new Date(task.created_at).getTime();
     const taskEnd = new Date(task.updated_at).getTime();
 
-    // Convert to relative time from start
     const taskStartRelative = taskStart - startTime;
     const taskEndRelative = taskEnd - startTime;
 
-    // Apply logarithmic scale
     const taskStartLog = timeToLogScale(taskStartRelative, totalDuration);
     const taskEndLog = timeToLogScale(taskEndRelative, totalDuration);
 
@@ -68,33 +60,85 @@ const AgentSwimLanesView = () => {
 
     return {
       left: `${startPercent}%`,
-      width: `${Math.max(durationPercent, 0.5)}%`, // Minimum width for visibility
+      width: `${Math.max(durationPercent, 0.5)}%`,
     };
   };
 
   const getTaskColor = (status: TaskStatus) => {
     switch (status) {
-      case 'todo':
-        return '#64748b';
-      case 'in_progress':
-        return '#3b82f6';
-      case 'done':
-        return '#10b981';
-      case 'blocked':
-        return '#ef4444';
-      default:
-        return '#64748b';
+      case 'todo': return '#64748b';
+      case 'in_progress': return '#3b82f6';
+      case 'done': return '#10b981';
+      case 'blocked': return '#ef4444';
+      default: return '#64748b';
     }
   };
 
-  // Get messages for task at current time
   const getMessagesForTask = (taskId: string) => {
     return snapshot.messages.filter(
       (m) => m.task_id === taskId && new Date(m.timestamp).getTime() <= currentAbsTime
     );
   };
 
-  // Apply power scale to indicator position to match task bar positions
+  // Build parent context groups from all work subtasks (for the context lane above agents)
+  const subtasksByParent = new Map<string, {
+    name: string;
+    tasks: SnapshotTask[];
+    done: number;
+    total: number;
+  }>();
+
+  for (const task of snapshot.tasks) {
+    if ((task.display_role || 'work') !== 'work') continue;
+    if (!task.parent_task_id) continue;
+    const pid = task.parent_task_id;
+    if (!subtasksByParent.has(pid)) {
+      subtasksByParent.set(pid, {
+        name: task.parent_task_name || 'Parent Task',
+        tasks: [],
+        done: 0,
+        total: 0,
+      });
+    }
+    const entry = subtasksByParent.get(pid)!;
+    entry.tasks.push(task);
+    entry.total++;
+    const state = getTaskStateAtTime(task, currentAbsTime);
+    if (state.status === 'done') entry.done++;
+  }
+
+  // Compute timeline span for each parent group
+  const parentContextGroups = Array.from(subtasksByParent.entries())
+    .filter(([, v]) => v.total >= 2)
+    .map(([parentId, v]) => {
+      const starts = v.tasks.map((t) => {
+        const ts = t.started_at
+          ? new Date(t.started_at).getTime()
+          : new Date(t.created_at).getTime();
+        return ts - startTime;
+      });
+      const ends = v.tasks.map((t) => {
+        const state = getTaskStateAtTime(t, currentAbsTime);
+        if (state.status === 'in_progress') return currentTime;
+        return new Date(t.updated_at).getTime() - startTime;
+      });
+
+      const earliest = Math.max(0, Math.min(...starts));
+      const latest = Math.min(totalDuration, Math.max(...ends, earliest + 1000));
+
+      const startLog = timeToLogScale(earliest, totalDuration);
+      const endLog = timeToLogScale(latest, totalDuration);
+
+      return {
+        parentId,
+        name: v.name,
+        done: v.done,
+        total: v.total,
+        left: `${(startLog / totalDuration) * 100}%`,
+        width: `${Math.max(((endLog - startLog) / totalDuration) * 100, 1)}%`,
+      };
+    });
+
   const currentTimeScaled = timeToLogScale(currentTime, totalDuration);
   const currentTimePercent = (currentTimeScaled / totalDuration) * 100;
 
@@ -105,19 +149,15 @@ const AgentSwimLanesView = () => {
           {/* Time axis */}
           <div className="time-axis">
             {Array.from({ length: 13 }, (_, i) => i * 30).map((minutes) => {
-              // Convert minutes to milliseconds, apply power scale
               const timeMs = minutes * 60000;
               const timeScaledMs = timeToLogScale(timeMs, totalDuration);
               const position = (timeScaledMs / totalDuration) * 100;
-
               return (
                 <div key={minutes} className="time-marker" style={{ left: `${position}%` }}>
                   <span>{minutes}m</span>
                 </div>
               );
             })}
-
-            {/* Current time indicator - positioned relative to time-axis */}
             <div
               className="current-time-line"
               style={{ left: `${currentTimePercent}%` }}
@@ -143,7 +183,6 @@ const AgentSwimLanesView = () => {
                 {designTasks.map((task) => {
                   const taskState = getTaskStateAtTime(task, currentAbsTime);
                   const isActive = taskState.isActive;
-
                   return (
                     <div
                       key={task.id}
@@ -167,16 +206,36 @@ const AgentSwimLanesView = () => {
                           {taskState.status === 'done' ? 'Design' : `${taskState.progress}%`}
                         </span>
                       </div>
-
                       {taskState.progress === 100 && (
-                        <div className="completion-indicator" title="Design complete">
-                          ✓
-                        </div>
+                        <div className="completion-indicator" title="Design complete">✓</div>
                       )}
                     </div>
                   );
                 })}
               </div>
+            </div>
+          )}
+
+          {/* Parent context lanes — one thin row per parent group, above agent lanes */}
+          {parentContextGroups.length > 0 && (
+            <div className="parent-context-section">
+              {parentContextGroups.map(({ parentId, name, done, total, left, width }) => (
+                <div key={parentId} className="parent-context-lane">
+                  <div className="parent-context-info">
+                    <span className="parent-context-name">{name}</span>
+                    <span className={`parent-context-badge ${done === total ? 'all-done' : ''}`}>
+                      {done}/{total} ✓
+                    </span>
+                  </div>
+                  <div className="parent-context-timeline">
+                    <div
+                      className="parent-context-bar"
+                      style={{ left, width }}
+                      title={`${name}: ${done}/${total} subtasks done`}
+                    />
+                  </div>
+                </div>
+              ))}
             </div>
           )}
 
@@ -195,11 +254,10 @@ const AgentSwimLanesView = () => {
 
               <div className="lane-timeline">
                 {tasks.map((task) => {
-                  const messages = getMessagesForTask(task.id);
-                  const questions = messages.filter((m) => m.type === 'question');
-                  const blockers = messages.filter((m) => m.type === 'blocker');
+                  const msgs = getMessagesForTask(task.id);
+                  const questions = msgs.filter((m) => m.type === 'question');
+                  const blockers = msgs.filter((m) => m.type === 'blocker');
 
-                  // Get dynamic state based on current time
                   const taskState = getTaskStateAtTime(task, currentAbsTime);
                   const isActive = taskState.isActive;
 
@@ -214,7 +272,7 @@ const AgentSwimLanesView = () => {
                       onClick={(e) => {
                         e.stopPropagation();
                         selectTask(task.id);
-                        setLifecycleTask(task); // Show lifecycle panel
+                        setLifecycleTask(task);
                       }}
                       title={task.name}
                     >
@@ -223,7 +281,6 @@ const AgentSwimLanesView = () => {
                         <span className="task-bar-progress">{taskState.progress}%</span>
                       </div>
 
-                      {/* Message indicators */}
                       {questions.map((q, idx) => {
                         const qTime = new Date(q.timestamp).getTime();
                         const qPercent =
@@ -231,7 +288,6 @@ const AgentSwimLanesView = () => {
                             (new Date(task.updated_at).getTime() -
                               new Date(task.created_at).getTime())) *
                           100;
-
                         return (
                           <div
                             key={idx}
@@ -251,7 +307,6 @@ const AgentSwimLanesView = () => {
                             (new Date(task.updated_at).getTime() -
                               new Date(task.created_at).getTime())) *
                           100;
-
                         return (
                           <div
                             key={idx}
@@ -265,9 +320,7 @@ const AgentSwimLanesView = () => {
                       })}
 
                       {taskState.progress === 100 && (
-                        <div className="completion-indicator" title="Task completed">
-                          ✓
-                        </div>
+                        <div className="completion-indicator" title="Task completed">✓</div>
                       )}
                     </div>
                   );
@@ -278,7 +331,6 @@ const AgentSwimLanesView = () => {
         </div>
       </div>
 
-      {/* Task Lifecycle Panel */}
       {lifecycleTask && (
         <TaskLifecyclePanel
           task={lifecycleTask}

--- a/dashboard/src/components/BoardView.css
+++ b/dashboard/src/components/BoardView.css
@@ -38,6 +38,7 @@
 .board-column {
   flex: 1 1 0;
   min-width: 220px;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   background-color: #1e293b;
@@ -77,6 +78,7 @@
 
 .column-cards {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 0.5rem;
   display: flex;

--- a/dashboard/src/components/BoardView.css
+++ b/dashboard/src/components/BoardView.css
@@ -11,10 +11,6 @@
   overflow: hidden;
 }
 
-.board-view.with-detail .board-columns {
-  flex: 1;
-}
-
 .board-empty {
   display: flex;
   align-items: center;
@@ -27,12 +23,13 @@
 /* ---- Columns grid ---- */
 
 .board-columns {
+  flex: 1;
+  min-height: 0;
   display: flex;
   gap: 0.75rem;
   padding: 1rem 1rem 0.5rem;
-  flex: 1;
-  min-height: 0;
   overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .board-column {
@@ -102,6 +99,7 @@
   border-radius: 0.375rem;
   padding: 0.625rem 0.75rem;
   cursor: pointer;
+  flex-shrink: 0;
   transition: box-shadow 0.15s, transform 0.15s;
 }
 
@@ -505,6 +503,7 @@
   border-radius: 0.375rem;
   border: 1px solid #334155;
   overflow: hidden;
+  flex-shrink: 0;
 }
 
 .parent-group-header {

--- a/dashboard/src/components/BoardView.css
+++ b/dashboard/src/components/BoardView.css
@@ -3,10 +3,10 @@
    ============================================================ */
 
 .board-view {
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
-  width: 100%;
-  height: 100%;
   background-color: #0f172a;
   overflow: hidden;
 }

--- a/dashboard/src/components/BoardView.css
+++ b/dashboard/src/components/BoardView.css
@@ -497,6 +497,87 @@
   color: #475569;
 }
 
+/* ---- Parent groups ---- */
+
+.parent-group {
+  border-radius: 0.375rem;
+  border: 1px solid #334155;
+  overflow: hidden;
+}
+
+.parent-group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.5rem;
+  background-color: #162032;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.15s;
+}
+
+.parent-group-header:hover {
+  background-color: #1e3a5f;
+}
+
+.parent-group-chevron {
+  font-size: 0.6rem;
+  color: #475569;
+  flex-shrink: 0;
+  width: 0.75rem;
+}
+
+.parent-group-name {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #94a3b8;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.parent-group-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.0625rem 0.375rem;
+  background-color: #1e3a5f;
+  color: #60a5fa;
+  border-radius: 999px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  border: 1px solid #3b82f644;
+}
+
+.parent-group-badge.all-done {
+  background-color: #14532d;
+  color: #4ade80;
+  border-color: #16a34a44;
+}
+
+.parent-group-pbar {
+  height: 2px;
+  background-color: #0f172a;
+}
+
+.parent-group-pbar-fill {
+  height: 100%;
+  background-color: #3b82f6;
+  transition: width 0.3s ease;
+}
+
+.parent-group-cards {
+  padding: 0.375rem 0.375rem 0.375rem 0.75rem;
+  background-color: #162032;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.parent-group-cards .board-card {
+  background-color: #1a2744;
+}
+
 /* ---- Scrollbar styling ---- */
 
 .column-cards::-webkit-scrollbar {

--- a/dashboard/src/components/BoardView.css
+++ b/dashboard/src/components/BoardView.css
@@ -520,13 +520,6 @@
   background-color: #1e3a5f;
 }
 
-.parent-group-chevron {
-  font-size: 0.6rem;
-  color: #475569;
-  flex-shrink: 0;
-  width: 0.75rem;
-}
-
 .parent-group-name {
   font-size: 0.72rem;
   font-weight: 600;
@@ -576,6 +569,38 @@
 
 .parent-group-cards .board-card {
   background-color: #1a2744;
+}
+
+.parent-group-expand {
+  display: block;
+  width: calc(100% - 0.75rem);
+  margin: 0.25rem 0 0.375rem 0.375rem;
+  padding: 0.3rem 0;
+  background: none;
+  border: 1px dashed #334155;
+  border-radius: 4px;
+  color: #60a5fa;
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+.parent-group-expand:hover {
+  background-color: #1e3a5f33;
+  border-color: #3b82f6;
+}
+
+.parent-group-expand.expanded {
+  color: #475569;
+  border-color: #1e293b;
+}
+
+.parent-group-expand.expanded:hover {
+  color: #94a3b8;
+  border-color: #334155;
+  background-color: transparent;
 }
 
 /* ---- Scrollbar styling ---- */

--- a/dashboard/src/components/BoardView.tsx
+++ b/dashboard/src/components/BoardView.tsx
@@ -252,6 +252,7 @@ const BoardView = () => {
                   const total = prog?.total ?? ptasks.length;
                   const pct = total > 0 ? (done / total) * 100 : 0;
                   const isExpanded = expandedGroups.has(parentId);
+                  // Truncate based on this column's card count, not cross-column total
                   const visibleCards = isExpanded ? ptasks : ptasks.slice(0, MAX_VISIBLE);
                   const hiddenCount = ptasks.length - MAX_VISIBLE;
 

--- a/dashboard/src/components/BoardView.tsx
+++ b/dashboard/src/components/BoardView.tsx
@@ -23,7 +23,7 @@ const BoardView = () => {
   const currentTime = useVisualizationStore((state) => state.currentTime);
   const messages = useVisualizationStore((state) => state.getMessagesUpToCurrentTime());
   const [selectedCard, setSelectedCard] = useState<string | null>(null);
-  const [collapsedParents, setCollapsedParents] = useState<Set<string>>(new Set());
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
   const { grouped, metrics, parentProgress } = useMemo(() => {
     if (!snapshot || !snapshot.start_time) {
@@ -125,8 +125,8 @@ const BoardView = () => {
     return `${hours}h${mins > 0 ? ` ${mins}m` : ''}`;
   };
 
-  const toggleParent = (parentId: string) => {
-    setCollapsedParents((prev) => {
+  const toggleExpanded = (parentId: string) => {
+    setExpandedGroups((prev) => {
       const next = new Set(prev);
       if (next.has(parentId)) next.delete(parentId);
       else next.add(parentId);
@@ -244,23 +244,20 @@ const BoardView = () => {
 
                 {/* Subtask groups */}
                 {Array.from(byParent.entries()).map(([parentId, ptasks]) => {
+                  const MAX_VISIBLE = 3;
                   const prog = parentProgress.get(parentId);
                   const name =
                     prog?.name ?? ptasks[0]?.parent_task_name ?? 'Parent Task';
                   const done = prog?.done ?? 0;
                   const total = prog?.total ?? ptasks.length;
                   const pct = total > 0 ? (done / total) * 100 : 0;
-                  const isCollapsed = collapsedParents.has(parentId);
+                  const isExpanded = expandedGroups.has(parentId);
+                  const visibleCards = isExpanded ? ptasks : ptasks.slice(0, MAX_VISIBLE);
+                  const hiddenCount = ptasks.length - MAX_VISIBLE;
 
                   return (
                     <div key={parentId} className="parent-group">
-                      <div
-                        className="parent-group-header"
-                        onClick={() => toggleParent(parentId)}
-                      >
-                        <span className="parent-group-chevron">
-                          {isCollapsed ? '▸' : '▾'}
-                        </span>
+                      <div className="parent-group-header">
                         <span className="parent-group-name">{name}</span>
                         <span
                           className={`parent-group-badge ${done === total ? 'all-done' : ''}`}
@@ -274,10 +271,18 @@ const BoardView = () => {
                           style={{ width: `${pct}%` }}
                         />
                       </div>
-                      {!isCollapsed && (
-                        <div className="parent-group-cards">
-                          {ptasks.map((task) => renderCard(task, col))}
-                        </div>
+                      <div className="parent-group-cards">
+                        {visibleCards.map((task) => renderCard(task, col))}
+                      </div>
+                      {ptasks.length > MAX_VISIBLE && (
+                        <button
+                          className={`parent-group-expand ${isExpanded ? 'expanded' : ''}`}
+                          onClick={() => toggleExpanded(parentId)}
+                        >
+                          {isExpanded
+                            ? '▴  Show less'
+                            : `▾  Show ${hiddenCount} more task${hiddenCount !== 1 ? 's' : ''}…`}
+                        </button>
                       )}
                     </div>
                   );

--- a/dashboard/src/components/BoardView.tsx
+++ b/dashboard/src/components/BoardView.tsx
@@ -4,9 +4,6 @@ import { Task } from '../services/dataService';
 import { getTaskStateAtTime } from '../utils/timelineUtils';
 import './BoardView.css';
 
-/**
- * Column configuration for the kanban board.
- */
 const COLUMNS: { key: Task['status']; label: string; color: string; icon: string }[] = [
   { key: 'todo', label: 'Backlog', color: '#eab308', icon: '📋' },
   { key: 'in_progress', label: 'In Progress', color: '#3b82f6', icon: '⚡' },
@@ -14,9 +11,6 @@ const COLUMNS: { key: Task['status']; label: string; color: string; icon: string
   { key: 'done', label: 'Done', color: '#10b981', icon: '✓' },
 ];
 
-/**
- * Priority badge styling.
- */
 const PRIORITY_COLORS: Record<string, string> = {
   urgent: '#ef4444',
   high: '#f97316',
@@ -29,13 +23,14 @@ const BoardView = () => {
   const currentTime = useVisualizationStore((state) => state.currentTime);
   const messages = useVisualizationStore((state) => state.getMessagesUpToCurrentTime());
   const [selectedCard, setSelectedCard] = useState<string | null>(null);
+  const [collapsedParents, setCollapsedParents] = useState<Set<string>>(new Set());
 
-  // Group tasks by time-aware status
-  const { grouped, metrics } = useMemo(() => {
+  const { grouped, metrics, parentProgress } = useMemo(() => {
     if (!snapshot || !snapshot.start_time) {
       return {
         grouped: { todo: [], in_progress: [], blocked: [], done: [] } as Record<Task['status'], Task[]>,
         metrics: { total: 0, done: 0, blocked: 0, pct: 0, agents: 0 },
+        parentProgress: new Map<string, { name: string; done: number; total: number }>(),
       };
     }
 
@@ -49,7 +44,11 @@ const BoardView = () => {
       done: [],
     };
 
-    for (const task of snapshot.tasks) {
+    const workTasks = snapshot.tasks.filter(
+      (t) => (t.display_role || 'work') === 'work'
+    );
+
+    for (const task of workTasks) {
       const state = getTaskStateAtTime(task, currentAbsTime);
       const status = state.status as Task['status'];
       if (g[status]) {
@@ -57,7 +56,7 @@ const BoardView = () => {
       }
     }
 
-    const total = snapshot.tasks.length;
+    const total = workTasks.length;
     const done = g.done.length;
     const blocked = g.blocked.length;
     const pct = total > 0 ? Math.round((done / total) * 100) : 0;
@@ -67,13 +66,31 @@ const BoardView = () => {
         .filter(Boolean)
     ).size;
 
+    // Build cross-column parent progress map (done/total across ALL statuses)
+    const parentProgress = new Map<string, { name: string; done: number; total: number }>();
+    for (const task of workTasks) {
+      if (!task.parent_task_id) continue;
+      const state = getTaskStateAtTime(task, currentAbsTime);
+      const pid = task.parent_task_id;
+      if (!parentProgress.has(pid)) {
+        parentProgress.set(pid, {
+          name: task.parent_task_name || 'Parent Task',
+          done: 0,
+          total: 0,
+        });
+      }
+      const entry = parentProgress.get(pid)!;
+      entry.total++;
+      if (state.status === 'done') entry.done++;
+    }
+
     return {
       grouped: g,
       metrics: { total, done, blocked, pct, agents },
+      parentProgress,
     };
   }, [snapshot, currentTime]);
 
-  // Get the selected task and its messages
   const selectedTask = useMemo(() => {
     if (!selectedCard || !snapshot) return null;
     return snapshot.tasks.find((t) => t.id === selectedCard) || null;
@@ -84,7 +101,6 @@ const BoardView = () => {
     return messages.filter((m) => m.task_id === selectedCard);
   }, [selectedCard, messages]);
 
-  // Get subtasks for the selected task
   const subtasks = useMemo(() => {
     if (!selectedCard || !snapshot) return [];
     return snapshot.tasks.filter((t) => t.parent_task_id === selectedCard);
@@ -109,12 +125,99 @@ const BoardView = () => {
     return `${hours}h${mins > 0 ? ` ${mins}m` : ''}`;
   };
 
+  const toggleParent = (parentId: string) => {
+    setCollapsedParents((prev) => {
+      const next = new Set(prev);
+      if (next.has(parentId)) next.delete(parentId);
+      else next.add(parentId);
+      return next;
+    });
+  };
+
+  const renderCard = (task: Task, col: typeof COLUMNS[number]) => (
+    <div
+      key={task.id}
+      className={`board-card ${selectedCard === task.id ? 'selected' : ''}`}
+      style={{
+        borderLeftColor:
+          task.assigned_agent_id
+            ? agentColor(task.assigned_agent_id, snapshot.agents)
+            : col.color,
+      }}
+      onClick={() =>
+        setSelectedCard(selectedCard === task.id ? null : task.id)
+      }
+    >
+      <div className="card-header">
+        <span className="card-id">#{task.id.substring(0, 8)}</span>
+        <span
+          className="card-priority"
+          style={{ color: PRIORITY_COLORS[task.priority] || '#64748b' }}
+        >
+          {task.priority === 'urgent' || task.priority === 'high'
+            ? task.priority.toUpperCase()
+            : ''}
+        </span>
+      </div>
+      <div className="card-name">{task.name}</div>
+      {task.description && (
+        <div className="card-desc">
+          {task.description.split('\n')[0].replace(/^[#*]+\s*/, '').slice(0, 80)}
+          {task.description.split('\n')[0].length > 80 ? '…' : ''}
+        </div>
+      )}
+      <div className="card-meta">
+        {task.assigned_agent_name && (
+          <span className="card-agent">{task.assigned_agent_name}</span>
+        )}
+        {task.estimated_hours > 0 && (
+          <span className="card-hours">
+            {Math.round(task.estimated_hours * 60)}m
+          </span>
+        )}
+      </div>
+      {task.progress_percent > 0 && task.progress_percent < 100 && (
+        <div className="card-progress-bar">
+          <div
+            className="card-progress-fill"
+            style={{
+              width: `${task.progress_percent}%`,
+              backgroundColor: col.color,
+            }}
+          />
+        </div>
+      )}
+      {task.labels.length > 0 && (
+        <div className="card-labels">
+          {task.labels.slice(0, 3).map((lbl) => (
+            <span key={lbl} className="card-label">{lbl}</span>
+          ))}
+          {task.labels.length > 3 && (
+            <span className="card-label card-label-more">
+              +{task.labels.length - 3}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
   return (
     <div className={`board-view ${selectedTask ? 'with-detail' : ''}`}>
       {/* Board columns */}
       <div className="board-columns">
         {COLUMNS.map((col) => {
           const tasks = grouped[col.key];
+
+          const standalone = tasks.filter((t) => !t.parent_task_id);
+          const byParent = new Map<string, Task[]>();
+          for (const t of tasks) {
+            if (!t.parent_task_id) continue;
+            const pid = t.parent_task_id;
+            if (!byParent.has(pid)) byParent.set(pid, []);
+            byParent.get(pid)!.push(t);
+          }
+
           return (
             <div key={col.key} className="board-column">
               <div
@@ -135,84 +238,50 @@ const BoardView = () => {
                 {tasks.length === 0 && (
                   <div className="card-empty">No tasks</div>
                 )}
-                {tasks.map((task) => (
-                  <div
-                    key={task.id}
-                    className={`board-card ${selectedCard === task.id ? 'selected' : ''}`}
-                    style={{
-                      borderLeftColor:
-                        task.assigned_agent_id
-                          ? agentColor(task.assigned_agent_id, snapshot.agents)
-                          : col.color,
-                    }}
-                    onClick={() =>
-                      setSelectedCard(
-                        selectedCard === task.id ? null : task.id
-                      )
-                    }
-                  >
-                    <div className="card-header">
-                      <span className="card-id">
-                        #{task.id.substring(0, 8)}
-                      </span>
-                      <span
-                        className="card-priority"
-                        style={{
-                          color: PRIORITY_COLORS[task.priority] || '#64748b',
-                        }}
+
+                {/* Standalone tasks (no parent) */}
+                {standalone.map((task) => renderCard(task, col))}
+
+                {/* Subtask groups */}
+                {Array.from(byParent.entries()).map(([parentId, ptasks]) => {
+                  const prog = parentProgress.get(parentId);
+                  const name =
+                    prog?.name ?? ptasks[0]?.parent_task_name ?? 'Parent Task';
+                  const done = prog?.done ?? 0;
+                  const total = prog?.total ?? ptasks.length;
+                  const pct = total > 0 ? (done / total) * 100 : 0;
+                  const isCollapsed = collapsedParents.has(parentId);
+
+                  return (
+                    <div key={parentId} className="parent-group">
+                      <div
+                        className="parent-group-header"
+                        onClick={() => toggleParent(parentId)}
                       >
-                        {task.priority === 'urgent' || task.priority === 'high'
-                          ? task.priority.toUpperCase()
-                          : ''}
-                      </span>
-                    </div>
-                    <div className="card-name">{task.name}</div>
-                    {task.description && (
-                      <div className="card-desc">
-                        {task.description.split('\n')[0].replace(/^[#*]+\s*/, '').slice(0, 80)}
-                        {task.description.split('\n')[0].length > 80 ? '…' : ''}
+                        <span className="parent-group-chevron">
+                          {isCollapsed ? '▸' : '▾'}
+                        </span>
+                        <span className="parent-group-name">{name}</span>
+                        <span
+                          className={`parent-group-badge ${done === total ? 'all-done' : ''}`}
+                        >
+                          {done}/{total} ✓
+                        </span>
                       </div>
-                    )}
-                    <div className="card-meta">
-                      {task.assigned_agent_name && (
-                        <span className="card-agent">
-                          {task.assigned_agent_name}
-                        </span>
-                      )}
-                      {task.estimated_hours > 0 && (
-                        <span className="card-hours">
-                          {Math.round(task.estimated_hours * 60)}m
-                        </span>
-                      )}
-                    </div>
-                    {task.progress_percent > 0 &&
-                      task.progress_percent < 100 && (
-                        <div className="card-progress-bar">
-                          <div
-                            className="card-progress-fill"
-                            style={{
-                              width: `${task.progress_percent}%`,
-                              backgroundColor: col.color,
-                            }}
-                          />
+                      <div className="parent-group-pbar">
+                        <div
+                          className="parent-group-pbar-fill"
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                      {!isCollapsed && (
+                        <div className="parent-group-cards">
+                          {ptasks.map((task) => renderCard(task, col))}
                         </div>
                       )}
-                    {task.labels.length > 0 && (
-                      <div className="card-labels">
-                        {task.labels.slice(0, 3).map((lbl) => (
-                          <span key={lbl} className="card-label">
-                            {lbl}
-                          </span>
-                        ))}
-                        {task.labels.length > 3 && (
-                          <span className="card-label card-label-more">
-                            +{task.labels.length - 3}
-                          </span>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                ))}
+                    </div>
+                  );
+                })}
               </div>
             </div>
           );
@@ -441,41 +510,25 @@ const BoardView = () => {
   );
 };
 
-/**
- * Assign a consistent color to an agent based on their position in the agents list.
- */
 const AGENT_COLORS = [
   '#3b82f6', '#8b5cf6', '#06b6d4', '#f97316', '#10b981',
   '#ec4899', '#eab308', '#14b8a6', '#f43f5e', '#6366f1',
 ];
 
-function agentColor(
-  agentId: string,
-  agents: { id: string }[]
-): string {
+function agentColor(agentId: string, agents: { id: string }[]): string {
   const idx = agents.findIndex((a) => a.id === agentId);
   return AGENT_COLORS[idx >= 0 ? idx % AGENT_COLORS.length : 0];
 }
 
-/**
- * Map message type to an icon for the coordination trail.
- */
 function messageIcon(type: string): string {
   switch (type) {
-    case 'task_assignment':
-      return '📋';
-    case 'status_update':
-      return '📊';
-    case 'blocker':
-      return '🚫';
-    case 'question':
-      return '❓';
-    case 'answer':
-      return '💬';
-    case 'instruction':
-      return '📝';
-    default:
-      return '•';
+    case 'task_assignment': return '📋';
+    case 'status_update': return '📊';
+    case 'blocker': return '🚫';
+    case 'question': return '❓';
+    case 'answer': return '💬';
+    case 'instruction': return '📝';
+    default: return '•';
   }
 }
 

--- a/dashboard/src/components/NetworkGraphView.css
+++ b/dashboard/src/components/NetworkGraphView.css
@@ -8,11 +8,17 @@
   position: relative;
 }
 
-.network-svg {
+.network-graph-body {
+  position: relative;
   flex: 1;
+  min-height: 0;
+}
+
+.network-svg {
   width: 100%;
   height: 100%;
   background-color: #0f172a;
+  display: block;
 }
 
 .pulsing-node {
@@ -87,4 +93,87 @@
   width: 24px;
   height: 0;
   flex-shrink: 0;
+}
+
+.design-origins-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 1rem;
+  background-color: rgba(46, 16, 101, 0.35);
+  border-bottom: 1px solid rgba(168, 85, 247, 0.25);
+  flex-shrink: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(168, 85, 247, 0.4) transparent;
+}
+
+.strip-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #d8b4fe;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  flex-shrink: 0;
+  padding-right: 0.75rem;
+  border-right: 1px solid rgba(168, 85, 247, 0.3);
+}
+
+.strip-pills {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.design-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.7rem;
+  background-color: rgba(46, 16, 101, 0.55);
+  border: 1px dashed #a855f7;
+  border-radius: 999px;
+  color: #d8b4fe;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+    box-shadow 0.15s ease, color 0.15s ease;
+  font-family: inherit;
+  white-space: nowrap;
+}
+
+.design-pill:hover,
+.design-pill.active {
+  background-color: rgba(168, 85, 247, 0.28);
+  border-style: solid;
+  color: #f3e8ff;
+  box-shadow: 0 0 0 3px rgba(168, 85, 247, 0.18);
+}
+
+.design-pill.selected {
+  background-color: rgba(168, 85, 247, 0.4);
+  border-color: #f59e0b;
+  border-style: solid;
+  color: #fff;
+}
+
+.pill-icon {
+  font-size: 0.7rem;
+  opacity: 0.85;
+  font-style: italic;
+}
+
+.pill-name {
+  font-style: italic;
+}
+
+.pill-count {
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #c084fc;
+  background-color: rgba(168, 85, 247, 0.15);
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  font-style: normal;
 }

--- a/dashboard/src/components/NetworkGraphView.tsx
+++ b/dashboard/src/components/NetworkGraphView.tsx
@@ -29,6 +29,7 @@ const NetworkGraphView = () => {
   const svgRef = useRef<SVGSVGElement>(null);
   const simulationRef = useRef<d3.Simulation<GraphNode, GraphLink> | null>(null);
   const nodesRef = useRef<GraphNode[]>([]);
+  const subtaskGroupsRef = useRef<Map<string, { nodes: GraphNode[]; name: string }>>(new Map());
 
   const tasks = useVisualizationStore((state) => state.getDagTasks());
   const currentTime = useVisualizationStore((state) => state.currentTime);
@@ -307,6 +308,67 @@ const NetworkGraphView = () => {
     // Design-origin markers are rendered as HTML pills above the SVG (see JSX below).
     // Here we just keep the column layout driven by nodePrimaryGhost / primaryGhostIds.
 
+    // Group sibling subtasks — dashed bounding rect + progress badge rendered behind nodes
+    const subtaskGroups = new Map<string, { nodes: GraphNode[]; name: string }>();
+    visibleNodes.forEach(node => {
+      if (!node.task.parent_task_id) return;
+      const pid = node.task.parent_task_id;
+      if (!subtaskGroups.has(pid)) {
+        subtaskGroups.set(pid, { nodes: [], name: node.task.parent_task_name || 'Group' });
+      }
+      subtaskGroups.get(pid)!.nodes.push(node);
+    });
+    subtaskGroupsRef.current = subtaskGroups;
+
+    const groupLayer = g.append('g').attr('class', 'subtask-groups');
+
+    subtaskGroups.forEach((group, parentId) => {
+      if (group.nodes.length < 2) return;
+      const xs = group.nodes.map(n => n.x!);
+      const ys = group.nodes.map(n => n.y!);
+      const pad = 34;
+      const rx = Math.min(...xs) - pad;
+      const ry = Math.min(...ys) - pad;
+      const rw = Math.max(...xs) - Math.min(...xs) + pad * 2;
+      const rh = Math.max(...ys) - Math.min(...ys) + pad * 2;
+
+      groupLayer.append('rect')
+        .attr('x', rx).attr('y', ry)
+        .attr('width', rw).attr('height', rh)
+        .attr('rx', 8).attr('ry', 8)
+        .attr('fill', '#1e3a5f0d')
+        .attr('stroke', '#3b82f655')
+        .attr('stroke-width', 1.5)
+        .attr('stroke-dasharray', '6,3');
+
+      const shortName = group.name.length > 26
+        ? group.name.substring(0, 26) + '…'
+        : group.name;
+
+      groupLayer.append('text')
+        .attr('x', rx + 6).attr('y', ry + 11)
+        .attr('fill', '#60a5fa').attr('font-size', '9px').attr('font-weight', '600')
+        .style('pointer-events', 'none')
+        .text(shortName);
+
+      const initDone = group.nodes.filter(n => n.status === 'done').length;
+
+      groupLayer.append('rect')
+        .attr('x', rx + rw - 44).attr('y', ry + 2)
+        .attr('width', 40).attr('height', 14)
+        .attr('rx', 7)
+        .attr('fill', '#1e3a5f').attr('stroke', '#3b82f644').attr('stroke-width', 1);
+
+      groupLayer.append('text')
+        .attr('class', 'subtask-group-progress')
+        .attr('data-parent-id', parentId)
+        .attr('x', rx + rw - 24).attr('y', ry + 12)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#60a5fa').attr('font-size', '8px').attr('font-weight', '700')
+        .style('pointer-events', 'none')
+        .text(`${initDone}/${group.nodes.length} ✓`);
+    });
+
     // Create node lookup map for link resolution
     const nodeMap = new Map<string, GraphNode>();
     visibleNodes.forEach(n => nodeMap.set(n.id, n));
@@ -507,6 +569,16 @@ const NetworkGraphView = () => {
       .data(nodesRef.current)
       .text(d => d.isGhost ? 'Design' : `${d.progress}%`);
 
+    // Update subtask group progress badges
+    subtaskGroupsRef.current.forEach((group, parentId) => {
+      const done = group.nodes.filter(n => {
+        const state = getTaskStateAtTime(n.task, currentAbsTime);
+        return state.status === 'done';
+      }).length;
+      svg.select(`[data-parent-id="${parentId}"]`)
+        .text(`${done}/${group.nodes.length} ✓`);
+    });
+
   }, [currentTime, selectedTaskId]); // Re-run when time or selection changes
 
   // Toggle the design-link ring on nodes depending on the hovered design pill.
@@ -580,6 +652,13 @@ const NetworkGraphView = () => {
           <div className="legend-item">
             <div className="legend-border" style={{ borderColor: '#a855f7', borderStyle: 'dashed', backgroundColor: 'transparent' }}></div>
             <span>Hover a pill to highlight dependents</span>
+          </div>
+        </div>
+        <div className="legend-section">
+          <div className="legend-title">Subtask Groups</div>
+          <div className="legend-item">
+            <div className="legend-border" style={{ borderColor: '#3b82f6', borderStyle: 'dashed', backgroundColor: '#1e3a5f11' }}></div>
+            <span>Sibling subtasks</span>
           </div>
         </div>
         <div className="legend-section">

--- a/dashboard/src/components/NetworkGraphView.tsx
+++ b/dashboard/src/components/NetworkGraphView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as d3 from 'd3';
 import { useVisualizationStore } from '../store/visualizationStore';
 import { Task } from '../services/dataService';
@@ -37,6 +37,36 @@ const NetworkGraphView = () => {
 
   // Local state for lifecycle panel
   const [lifecycleTask, setLifecycleTask] = useState<Task | null>(null);
+  // Which design-origin pill the user is hovering — highlights linked impl nodes
+  const [hoveredGhostId, setHoveredGhostId] = useState<string | null>(null);
+
+  // Design tasks rendered as HTML pills above the DAG (option 1 header strip).
+  // Sorted so pill order is stable across renders.
+  const designTasks = useMemo(
+    () =>
+      tasks
+        .filter((t) => t.display_role === 'structural')
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [tasks]
+  );
+
+  // Map ghost (design) task id -> set of impl task ids that directly depend on it.
+  // Used to highlight impl nodes when a pill is hovered.
+  const ghostToImpls = useMemo(() => {
+    const ghostIds = new Set(designTasks.map((t) => t.id));
+    const map = new Map<string, Set<string>>();
+    tasks.forEach((task) => {
+      if (task.display_role === 'structural') return;
+      (task.dependency_ids || []).forEach((depId) => {
+        if (ghostIds.has(depId)) {
+          if (!map.has(depId)) map.set(depId, new Set());
+          map.get(depId)!.add(task.id);
+        }
+      });
+    });
+    return map;
+  }, [tasks, designTasks]);
 
   // Build graph structure once when tasks change
   useEffect(() => {
@@ -201,15 +231,34 @@ const NetworkGraphView = () => {
     // Group nodes by which ghost task they originally depended on.
     // Ghost tasks encode the design stream each impl task came from —
     // they're filtered from the display but their lineage is still in rawDepMap.
-    const nodeGhostGroup = new Map<string, string>(); // nodeId -> ghostId
+    //
+    // Two maps, different purposes:
+    //   - nodePrimaryGhost: one ghost per impl node for COLUMN LAYOUT.
+    //     Skips convergence (maxDepth) so fan-in nodes stay centered.
+    //   - ghostToImpls: all ghosts any impl depends on, for MARKER RENDERING.
+    //     Includes convergence so design tasks referenced only by final
+    //     integration still appear. A node contributing multiple ghosts
+    //     (e.g. both 'Design System' and 'Visual Design System') registers
+    //     all of them, so every referenced design task gets a marker.
+    const nodePrimaryGhost = new Map<string, string>();
+    const ghostToImpls = new Map<string, Set<string>>();
     visibleNodes.forEach(node => {
+      const depth = depthMap.get(node.id) || 0;
       const originalDeps = Array.from(rawDepMap.get(node.id) || []);
-      const ghostDep = originalDeps.find(depId => ghostIds.has(depId));
-      if (ghostDep) nodeGhostGroup.set(node.id, ghostDep);
+      const ghostDeps = originalDeps.filter(depId => ghostIds.has(depId));
+      if (ghostDeps.length === 0) return;
+
+      if (depth < maxDepth) {
+        nodePrimaryGhost.set(node.id, ghostDeps[0]);
+      }
+      ghostDeps.forEach(gId => {
+        if (!ghostToImpls.has(gId)) ghostToImpls.set(gId, new Set());
+        ghostToImpls.get(gId)!.add(node.id);
+      });
     });
 
-    const ghostGroupIds = Array.from(new Set(nodeGhostGroup.values()));
-    const numGroups = ghostGroupIds.length;
+    const primaryGhostIds = Array.from(new Set(nodePrimaryGhost.values()));
+    const numGroups = primaryGhostIds.length;
 
     const padding = 50;
     const verticalSpacing = (height - 100) / (maxDepth + 1);
@@ -223,8 +272,8 @@ const NetworkGraphView = () => {
     });
 
     byDepth.forEach((layerNodes, depth) => {
-      const grouped = layerNodes.filter(n => nodeGhostGroup.has(n.id));
-      const ungrouped = layerNodes.filter(n => !nodeGhostGroup.has(n.id));
+      const grouped = layerNodes.filter(n => nodePrimaryGhost.has(n.id));
+      const ungrouped = layerNodes.filter(n => !nodePrimaryGhost.has(n.id));
 
       // Ungrouped nodes (roots, shared parents, convergence): center across full width
       if (ungrouped.length > 0) {
@@ -240,8 +289,8 @@ const NetworkGraphView = () => {
       // Grouped nodes: each ghost stream gets its own column slice
       if (grouped.length > 0 && numGroups > 0) {
         const groupWidth = (width - padding * 2) / numGroups;
-        ghostGroupIds.forEach((ghostId, gIdx) => {
-          const groupNodes = grouped.filter(n => nodeGhostGroup.get(n.id) === ghostId);
+        primaryGhostIds.forEach((ghostId, gIdx) => {
+          const groupNodes = grouped.filter(n => nodePrimaryGhost.get(n.id) === ghostId);
           if (groupNodes.length === 0) return;
           const colLeft = padding + gIdx * groupWidth;
           const hSpacing = groupWidth / (groupNodes.length + 1);
@@ -254,6 +303,9 @@ const NetworkGraphView = () => {
         });
       }
     });
+
+    // Design-origin markers are rendered as HTML pills above the SVG (see JSX below).
+    // Here we just keep the column layout driven by nodePrimaryGhost / primaryGhostIds.
 
     // Create node lookup map for link resolution
     const nodeMap = new Map<string, GraphNode>();
@@ -319,6 +371,18 @@ const NetworkGraphView = () => {
       .enter().append('g')
       .attr('cursor', 'pointer')
       .attr('class', d => `node-${d.id}`);
+
+    // Design-link highlight ring — behind the node circle, hidden by default.
+    // Shown when a design-origin pill is hovered and this node depends on that design.
+    node.append('circle')
+      .attr('class', 'design-link-ring')
+      .attr('r', 28)
+      .attr('fill', 'none')
+      .attr('stroke', '#a855f7')
+      .attr('stroke-width', 3)
+      .attr('stroke-dasharray', '3,2')
+      .attr('opacity', 0)
+      .style('pointer-events', 'none');
 
     node.append('circle')
       .attr('class', 'node-circle')
@@ -445,8 +509,51 @@ const NetworkGraphView = () => {
 
   }, [currentTime, selectedTaskId]); // Re-run when time or selection changes
 
+  // Toggle the design-link ring on nodes depending on the hovered design pill.
+  useEffect(() => {
+    if (!svgRef.current) return;
+    const linkedIds = hoveredGhostId
+      ? ghostToImpls.get(hoveredGhostId) || new Set<string>()
+      : new Set<string>();
+    d3.select(svgRef.current)
+      .selectAll<SVGCircleElement, GraphNode>('.design-link-ring')
+      .attr('opacity', (d) => (linkedIds.has(d.id) ? 0.9 : 0));
+  }, [hoveredGhostId, ghostToImpls]);
+
   return (
     <div className="network-graph-view">
+      {designTasks.length > 0 && (
+        <div className="design-origins-strip">
+          <div className="strip-label">Design Origins</div>
+          <div className="strip-pills">
+            {designTasks.map((t) => {
+              const count = ghostToImpls.get(t.id)?.size ?? 0;
+              const displayName = t.name.replace(/^Design\s+/i, '');
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  className={`design-pill ${hoveredGhostId === t.id ? 'active' : ''} ${
+                    selectedTaskId === t.id ? 'selected' : ''
+                  }`}
+                  onMouseEnter={() => setHoveredGhostId(t.id)}
+                  onMouseLeave={() => setHoveredGhostId(null)}
+                  onClick={() => {
+                    selectTask(t.id);
+                    setLifecycleTask(t);
+                  }}
+                  title={`${t.name} — ${count} dependent task${count === 1 ? '' : 's'}`}
+                >
+                  <span className="pill-icon" aria-hidden>◐</span>
+                  <span className="pill-name">{displayName}</span>
+                  {count > 0 && <span className="pill-count">{count}</span>}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+      <div className="network-graph-body">
       <svg ref={svgRef} className="network-svg" />
       <div className="legend">
         <div className="legend-section">
@@ -469,10 +576,10 @@ const NetworkGraphView = () => {
           </div>
         </div>
         <div className="legend-section">
-          <div className="legend-title">Node Types</div>
+          <div className="legend-title">Design Origins</div>
           <div className="legend-item">
-            <div className="legend-border" style={{ borderColor: '#64748b', borderStyle: 'dashed', opacity: 0.6 }}></div>
-            <span>Design origin</span>
+            <div className="legend-border" style={{ borderColor: '#a855f7', borderStyle: 'dashed', backgroundColor: 'transparent' }}></div>
+            <span>Hover a pill to highlight dependents</span>
           </div>
         </div>
         <div className="legend-section">
@@ -490,6 +597,7 @@ const NetworkGraphView = () => {
             <span>Redundant dep</span>
           </div>
         </div>
+      </div>
       </div>
 
       {/* Task Lifecycle Panel */}

--- a/dashboard/src/components/NetworkGraphView.tsx
+++ b/dashboard/src/components/NetworkGraphView.tsx
@@ -29,7 +29,6 @@ const NetworkGraphView = () => {
   const svgRef = useRef<SVGSVGElement>(null);
   const simulationRef = useRef<d3.Simulation<GraphNode, GraphLink> | null>(null);
   const nodesRef = useRef<GraphNode[]>([]);
-  const subtaskGroupsRef = useRef<Map<string, { nodes: GraphNode[]; name: string }>>(new Map());
 
   const tasks = useVisualizationStore((state) => state.getDagTasks());
   const currentTime = useVisualizationStore((state) => state.currentTime);
@@ -308,7 +307,7 @@ const NetworkGraphView = () => {
     // Design-origin markers are rendered as HTML pills above the SVG (see JSX below).
     // Here we just keep the column layout driven by nodePrimaryGhost / primaryGhostIds.
 
-    // Group sibling subtasks — dashed bounding rect + progress badge rendered behind nodes
+    // Group sibling subtasks — used for hover-highlight only (no persistent visual)
     const subtaskGroups = new Map<string, { nodes: GraphNode[]; name: string }>();
     visibleNodes.forEach(node => {
       if (!node.task.parent_task_id) return;
@@ -318,55 +317,12 @@ const NetworkGraphView = () => {
       }
       subtaskGroups.get(pid)!.nodes.push(node);
     });
-    subtaskGroupsRef.current = subtaskGroups;
 
-    const groupLayer = g.append('g').attr('class', 'subtask-groups');
-
-    subtaskGroups.forEach((group, parentId) => {
-      if (group.nodes.length < 2) return;
-      const xs = group.nodes.map(n => n.x!);
-      const ys = group.nodes.map(n => n.y!);
-      const pad = 34;
-      const rx = Math.min(...xs) - pad;
-      const ry = Math.min(...ys) - pad;
-      const rw = Math.max(...xs) - Math.min(...xs) + pad * 2;
-      const rh = Math.max(...ys) - Math.min(...ys) + pad * 2;
-
-      groupLayer.append('rect')
-        .attr('x', rx).attr('y', ry)
-        .attr('width', rw).attr('height', rh)
-        .attr('rx', 8).attr('ry', 8)
-        .attr('fill', '#1e3a5f0d')
-        .attr('stroke', '#3b82f655')
-        .attr('stroke-width', 1.5)
-        .attr('stroke-dasharray', '6,3');
-
-      const shortName = group.name.length > 26
-        ? group.name.substring(0, 26) + '…'
-        : group.name;
-
-      groupLayer.append('text')
-        .attr('x', rx + 6).attr('y', ry + 11)
-        .attr('fill', '#60a5fa').attr('font-size', '9px').attr('font-weight', '600')
-        .style('pointer-events', 'none')
-        .text(shortName);
-
-      const initDone = group.nodes.filter(n => n.status === 'done').length;
-
-      groupLayer.append('rect')
-        .attr('x', rx + rw - 44).attr('y', ry + 2)
-        .attr('width', 40).attr('height', 14)
-        .attr('rx', 7)
-        .attr('fill', '#1e3a5f').attr('stroke', '#3b82f644').attr('stroke-width', 1);
-
-      groupLayer.append('text')
-        .attr('class', 'subtask-group-progress')
-        .attr('data-parent-id', parentId)
-        .attr('x', rx + rw - 24).attr('y', ry + 12)
-        .attr('text-anchor', 'middle')
-        .attr('fill', '#60a5fa').attr('font-size', '8px').attr('font-weight', '700')
-        .style('pointer-events', 'none')
-        .text(`${initDone}/${group.nodes.length} ✓`);
+    // Assign a stable hue to each parent group
+    const GROUP_COLORS = ['#8b5cf6', '#06b6d4', '#f59e0b', '#ec4899', '#10b981', '#f97316', '#6366f1'];
+    const parentGroupColorMap = new Map<string, string>();
+    Array.from(subtaskGroups.keys()).forEach((pid, idx) => {
+      parentGroupColorMap.set(pid, GROUP_COLORS[idx % GROUP_COLORS.length]);
     });
 
     // Create node lookup map for link resolution
@@ -432,7 +388,17 @@ const NetworkGraphView = () => {
       .data(visibleNodes)
       .enter().append('g')
       .attr('cursor', 'pointer')
-      .attr('class', d => `node-${d.id}`);
+      .attr('class', d => `dag-node node-${d.id}`);
+
+    // Sibling-group glow ring — shown only on hover, hidden at rest
+    node.append('circle')
+      .attr('class', 'sibling-ring')
+      .attr('r', 30)
+      .attr('fill', 'none')
+      .attr('stroke', '#8b5cf6')
+      .attr('stroke-width', 3)
+      .attr('opacity', 0)
+      .style('pointer-events', 'none');
 
     // Design-link highlight ring — behind the node circle, hidden by default.
     // Shown when a design-origin pill is hovered and this node depends on that design.
@@ -463,6 +429,63 @@ const NetworkGraphView = () => {
       .on('click', (_, d) => {
         if (!d.isGhost) { selectTask(d.id); setLifecycleTask(d.task); }
       });
+
+    // Sibling hover: on mouseenter highlight all siblings, dim everything else
+    node.on('mouseenter', (_, d) => {
+      const pid = d.task.parent_task_id;
+      if (!pid || !subtaskGroups.has(pid)) return;
+
+      const siblingIds = new Set(subtaskGroups.get(pid)!.nodes.map(n => n.id));
+      const color = parentGroupColorMap.get(pid) || '#8b5cf6';
+
+      g.selectAll<SVGGElement, GraphNode>('.dag-node')
+        .each(function(nd) {
+          const isSibling = siblingIds.has(nd.id);
+          const el = d3.select(this);
+          el.select('.node-circle')
+            .transition().duration(120)
+            .attr('opacity', isSibling ? 1 : 0.12);
+          el.select('.node-label')
+            .transition().duration(120)
+            .attr('opacity', isSibling ? 1 : 0.12);
+          el.select('.node-progress')
+            .transition().duration(120)
+            .attr('opacity', isSibling ? 1 : 0.12);
+          el.select('.sibling-ring')
+            .transition().duration(120)
+            .attr('opacity', isSibling ? 0.9 : 0)
+            .attr('stroke', color);
+        });
+
+      g.selectAll('line')
+        .transition().duration(120)
+        .attr('opacity', 0.05);
+
+    }).on('mouseleave', (_, d) => {
+      const pid = d.task.parent_task_id;
+      if (!pid || !subtaskGroups.has(pid)) return;
+
+      g.selectAll<SVGGElement, GraphNode>('.dag-node')
+        .each(function(nd) {
+          const el = d3.select(this);
+          el.select('.node-circle')
+            .transition().duration(180)
+            .attr('opacity', nd.isGhost ? 0.6 : 1);
+          el.select('.node-label')
+            .transition().duration(180)
+            .attr('opacity', nd.isGhost ? 0.6 : 1);
+          el.select('.node-progress')
+            .transition().duration(180)
+            .attr('opacity', nd.isGhost ? 0.6 : 1);
+          el.select('.sibling-ring')
+            .transition().duration(180)
+            .attr('opacity', 0);
+        });
+
+      g.selectAll('line')
+        .transition().duration(180)
+        .attr('opacity', 0.6);
+    });
 
     node.append('text')
       .attr('class', 'node-label')
@@ -569,16 +592,6 @@ const NetworkGraphView = () => {
       .data(nodesRef.current)
       .text(d => d.isGhost ? 'Design' : `${d.progress}%`);
 
-    // Update subtask group progress badges
-    subtaskGroupsRef.current.forEach((group, parentId) => {
-      const done = group.nodes.filter(n => {
-        const state = getTaskStateAtTime(n.task, currentAbsTime);
-        return state.status === 'done';
-      }).length;
-      svg.select(`[data-parent-id="${parentId}"]`)
-        .text(`${done}/${group.nodes.length} ✓`);
-    });
-
   }, [currentTime, selectedTaskId]); // Re-run when time or selection changes
 
   // Toggle the design-link ring on nodes depending on the hovered design pill.
@@ -657,8 +670,8 @@ const NetworkGraphView = () => {
         <div className="legend-section">
           <div className="legend-title">Subtask Groups</div>
           <div className="legend-item">
-            <div className="legend-border" style={{ borderColor: '#3b82f6', borderStyle: 'dashed', backgroundColor: '#1e3a5f11' }}></div>
-            <span>Sibling subtasks</span>
+            <div className="legend-border" style={{ borderColor: '#8b5cf6', borderStyle: 'solid', backgroundColor: 'transparent' }}></div>
+            <span>Hover node to highlight siblings</span>
           </div>
         </div>
         <div className="legend-section">

--- a/dashboard/src/components/TaskLifecyclePanel.tsx
+++ b/dashboard/src/components/TaskLifecyclePanel.tsx
@@ -21,10 +21,15 @@ const TaskLifecyclePanel = ({ task, onClose }: TaskLifecyclePanelProps) => {
     artifactType: string;
   } | null>(null);
 
-  // Only show artifacts/decisions/messages that belong to this specific task
+  // For structural (design origin) tasks, also include their direct dependent tasks
+  // so artifacts/decisions from impl tasks spawned by this design are visible.
   const relevantTaskIds = useMemo(() => {
     if (!task) return new Set<string>();
-    return new Set<string>([task.id]);
+    const ids = new Set<string>([task.id]);
+    if (task.display_role === 'structural') {
+      task.dependent_task_ids.forEach(id => ids.add(id));
+    }
+    return ids;
   }, [task]);
 
   // Get messages related to this task

--- a/mockup_subtask_progress.html
+++ b/mockup_subtask_progress.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Subtask Progress Mockup</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0f172a; color: #e2e8f0; font-family: 'Inter', system-ui, sans-serif; font-size: 13px; padding: 24px; }
+  h1 { color: #94a3b8; font-size: 11px; text-transform: uppercase; letter-spacing: 2px; margin-bottom: 6px; }
+  h2 { color: #64748b; font-size: 10px; text-transform: uppercase; letter-spacing: 1.5px; margin-bottom: 16px; }
+  .section { margin-bottom: 48px; }
+  .label-new { background: #22c55e22; color: #22c55e; border: 1px solid #22c55e44; font-size: 9px; padding: 2px 6px; border-radius: 99px; text-transform: uppercase; letter-spacing: 1px; vertical-align: middle; margin-left: 8px; }
+  .label-before { background: #ef444422; color: #ef4444; border: 1px solid #ef444444; font-size: 9px; padding: 2px 6px; border-radius: 99px; text-transform: uppercase; letter-spacing: 1px; vertical-align: middle; margin-left: 8px; }
+  .compare { display: flex; gap: 32px; }
+  .panel { flex: 1; }
+
+  /* ── BOARD ─────────────────────────────────────────────────── */
+  .board { display: flex; gap: 10px; }
+  .col { flex: 1; background: #1e293b; border-radius: 8px; overflow: hidden; min-width: 170px; }
+  .col-header { display: flex; align-items: center; gap: 6px; padding: 10px 12px 8px; border-bottom: 3px solid; }
+  .col-icon { font-size: 12px; }
+  .col-label { font-size: 11px; font-weight: 600; color: #cbd5e1; flex: 1; }
+  .col-count { font-size: 10px; font-weight: 700; padding: 1px 6px; border-radius: 99px; color: #fff; }
+  .col-cards { padding: 8px; display: flex; flex-direction: column; gap: 6px; }
+
+  /* parent group header */
+  .parent-group { border-radius: 6px; overflow: hidden; border: 1px solid #334155; margin-bottom: 2px; }
+  .parent-header { display: flex; align-items: center; gap: 6px; padding: 6px 8px; background: #162032; cursor: pointer; }
+  .parent-icon { font-size: 10px; color: #64748b; }
+  .parent-name { font-size: 10px; font-weight: 600; color: #94a3b8; flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .parent-badge { font-size: 9px; font-weight: 700; padding: 1px 7px; border-radius: 99px; background: #1e3a5f; color: #60a5fa; white-space: nowrap; }
+  .parent-badge.partial { background: #1e3a5f; color: #60a5fa; }
+  .parent-badge.done { background: #14532d; color: #4ade80; }
+  .parent-pbar { height: 2px; background: #0f172a; }
+  .parent-pbar-fill { height: 100%; background: #3b82f6; transition: width 0.3s; }
+  .subtask-cards { padding: 4px 6px 6px 16px; background: #162032; display: flex; flex-direction: column; gap: 4px; }
+
+  .card { background: #1e293b; border-radius: 6px; padding: 8px 10px; border-left: 3px solid; }
+  .card.subtask-card { background: #1a2744; border-radius: 4px; padding: 6px 8px; border-left: 2px solid; }
+  .card-id { font-size: 9px; color: #475569; }
+  .card-name { font-size: 11px; color: #e2e8f0; margin: 2px 0; font-weight: 500; line-height: 1.3; }
+  .card-name.subtask-name { font-size: 10px; color: #cbd5e1; }
+  .card-meta { display: flex; gap: 6px; margin-top: 4px; align-items: center; }
+  .card-agent { font-size: 9px; color: #64748b; background: #0f172a; padding: 1px 5px; border-radius: 3px; }
+  .card-progress { height: 3px; background: #334155; border-radius: 2px; margin-top: 5px; }
+  .card-progress-fill { height: 100%; border-radius: 2px; }
+  .subtask-check { font-size: 9px; margin-right: 4px; }
+  .card-parent-tag { font-size: 8px; color: #3b82f6; background: #1e3a5f; padding: 1px 5px; border-radius: 3px; }
+
+  /* ── SWIMLANE ───────────────────────────────────────────────── */
+  .swimlane-wrap { background: #1e293b; border-radius: 8px; padding: 0; overflow: hidden; }
+  .swim-header { padding: 10px 16px; border-bottom: 1px solid #334155; display: flex; align-items: center; gap: 8px; }
+  .swim-title { font-size: 11px; color: #94a3b8; font-weight: 600; }
+  .timeline-ticks { display: flex; padding: 4px 16px 4px 100px; gap: 0; border-bottom: 1px solid #1e293b; }
+  .tick { flex: 1; font-size: 8px; color: #475569; text-align: left; border-left: 1px solid #334155; padding-left: 3px; }
+  .lane { display: flex; align-items: center; border-bottom: 1px solid #1e293b; min-height: 36px; }
+  .lane-label { width: 100px; min-width: 100px; padding: 0 12px; font-size: 10px; color: #94a3b8; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .lane-track { flex: 1; position: relative; height: 36px; }
+  .bar { position: absolute; height: 18px; top: 9px; border-radius: 3px; display: flex; align-items: center; padding: 0 6px; font-size: 9px; font-weight: 600; color: #fff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  /* new: parent context bar */
+  .parent-ctx-bar { position: absolute; height: 6px; top: 4px; border-radius: 2px; opacity: 0.35; }
+  .parent-ctx-label { position: absolute; top: 0; font-size: 8px; color: #94a3b8; white-space: nowrap; }
+  .parent-bracket { position: absolute; height: 28px; top: 4px; border: 1px dashed #3b82f655; border-radius: 3px; pointer-events: none; }
+  .parent-bracket-label { position: absolute; top: -14px; font-size: 8px; color: #60a5fa; white-space: nowrap; background: #1e293b; padding: 0 3px; border-radius: 2px; }
+  .progress-dot { position: absolute; width: 5px; height: 5px; border-radius: 50%; top: 50%; transform: translateY(-50%); }
+
+  /* ── DAG ────────────────────────────────────────────────────── */
+  .dag-wrap { background: #0f172a; border-radius: 8px; padding: 16px; position: relative; height: 340px; overflow: hidden; border: 1px solid #1e293b; }
+  .dag-node { position: absolute; width: 44px; height: 44px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 9px; font-weight: 700; color: #fff; border: 2px solid; cursor: pointer; z-index: 2; flex-direction: column; gap: 1px; }
+  .dag-label { position: absolute; font-size: 8px; color: #94a3b8; text-align: center; width: 70px; z-index: 2; }
+  .dag-group-rect { position: absolute; border: 1.5px dashed #3b82f655; border-radius: 8px; background: #1e3a5f11; z-index: 1; }
+  .dag-group-label { position: absolute; font-size: 8px; color: #60a5fa; background: #0f172a; padding: 0 4px; border-radius: 2px; z-index: 3; }
+  .dag-progress-badge { position: absolute; background: #1e3a5f; color: #60a5fa; font-size: 8px; font-weight: 700; padding: 2px 5px; border-radius: 99px; border: 1px solid #3b82f644; z-index: 3; white-space: nowrap; }
+  .dag-edge { position: absolute; pointer-events: none; z-index: 0; }
+  .dag-legend { display: flex; gap: 12px; margin-bottom: 10px; flex-wrap: wrap; }
+  .dag-legend-item { display: flex; align-items: center; gap: 4px; font-size: 9px; color: #64748b; }
+  .dag-legend-dot { width: 8px; height: 8px; border-radius: 50%; }
+
+  /* status colors */
+  .todo { border-color: #475569; background: #334155; }
+  .in_progress { border-color: #3b82f6; background: #1e3a5f; }
+  .done { border-color: #10b981; background: #14532d; }
+  .blocked { border-color: #ef4444; background: #7f1d1d; }
+
+  .divider { width: 1px; background: #334155; }
+  .vs-label { color: #475569; font-size: 10px; text-align: center; padding: 4px 0; }
+</style>
+</head>
+<body>
+
+<!-- ══════════════════════════════════════════════════════════════
+     BOARD VIEW
+     ══════════════════════════════════════════════════════════════ -->
+<div class="section">
+  <h1>Board View — Subtask Grouping</h1>
+  <h2>In Progress column (zoomed in)</h2>
+
+  <div class="compare">
+    <!-- BEFORE -->
+    <div class="panel">
+      <div style="margin-bottom:8px;color:#64748b;font-size:10px;">BEFORE <span class="label-before">stalled</span></div>
+      <div class="col" style="max-width:220px;">
+        <div class="col-header" style="border-color:#3b82f6;">
+          <span class="col-icon">⚡</span>
+          <span class="col-label">In Progress</span>
+          <span class="col-count" style="background:#3b82f6;">5</span>
+        </div>
+        <div class="col-cards">
+          <div class="card" style="border-color:#3b82f6;">
+            <div class="card-id">#a1b2c3d4</div>
+            <div class="card-name">Set up JWT signing keys</div>
+            <div class="card-meta"><span class="card-agent">agent-2</span></div>
+            <div class="card-progress"><div class="card-progress-fill" style="width:30%;background:#3b82f6;"></div></div>
+          </div>
+          <div class="card" style="border-color:#3b82f6;">
+            <div class="card-id">#b2c3d4e5</div>
+            <div class="card-name">Build session middleware</div>
+            <div class="card-meta"><span class="card-agent">agent-2</span></div>
+            <div class="card-progress"><div class="card-progress-fill" style="width:60%;background:#3b82f6;"></div></div>
+          </div>
+          <div class="card" style="border-color:#3b82f6;">
+            <div class="card-id">#c3d4e5f6</div>
+            <div class="card-name">Wire up database schema</div>
+            <div class="card-meta"><span class="card-agent">agent-3</span></div>
+            <div class="card-progress"><div class="card-progress-fill" style="width:10%;background:#3b82f6;"></div></div>
+          </div>
+          <div class="card" style="border-color:#3b82f6;">
+            <div class="card-id">#d4e5f6g7</div>
+            <div class="card-name">Add refresh token rotation</div>
+            <div class="card-meta"><span class="card-agent">agent-3</span></div>
+          </div>
+          <div class="card" style="border-color:#3b82f6;">
+            <div class="card-id">#e5f6g7h8</div>
+            <div class="card-name">Migrate users table indexes</div>
+            <div class="card-meta"><span class="card-agent">agent-1</span></div>
+          </div>
+        </div>
+      </div>
+      <div style="margin-top:8px;color:#475569;font-size:9px;max-width:220px;line-height:1.5;">
+        5 unrelated-looking tasks. No context. Is this progress? Hard to tell.
+      </div>
+    </div>
+
+    <div class="divider"></div>
+    <div class="vs-label">→</div>
+    <div class="divider"></div>
+
+    <!-- AFTER -->
+    <div class="panel">
+      <div style="margin-bottom:8px;color:#64748b;font-size:10px;">AFTER <span class="label-new">context visible</span></div>
+      <div class="col" style="max-width:220px;">
+        <div class="col-header" style="border-color:#3b82f6;">
+          <span class="col-icon">⚡</span>
+          <span class="col-label">In Progress</span>
+          <span class="col-count" style="background:#3b82f6;">5</span>
+        </div>
+        <div class="col-cards">
+          <!-- GROUP 1: Build Authentication -->
+          <div class="parent-group">
+            <div class="parent-header">
+              <span class="parent-icon">▾</span>
+              <span class="parent-name">Build Authentication System</span>
+              <span class="parent-badge partial">2 / 4 ✓</span>
+            </div>
+            <div class="parent-pbar"><div class="parent-pbar-fill" style="width:50%;"></div></div>
+            <div class="subtask-cards">
+              <div class="card subtask-card" style="border-color:#10b981;opacity:0.6;">
+                <div class="card-name subtask-name">✓ Set up JWT signing keys</div>
+                <div class="card-meta"><span class="card-agent">agent-2</span></div>
+              </div>
+              <div class="card subtask-card" style="border-color:#3b82f6;">
+                <div class="card-name subtask-name">Build session middleware</div>
+                <div class="card-meta"><span class="card-agent">agent-2</span></div>
+                <div class="card-progress"><div class="card-progress-fill" style="width:60%;background:#3b82f6;"></div></div>
+              </div>
+              <div class="card subtask-card" style="border-color:#eab308;opacity:0.7;">
+                <div class="card-name subtask-name">Add refresh token rotation</div>
+                <div class="card-meta"><span class="card-agent" style="color:#94a3b8;">unassigned</span></div>
+              </div>
+            </div>
+          </div>
+
+          <!-- GROUP 2: Database Migration -->
+          <div class="parent-group">
+            <div class="parent-header">
+              <span class="parent-icon">▾</span>
+              <span class="parent-name">Database Schema Migration</span>
+              <span class="parent-badge partial">0 / 2 ✓</span>
+            </div>
+            <div class="parent-pbar"><div class="parent-pbar-fill" style="width:5%;"></div></div>
+            <div class="subtask-cards">
+              <div class="card subtask-card" style="border-color:#3b82f6;">
+                <div class="card-name subtask-name">Wire up database schema</div>
+                <div class="card-meta"><span class="card-agent">agent-3</span></div>
+                <div class="card-progress"><div class="card-progress-fill" style="width:10%;background:#3b82f6;"></div></div>
+              </div>
+              <div class="card subtask-card" style="border-color:#3b82f6;">
+                <div class="card-name subtask-name">Migrate users table indexes</div>
+                <div class="card-meta"><span class="card-agent">agent-1</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div style="margin-top:8px;color:#475569;font-size:9px;max-width:220px;line-height:1.5;">
+        Parent context + progress badge. Auth is 50% done. DB migration just started.
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<!-- ══════════════════════════════════════════════════════════════
+     SWIMLANE VIEW
+     ══════════════════════════════════════════════════════════════ -->
+<div class="section">
+  <h1>Swimlane View — Parent Context Bar</h1>
+  <h2>Agent timeline with subtask grouping</h2>
+
+  <div class="compare">
+    <!-- BEFORE -->
+    <div class="panel">
+      <div style="margin-bottom:8px;color:#64748b;font-size:10px;">BEFORE <span class="label-before">stalled</span></div>
+      <div class="swimlane-wrap" style="max-width:500px;">
+        <div class="swim-header"><span class="swim-title">Agent Timelines</span></div>
+        <div class="timeline-ticks">
+          <div class="tick">0m</div><div class="tick">15m</div><div class="tick">30m</div>
+          <div class="tick">45m</div><div class="tick">60m</div>
+        </div>
+        <div class="lane">
+          <div class="lane-label">agent-1</div>
+          <div class="lane-track">
+            <div class="bar in_progress" style="left:5%;width:35%;">Migrate users table</div>
+          </div>
+        </div>
+        <div class="lane">
+          <div class="lane-label">agent-2</div>
+          <div class="lane-track">
+            <div class="bar done" style="left:2%;width:20%;">Set up JWT keys</div>
+            <div class="bar in_progress" style="left:24%;width:30%;">Build session mid…</div>
+          </div>
+        </div>
+        <div class="lane">
+          <div class="lane-label">agent-3</div>
+          <div class="lane-track">
+            <div class="bar in_progress" style="left:10%;width:28%;">Wire up DB schema</div>
+          </div>
+        </div>
+      </div>
+      <div style="margin-top:8px;color:#475569;font-size:9px;max-width:500px;line-height:1.5;">
+        Bars look stalled. No grouping — can't tell these agents are coordinating on the same parent tasks.
+      </div>
+    </div>
+
+    <div class="divider"></div>
+    <div class="vs-label">→</div>
+    <div class="divider"></div>
+
+    <!-- AFTER -->
+    <div class="panel">
+      <div style="margin-bottom:8px;color:#64748b;font-size:10px;">AFTER <span class="label-new">context visible</span></div>
+      <div class="swimlane-wrap" style="max-width:500px;">
+        <div class="swim-header"><span class="swim-title">Agent Timelines</span></div>
+        <div class="timeline-ticks">
+          <div class="tick">0m</div><div class="tick">15m</div><div class="tick">30m</div>
+          <div class="tick">45m</div><div class="tick">60m</div>
+        </div>
+
+        <!-- PARENT CONTEXT LANE: Build Auth -->
+        <div class="lane" style="min-height:20px;background:#162032;border-bottom:none;">
+          <div class="lane-label" style="color:#60a5fa;font-size:9px;">Build Auth System</div>
+          <div class="lane-track" style="height:20px;">
+            <!-- bracket spanning agent-2's work -->
+            <div style="position:absolute;left:2%;width:52%;height:16px;top:2px;background:#1e3a5f44;border:1px dashed #3b82f655;border-radius:3px;"></div>
+            <div style="position:absolute;left:2%;top:2px;font-size:8px;color:#60a5fa;padding:0 4px;">2/3 ✓</div>
+          </div>
+        </div>
+        <div class="lane">
+          <div class="lane-label">agent-2</div>
+          <div class="lane-track">
+            <div class="bar done" style="left:2%;width:20%;">Set up JWT keys</div>
+            <div class="bar in_progress" style="left:24%;width:30%;">Build session mid…</div>
+          </div>
+        </div>
+
+        <!-- PARENT CONTEXT LANE: DB Migration -->
+        <div class="lane" style="min-height:20px;background:#162032;border-bottom:none;">
+          <div class="lane-label" style="color:#60a5fa;font-size:9px;">DB Schema Migration</div>
+          <div class="lane-track" style="height:20px;">
+            <div style="position:absolute;left:5%;width:38%;height:16px;top:2px;background:#1e3a5f44;border:1px dashed #3b82f655;border-radius:3px;"></div>
+            <div style="position:absolute;left:5%;top:2px;font-size:8px;color:#60a5fa;padding:0 4px;">0/2 ✓</div>
+          </div>
+        </div>
+        <div class="lane">
+          <div class="lane-label">agent-1</div>
+          <div class="lane-track">
+            <div class="bar in_progress" style="left:5%;width:35%;">Migrate users table</div>
+          </div>
+        </div>
+        <div class="lane">
+          <div class="lane-label">agent-3</div>
+          <div class="lane-track">
+            <div class="bar in_progress" style="left:10%;width:28%;">Wire up DB schema</div>
+          </div>
+        </div>
+      </div>
+      <div style="margin-top:8px;color:#475569;font-size:9px;max-width:500px;line-height:1.5;">
+        Parent context lanes group related subtask bars. Auth is 2/3 done. DB just started. Progress is obvious.
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<!-- ══════════════════════════════════════════════════════════════
+     DAG VIEW
+     ══════════════════════════════════════════════════════════════ -->
+<div class="section">
+  <h1>DAG View — Subtask Group Rects</h1>
+  <h2>Network graph with sibling grouping + progress badge</h2>
+
+  <div class="compare">
+    <!-- BEFORE -->
+    <div class="panel">
+      <div style="margin-bottom:8px;color:#64748b;font-size:10px;">BEFORE <span class="label-before">stalled</span></div>
+      <div class="dag-wrap" style="width:340px;">
+        <!-- edges (SVG) -->
+        <svg style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;">
+          <!-- Design → auth subtasks -->
+          <line x1="60" y1="60" x2="120" y2="130" stroke="#334155" stroke-width="1.5"/>
+          <line x1="60" y1="60" x2="190" y2="130" stroke="#334155" stroke-width="1.5"/>
+          <line x1="60" y1="60" x2="260" y2="130" stroke="#334155" stroke-width="1.5"/>
+          <!-- auth subtasks → DB subtasks -->
+          <line x1="120" y1="174" x2="120" y2="230" stroke="#334155" stroke-width="1.5" stroke-dasharray="3,3"/>
+          <line x1="260" y1="174" x2="230" y2="230" stroke="#334155" stroke-width="1.5"/>
+        </svg>
+
+        <!-- Design node -->
+        <div class="dag-node done" style="left:38px;top:38px;border-color:#10b981;background:#14532d;">
+          <span>✓</span>
+        </div>
+        <div class="dag-label" style="left:16px;top:84px;">Design Auth</div>
+
+        <!-- Auth subtask nodes — NO grouping -->
+        <div class="dag-node done" style="left:98px;top:108px;">✓</div>
+        <div class="dag-label" style="left:76px;top:154px;font-size:7px;">JWT Keys</div>
+
+        <div class="dag-node in_progress" style="left:168px;top:108px;">60%</div>
+        <div class="dag-label" style="left:148px;top:154px;font-size:7px;">Session Mid.</div>
+
+        <div class="dag-node todo" style="left:238px;top:108px;">—</div>
+        <div class="dag-label" style="left:216px;top:154px;font-size:7px;">Refresh Tok.</div>
+
+        <!-- DB subtask nodes — NO grouping -->
+        <div class="dag-node in_progress" style="left:98px;top:208px;">10%</div>
+        <div class="dag-label" style="left:78px;top:254px;font-size:7px;">DB Schema</div>
+
+        <div class="dag-node in_progress" style="left:208px;top:208px;">5%</div>
+        <div class="dag-label" style="left:188px;top:254px;font-size:7px;">Users Index</div>
+      </div>
+      <div style="margin-top:8px;color:#475569;font-size:9px;width:340px;line-height:1.5;">
+        5 disconnected-looking nodes. No visual grouping shows they're part of the same parent effort.
+      </div>
+    </div>
+
+    <div class="divider"></div>
+    <div class="vs-label">→</div>
+    <div class="divider"></div>
+
+    <!-- AFTER -->
+    <div class="panel">
+      <div style="margin-bottom:8px;color:#64748b;font-size:10px;">AFTER <span class="label-new">context visible</span></div>
+      <div class="dag-wrap" style="width:340px;">
+        <svg style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;">
+          <line x1="60" y1="60" x2="120" y2="130" stroke="#334155" stroke-width="1.5"/>
+          <line x1="60" y1="60" x2="190" y2="130" stroke="#334155" stroke-width="1.5"/>
+          <line x1="60" y1="60" x2="260" y2="130" stroke="#334155" stroke-width="1.5"/>
+          <line x1="120" y1="174" x2="120" y2="228" stroke="#334155" stroke-width="1.5" stroke-dasharray="3,3"/>
+          <line x1="260" y1="174" x2="230" y2="228" stroke="#334155" stroke-width="1.5"/>
+        </svg>
+
+        <!-- AUTH GROUP RECT -->
+        <div class="dag-group-rect" style="left:84px;top:96px;width:198px;height:90px;"></div>
+        <div class="dag-group-label" style="left:88px;top:86px;">Build Auth System</div>
+        <div class="dag-progress-badge" style="left:222px;top:86px;">1/3 ✓</div>
+
+        <!-- DB GROUP RECT -->
+        <div class="dag-group-rect" style="left:84px;top:198px;width:168px;height:80px;"></div>
+        <div class="dag-group-label" style="left:88px;top:188px;">DB Schema Migration</div>
+        <div class="dag-progress-badge" style="left:208px;top:188px;">0/2 ✓</div>
+
+        <!-- Design node -->
+        <div class="dag-node done" style="left:38px;top:38px;border-color:#10b981;background:#14532d;"><span>✓</span></div>
+        <div class="dag-label" style="left:16px;top:84px;">Design Auth</div>
+
+        <!-- Auth subtask nodes -->
+        <div class="dag-node done" style="left:98px;top:108px;">✓</div>
+        <div class="dag-label" style="left:76px;top:154px;font-size:7px;">JWT Keys</div>
+
+        <div class="dag-node in_progress" style="left:168px;top:108px;">60%</div>
+        <div class="dag-label" style="left:148px;top:154px;font-size:7px;">Session Mid.</div>
+
+        <div class="dag-node todo" style="left:238px;top:108px;">—</div>
+        <div class="dag-label" style="left:216px;top:154px;font-size:7px;">Refresh Tok.</div>
+
+        <!-- DB subtask nodes -->
+        <div class="dag-node in_progress" style="left:98px;top:208px;">10%</div>
+        <div class="dag-label" style="left:78px;top:254px;font-size:7px;">DB Schema</div>
+
+        <div class="dag-node in_progress" style="left:208px;top:208px;">5%</div>
+        <div class="dag-label" style="left:188px;top:254px;font-size:7px;">Users Index</div>
+      </div>
+      <div style="margin-top:8px;color:#475569;font-size:9px;width:340px;line-height:1.5;">
+        Dashed group rects + progress badge. Immediately clear: Auth has 1/3 done, DB just started.
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tests/test_multi_path_aggregator.py
+++ b/tests/test_multi_path_aggregator.py
@@ -1,0 +1,167 @@
+"""Unit tests for multi-path Aggregator support.
+
+Verifies that Aggregator can load projects from multiple marcus_roots
+simultaneously (for parallel experiments) while keeping backward compat
+with the single marcus_root constructor.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cato_src.core.aggregator import Aggregator
+
+
+def _make_marcus_root(tmp_path: Path, suffix: str) -> Path:
+    """Create a minimal Marcus-like root with projects.json."""
+    root = tmp_path / f"marcus_{suffix}"
+    data_dir = root / "data" / "marcus_state"
+    data_dir.mkdir(parents=True)
+    logs_dir = root / "logs" / "conversations"
+    logs_dir.mkdir(parents=True)
+    return root
+
+
+def _write_projects(root: Path, projects: dict[str, Any]) -> None:
+    """Write projects.json to the persistence_dir of a marcus root."""
+    projects_file = root / "data" / "marcus_state" / "projects.json"
+    with open(projects_file, "w") as f:
+        json.dump(projects, f)
+
+
+@pytest.fixture
+def two_marcus_roots(tmp_path: Path) -> tuple[Path, Path]:
+    """Create two independent Marcus roots with distinct projects."""
+    root_a = _make_marcus_root(tmp_path, "a")
+    root_b = _make_marcus_root(tmp_path, "b")
+
+    _write_projects(
+        root_a,
+        {
+            "proj_a1": {
+                "id": "proj_a1",
+                "name": "Alpha One",
+                "created_at": "2026-01-01",
+            },
+            "proj_a2": {
+                "id": "proj_a2",
+                "name": "Alpha Two",
+                "created_at": "2026-01-02",
+            },
+        },
+    )
+    _write_projects(
+        root_b,
+        {
+            "proj_b1": {
+                "id": "proj_b1",
+                "name": "Beta One",
+                "created_at": "2026-01-03",
+            },
+        },
+    )
+    return root_a, root_b
+
+
+class TestMultiRootInit:
+    """Aggregator accepts both singular and plural root forms."""
+
+    def test_single_root_backward_compat(self, tmp_path: Path) -> None:
+        """Old-style marcus_root= kwarg still works."""
+        root = _make_marcus_root(tmp_path, "single")
+        agg = Aggregator(marcus_root=root)
+        assert agg.marcus_root == root
+
+    def test_plural_roots_accepted(self, two_marcus_roots: tuple[Path, Path]) -> None:
+        """New marcus_roots= list is accepted without error."""
+        root_a, root_b = two_marcus_roots
+        agg = Aggregator(marcus_roots=[root_a, root_b])
+        assert agg.marcus_roots == [root_a, root_b]
+
+    def test_plural_roots_sets_primary(
+        self, two_marcus_roots: tuple[Path, Path]
+    ) -> None:
+        """First entry in marcus_roots becomes marcus_root for backward compat."""
+        root_a, root_b = two_marcus_roots
+        agg = Aggregator(marcus_roots=[root_a, root_b])
+        assert agg.marcus_root == root_a
+
+    def test_single_root_wrapped_in_list(self, tmp_path: Path) -> None:
+        """Single marcus_root is also available as marcus_roots[0]."""
+        root = _make_marcus_root(tmp_path, "wrap")
+        agg = Aggregator(marcus_root=root)
+        assert agg.marcus_roots == [root]
+
+
+class TestMultiRootProjectLoading:
+    """_load_projects() merges from all roots."""
+
+    def test_loads_projects_from_all_roots(
+        self, two_marcus_roots: tuple[Path, Path]
+    ) -> None:
+        """All projects from all roots appear in _load_projects() result."""
+        root_a, root_b = two_marcus_roots
+        agg = Aggregator(marcus_roots=[root_a, root_b])
+        projects = agg._load_projects()
+        ids = {p["id"] for p in projects}
+        assert ids == {"proj_a1", "proj_a2", "proj_b1"}
+
+    def test_total_count_is_sum_of_all_roots(
+        self, two_marcus_roots: tuple[Path, Path]
+    ) -> None:
+        """Project count equals sum across all roots (2 + 1 = 3)."""
+        root_a, root_b = two_marcus_roots
+        agg = Aggregator(marcus_roots=[root_a, root_b])
+        projects = agg._load_projects()
+        assert len(projects) == 3
+
+    def test_project_root_map_populated(
+        self, two_marcus_roots: tuple[Path, Path]
+    ) -> None:
+        """_project_root maps each project_id to its source root."""
+        root_a, root_b = two_marcus_roots
+        agg = Aggregator(marcus_roots=[root_a, root_b])
+        agg._load_projects()
+        assert agg._project_root["proj_a1"] == root_a
+        assert agg._project_root["proj_a2"] == root_a
+        assert agg._project_root["proj_b1"] == root_b
+
+    def test_missing_projects_file_in_one_root_skipped(self, tmp_path: Path) -> None:
+        """A root with no projects.json is silently skipped; others still load."""
+        good_root = _make_marcus_root(tmp_path, "good")
+        empty_root = _make_marcus_root(tmp_path, "empty")
+        # No projects.json in empty_root
+        _write_projects(
+            good_root,
+            {
+                "proj_good": {
+                    "id": "proj_good",
+                    "name": "Good",
+                    "created_at": "2026-01-01",
+                }
+            },
+        )
+        agg = Aggregator(marcus_roots=[good_root, empty_root])
+        projects = agg._load_projects()
+        assert len(projects) == 1
+        assert projects[0]["id"] == "proj_good"
+
+    def test_single_root_still_loads_normally(self, tmp_path: Path) -> None:
+        """Single-root mode loads as before."""
+        root = _make_marcus_root(tmp_path, "solo")
+        _write_projects(
+            root,
+            {
+                "solo_proj": {
+                    "id": "solo_proj",
+                    "name": "Solo",
+                    "created_at": "2026-01-01",
+                }
+            },
+        )
+        agg = Aggregator(marcus_root=root)
+        projects = agg._load_projects()
+        assert len(projects) == 1
+        assert projects[0]["id"] == "solo_proj"

--- a/tests/test_realtime_log_normalization.py
+++ b/tests/test_realtime_log_normalization.py
@@ -1,0 +1,194 @@
+"""Unit tests for realtime log normalization in Cato's message loader.
+
+realtime_*.jsonl uses {type, source, target, ...} instead of
+{conversation_type, from_agent_id, to_agent_id, ...}. The aggregator
+must normalize realtime entries so they flow through the same
+task_id and agent_id filtering used for conversation logs.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cato_src.core.aggregator import Aggregator
+
+
+def _make_root(tmp_path: Path) -> Path:
+    """Create a minimal Marcus root with empty conversation logs dir."""
+    root = tmp_path / "marcus"
+    (root / "data" / "marcus_state").mkdir(parents=True)
+    (root / "logs" / "conversations").mkdir(parents=True)
+    return root
+
+
+class TestNormalizeRealtimeEntry:
+    """Tests for Aggregator._normalize_realtime_entry() static helper."""
+
+    def test_task_assignment_maps_agent_id_to_to_agent(self) -> None:
+        """task_assignment must set to_agent_id from agent_id field."""
+        entry = {
+            "timestamp": "2026-01-01T00:00:00Z",
+            "type": "task_assignment",
+            "agent_id": "agent_unicorn_1",
+            "task_id": "task_abc",
+            "task_name": "Build widget",
+            "source": "marcus",
+            "target": "agent_unicorn_1",
+        }
+        normalized = Aggregator._normalize_realtime_entry(entry)
+        assert normalized["to_agent_id"] == "agent_unicorn_1"
+        assert normalized["task_id"] == "task_abc"
+
+    def test_task_request_maps_source_to_from_agent(self) -> None:
+        """task_request must set from_agent_id from source field."""
+        entry = {
+            "timestamp": "2026-01-01T00:00:00Z",
+            "type": "task_request",
+            "worker_id": "agent_unicorn_2",
+            "source": "agent_unicorn_2",
+            "target": "marcus",
+        }
+        normalized = Aggregator._normalize_realtime_entry(entry)
+        assert normalized["from_agent_id"] == "agent_unicorn_2"
+
+    def test_task_progress_preserves_task_id(self) -> None:
+        """task_progress entries must keep task_id for message-task matching."""
+        entry = {
+            "timestamp": "2026-01-01T00:00:00Z",
+            "type": "task_progress",
+            "agent_id": "agent_unicorn_3",
+            "task_id": "task_xyz",
+            "progress": 0.5,
+            "source": "agent_unicorn_3",
+            "target": "marcus",
+        }
+        normalized = Aggregator._normalize_realtime_entry(entry)
+        assert normalized["task_id"] == "task_xyz"
+
+    def test_message_type_set_from_type_field(self) -> None:
+        """Normalized entry must have message_type copied from type field."""
+        entry = {
+            "timestamp": "2026-01-01T00:00:00Z",
+            "type": "task_assignment",
+            "agent_id": "agent_1",
+            "task_id": "t1",
+            "source": "marcus",
+            "target": "agent_1",
+        }
+        normalized = Aggregator._normalize_realtime_entry(entry)
+        assert normalized.get("message_type") == "task_assignment"
+
+    def test_server_startup_not_set_agent_ids(self) -> None:
+        """Non-agent events like server_startup must not get fake agent IDs."""
+        entry = {
+            "timestamp": "2026-01-01T00:00:00Z",
+            "type": "server_startup",
+            "provider": "sqlite",
+        }
+        normalized = Aggregator._normalize_realtime_entry(entry)
+        assert "from_agent_id" not in normalized or normalized["from_agent_id"] is None
+        assert "to_agent_id" not in normalized or normalized["to_agent_id"] is None
+
+    def test_original_fields_preserved(self) -> None:
+        """Normalization must not drop original fields from the entry."""
+        entry = {
+            "timestamp": "2026-01-01T00:00:00Z",
+            "type": "task_assignment",
+            "agent_id": "agent_unicorn_1",
+            "task_id": "task_abc",
+            "task_name": "Build widget",
+            "priority": "high",
+            "source": "marcus",
+            "target": "agent_unicorn_1",
+        }
+        normalized = Aggregator._normalize_realtime_entry(entry)
+        assert normalized["task_name"] == "Build widget"
+        assert normalized["priority"] == "high"
+        assert normalized["timestamp"] == "2026-01-01T00:00:00Z"
+
+
+class TestRealtimeEntriesInLoadMessages:
+    """_load_messages() must include normalized realtime entries."""
+
+    def _write_log(self, logs_dir: Path, filename: str, entries: list) -> None:
+        with open(logs_dir / filename, "w") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+
+    def test_realtime_entries_included_in_messages(self, tmp_path: Path) -> None:
+        """_load_messages() must return entries from realtime_*.jsonl files."""
+        root = _make_root(tmp_path)
+        logs_dir = root / "logs" / "conversations"
+
+        self._write_log(
+            logs_dir,
+            "realtime_20260101_000000.jsonl",
+            [
+                {
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "type": "task_assignment",
+                    "agent_id": "agent_1",
+                    "task_id": "t1",
+                    "source": "marcus",
+                    "target": "agent_1",
+                }
+            ],
+        )
+        agg = Aggregator(marcus_root=root)
+        messages = agg._load_messages()
+        assert any(m.get("task_id") == "t1" for m in messages)
+
+    def test_realtime_task_assignment_filterable_by_task_id(
+        self, tmp_path: Path
+    ) -> None:
+        """After normalization, task_assignment entries must have task_id."""
+        root = _make_root(tmp_path)
+        logs_dir = root / "logs" / "conversations"
+
+        self._write_log(
+            logs_dir,
+            "realtime_20260101_000000.jsonl",
+            [
+                {
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "type": "task_assignment",
+                    "agent_id": "agent_unicorn_1",
+                    "task_id": "task_abc123",
+                    "task_name": "Build widget",
+                    "source": "marcus",
+                    "target": "agent_unicorn_1",
+                }
+            ],
+        )
+        agg = Aggregator(marcus_root=root)
+        messages = agg._load_messages()
+        task_ids = [m.get("task_id") for m in messages]
+        assert "task_abc123" in task_ids
+
+    def test_realtime_entries_have_agent_ids_for_filtering(
+        self, tmp_path: Path
+    ) -> None:
+        """Normalized entries must have from_agent_id or to_agent_id set."""
+        root = _make_root(tmp_path)
+        logs_dir = root / "logs" / "conversations"
+
+        self._write_log(
+            logs_dir,
+            "realtime_20260101_000000.jsonl",
+            [
+                {
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "type": "task_assignment",
+                    "agent_id": "agent_unicorn_1",
+                    "task_id": "t1",
+                    "source": "marcus",
+                    "target": "agent_unicorn_1",
+                }
+            ],
+        )
+        agg = Aggregator(marcus_root=root)
+        messages = agg._load_messages()
+        assignment = next((m for m in messages if m.get("task_id") == "t1"), None)
+        assert assignment is not None
+        assert assignment.get("to_agent_id") == "agent_unicorn_1"


### PR DESCRIPTION
## Summary

- `Aggregator` now accepts `marcus_roots=[...]` to load from N parallel Marcus data directories
- `api.py` reads `marcus_data_paths` from `config.json` (overrides singular `marcus_data_path`)
- `_project_root` map tracks each project's source root for downstream resource loading
- Full backward compat: existing single-path config unchanged

## Why

Enables Cato to display projects from all N parallel experiment instances simultaneously in the project selector — essential for comparing parallel runs in batch-testing mode.

## Test plan

- [ ] `pytest tests/test_multi_path_aggregator.py -v` → 9 passed
- [ ] `pytest tests/ -v` → 21 passed, 7 skipped (no regressions)
- [ ] Add `"marcus_data_paths": ["/path/1/data", "/path/2/data"]` to `config.json` and verify both instances' projects appear in Cato project selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)