### PR TITLE
chore: sync develop → main (task visibility fix + v0.3.2 changelog)

### DIFF
--- a/cato_src/core/aggregator.py
+++ b/cato_src/core/aggregator.py
@@ -1467,8 +1467,31 @@ class Aggregator:
                 )
                 return None
 
-            # Step 2: Fetch parent task rows for the candidate IDs
+            # Step 2: Fetch parent task rows for the candidate IDs, then
+            # follow ``dependencies`` edges to pull in any referenced parents
+            # that didn't surface via conversations / Planka prefix. Without
+            # this expansion, an unstarted task whose dependent appears first
+            # in the logs would be a dangling edge target → orphan-filtered
+            # out of the DAG. The slow path does the same walk inline
+            # (aggregator.py:1771-1789).
             parent_tasks = self._load_parent_tasks_by_ids(candidates, root)
+            seen_ids = set(candidates)
+            for _ in range(8):  # bounded BFS over dep chain depth
+                new_dep_ids: Set[str] = set()
+                for task in parent_tasks:
+                    deps = task.get("dependencies") or task.get("dependency_ids") or []
+                    for dep in deps:
+                        dep_str = str(dep)
+                        if dep_str and dep_str not in seen_ids:
+                            new_dep_ids.add(dep_str)
+                if not new_dep_ids:
+                    break
+                seen_ids |= new_dep_ids
+                extra = self._load_parent_tasks_by_ids(new_dep_ids, root)
+                if not extra:
+                    break
+                parent_tasks.extend(extra)
+            candidates = seen_ids
 
             # Step 3: Read subtasks.json (mtime-cached) and filter by parent
             all_subtasks = self._load_subtasks_json_cached(root)

--- a/cato_src/core/aggregator.py
+++ b/cato_src/core/aggregator.py
@@ -1429,11 +1429,35 @@ class Aggregator:
             except Exception as e:
                 logger.debug(f"Conversation parent-id lookup failed: {e}")
 
-            # Source B: Planka prefix fuzzy match (numeric IDs only)
-            if planka_board_id or planka_project_id:
+            # Determine whether the slow path would take the Planka prefix
+            # match or its no-prefix project_id fallback. This gate matches
+            # aggregator.py:1656 — non-numeric Planka IDs fall back.
+            has_numeric_planka = False
+            for pid in (planka_board_id, planka_project_id):
+                if pid and len(pid) >= 8:
+                    try:
+                        int(pid[:8])
+                        has_numeric_planka = True
+                        break
+                    except ValueError:
+                        pass
+
+            if has_numeric_planka:
+                # Source B: Planka prefix fuzzy match (numeric IDs only)
                 candidates |= self._query_parent_ids_by_planka_prefix(
                     planka_board_id, planka_project_id, root
                 )
+            else:
+                # Source B': project_id field match — slow-path fallback for
+                # hex-Planka projects (board_id like "f3ae1ca0..."). Without
+                # this every parent except the few in conversations is missing.
+                candidates |= self._query_parent_ids_by_project_metadata(
+                    project_id, root
+                )
+                if planka_project_id and planka_project_id != project_id:
+                    candidates |= self._query_parent_ids_by_project_metadata(
+                        planka_project_id, root
+                    )
 
             # Source C: parent IDs of subtasks that match Planka prefix.
             # Replicates the slow path's "matched subtask reveals parent"

--- a/dashboard/src/components/MetricsPanel.css
+++ b/dashboard/src/components/MetricsPanel.css
@@ -94,6 +94,51 @@
   color: #f59e0b;
 }
 
+.metric-value.project-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.7rem;
+  color: #94a3b8;
+  font-weight: 500;
+  cursor: pointer;
+  max-width: 65%;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.4rem;
+  background: transparent;
+  border: 1px solid #334155;
+  border-radius: 0.25rem;
+  transition: background-color 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.metric-value.project-id:hover {
+  color: #e2e8f0;
+  background: #1e293b;
+  border-color: #475569;
+}
+
+.metric-value.project-id:active {
+  background: #0f172a;
+}
+
+.project-id-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  text-align: left;
+}
+
+.project-id-icon {
+  flex-shrink: 0;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.metric-value.project-id:hover .project-id-icon {
+  color: #94a3b8;
+}
+
 .agent-autonomy-item {
   margin-bottom: 0.75rem;
   padding-bottom: 0.75rem;

--- a/dashboard/src/components/MetricsPanel.tsx
+++ b/dashboard/src/components/MetricsPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useVisualizationStore } from '../store/visualizationStore';
 import './MetricsPanel.css';
 
@@ -5,8 +6,28 @@ const MetricsPanel = () => {
   const snapshot = useVisualizationStore((state) => state.snapshot);
   const getMetrics = useVisualizationStore((state) => state.getMetrics);
   const activeAgents = useVisualizationStore((state) => state.getActiveAgentsAtCurrentTime());
+  const [copied, setCopied] = useState(false);
 
   const metrics = getMetrics();
+
+  const copyProjectId = async () => {
+    if (!snapshot?.project_id) return;
+    try {
+      await navigator.clipboard.writeText(snapshot.project_id);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard API blocked (e.g. insecure context) — fallback select
+      const range = document.createRange();
+      const sel = window.getSelection();
+      const el = document.querySelector('.metric-value.project-id');
+      if (el && sel) {
+        range.selectNodeContents(el);
+        sel.removeAllRanges();
+        sel.addRange(range);
+      }
+    }
+  };
 
   if (!snapshot || !metrics) {
     return (
@@ -35,6 +56,21 @@ const MetricsPanel = () => {
             <span className="metric-label">Project Name</span>
             <span className="metric-value">{snapshot.project_name}</span>
           </div>
+          {snapshot.project_id && (
+            <div className="metric-item">
+              <span className="metric-label">Project ID</span>
+              <button
+                type="button"
+                className="metric-value project-id"
+                title={copied ? 'Copied!' : `Copy: ${snapshot.project_id}`}
+                onClick={copyProjectId}
+                aria-label={`Copy project ID ${snapshot.project_id}`}
+              >
+                <span className="project-id-text">{snapshot.project_id}</span>
+                <span className="project-id-icon">{copied ? '✓' : '⧉'}</span>
+              </button>
+            </div>
+          )}
           <div className="metric-item">
             <span className="metric-label">Total Duration</span>
             <span className="metric-value">{snapshot.duration_minutes}m</span>


### PR DESCRIPTION
## Summary

- Merges `develop` → `main` to bring in commit `53b4eff` ("Make tasks visible right after creation") that was missing from main after the v0.3.2 release branch was merged directly
- Also pulls in the v0.3.2 merge commit so develop and main share a common history going forward

## What happened

`release/v0.3.2` was merged into `main` via PR #26, but `develop` already had the same bug fixes (different commit hashes via cherry-pick) plus an additional commit (`53b4eff`) that never made it to main. This PR resolves the divergence.

## Changes

- `53b4eff` — Make tasks visible right after creation
- Merge commit syncing `origin/main` (v0.3.2 changelog + version bump) into develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)