### PR TITLE
feat(cost): /api/cost/* endpoints backed by Marcus (Marcus #409 phase 6)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -147,6 +147,13 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Cost-tracking router (Marcus issue #409). Imports Marcus's CostStore /
+# CostAggregator directly via cost_routes; available iff Marcus is on
+# sys.path with src/cost_tracking present.
+from backend.cost_routes import router as cost_router  # noqa: E402
+
+app.include_router(cost_router)
+
 # Initialize aggregator for snapshot API — multi-root if configured
 aggregator = (
     Aggregator(

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -1,0 +1,368 @@
+"""
+Cato cost-tracking API routes.
+
+Exposes ``/api/cost/*`` endpoints backed by Marcus's :class:`CostStore`
+and :class:`CostAggregator` (see Marcus issue #409). Cato runs as a
+sidecar to Marcus and imports the cost-tracking modules directly,
+following the same pattern used by the historical analysis endpoints
+in ``backend/api.py``.
+
+Endpoints
+---------
+- ``GET  /api/cost/experiments`` — list experiments with totals
+- ``GET  /api/cost/experiments/{exp_id}`` — full per-experiment breakdown
+- ``GET  /api/cost/projects/{project_id}`` — project rollup + experiments
+- ``GET  /api/cost/sessions/{session_id}/turns`` — per-turn trajectory
+- ``GET  /api/cost/prices`` — current pricing table (latest per model)
+- ``POST /api/cost/prices`` — insert a new price row (versioned by ``effective_from``)
+- ``GET  /api/cost/export/{exp_id}`` — CSV export of all events
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Marcus module discovery
+# ---------------------------------------------------------------------------
+
+COST_TRACKING_AVAILABLE = False
+CostStore: Any = None
+CostAggregator: Any = None
+ModelPrice: Any = None
+
+try:
+    import sys
+
+    # Mirror the historical-mode discovery in backend/api.py: search a few
+    # well-known Marcus locations and add its root to sys.path.
+    _possible_roots = [
+        Path(__file__).parent.parent.parent / "marcus",  # sibling
+        Path.home() / "dev" / "marcus",
+        Path("/Users/lwgray/dev/marcus"),
+    ]
+    _marcus_root: Optional[Path] = None
+    for _root in _possible_roots:
+        if (_root / "src" / "cost_tracking").exists():
+            _marcus_root = _root
+            break
+    if _marcus_root is not None:
+        if str(_marcus_root) not in sys.path:
+            sys.path.insert(0, str(_marcus_root))
+        from src.cost_tracking.cost_aggregator import (  # type: ignore[no-redef]
+            CostAggregator,
+        )
+        from src.cost_tracking.cost_store import (  # type: ignore[no-redef]
+            CostStore,
+            ModelPrice,
+        )
+
+        COST_TRACKING_AVAILABLE = True
+        logger.info("Cato cost-tracking enabled (Marcus at %s)", _marcus_root)
+    else:
+        logger.warning("Marcus cost_tracking modules not found; /api/cost/* disabled")
+except Exception as exc:  # pragma: no cover - logged, fallback to disabled
+    logger.error("Could not import Marcus cost_tracking: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Store provider (FastAPI dependency, overridable in tests)
+# ---------------------------------------------------------------------------
+
+
+def _default_db_path() -> Path:
+    """Return the default cost DB path Marcus uses (``~/.marcus/costs.db``).
+
+    Override with the ``MARCUS_COST_DB`` env var in tests / non-default
+    deployments.
+    """
+    return Path(
+        os.environ.get("MARCUS_COST_DB", str(Path.home() / ".marcus" / "costs.db"))
+    )
+
+
+def get_store() -> Any:
+    """Yield a :class:`CostStore` instance (FastAPI dependency).
+
+    Tests override this via ``app.dependency_overrides`` to point at a
+    tmp database.
+
+    Raises
+    ------
+    HTTPException
+        503 if Marcus's cost_tracking modules are not importable.
+    """
+    if not COST_TRACKING_AVAILABLE or CostStore is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Marcus cost_tracking modules are not available",
+        )
+    return CostStore(db_path=_default_db_path())
+
+
+def get_aggregator(store: Any = Depends(get_store)) -> Any:
+    """Yield a :class:`CostAggregator` (FastAPI dependency)."""
+    return CostAggregator(store=store)
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class PriceCreateRequest(BaseModel):
+    """Payload for POST /api/cost/prices.
+
+    Mirrors :class:`src.cost_tracking.cost_store.ModelPrice`. Pricing is
+    versioned: send a new ``effective_from`` to update a model's rate
+    without rewriting historical events.
+    """
+
+    model: str = Field(..., description="Model identifier (e.g. 'claude-sonnet-4-6')")
+    provider: str = Field(..., description="Provider tag ('anthropic', 'openai', etc.)")
+    effective_from: Optional[datetime] = Field(
+        None,
+        description="UTC datetime this price became active. Defaults to now.",
+    )
+    input_per_million: float = Field(..., ge=0)
+    output_per_million: float = Field(..., ge=0)
+    cache_creation_per_million: Optional[float] = Field(None, ge=0)
+    cache_read_per_million: Optional[float] = Field(None, ge=0)
+    source: str = Field(
+        "cato_user",
+        description="Origin tag — 'cato_user' for UI edits, 'contract' for "
+        "negotiated rates, 'default' is reserved for seed data.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+router = APIRouter(prefix="/api/cost", tags=["cost"])
+
+
+@router.get("/experiments")  # type: ignore[misc]
+def list_experiments(
+    project_id: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=1000),
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """List experiments with token + cost totals attached.
+
+    Parameters
+    ----------
+    project_id : str, optional
+        Restrict to one project.
+    limit : int
+        Cap at 1000. Default 100.
+    """
+    rows = aggregator.list_experiments(project_id=project_id, limit=limit)
+    return {"experiments": rows, "count": len(rows)}
+
+
+@router.get("/experiments/{experiment_id}")  # type: ignore[misc]
+def experiment_summary(
+    experiment_id: str,
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """Full per-experiment breakdown (summary + by_role / agent / task / etc.).
+
+    Returns the exact dict shape documented in Marcus #409. Cato's
+    frontend renders the result without further transformation.
+
+    Raises
+    ------
+    HTTPException
+        404 if the experiment does not exist.
+    """
+    summary: Optional[Dict[str, Any]] = aggregator.experiment_summary(experiment_id)
+    if summary is None:
+        raise HTTPException(status_code=404, detail="experiment not found")
+    return summary
+
+
+@router.get("/projects/{project_id}")  # type: ignore[misc]
+def project_summary(
+    project_id: str,
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """Project rollup + list of experiment summaries."""
+    return {
+        "project_id": project_id,
+        "totals": aggregator.project_totals(project_id),
+        "experiments": aggregator.list_experiments(project_id=project_id),
+    }
+
+
+@router.get("/sessions/{session_id}/turns")  # type: ignore[misc]
+def session_turns(
+    session_id: str,
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """Per-turn cost trajectory for one Claude Code session."""
+    turns = aggregator.session_turns(session_id)
+    return {"session_id": session_id, "turns": turns}
+
+
+# -- pricing endpoints -------------------------------------------------------
+
+
+@router.get("/prices")  # type: ignore[misc]
+def list_current_prices(
+    store: Any = Depends(get_store),
+) -> Dict[str, Any]:
+    """Return the latest price per (model, provider) — what's currently in effect."""
+    rows = list(store.conn.execute("""
+            SELECT model, provider, effective_from,
+                   input_per_million, output_per_million,
+                   cache_creation_per_million, cache_read_per_million, source
+            FROM model_prices p1
+            WHERE effective_from = (
+                SELECT MAX(effective_from) FROM model_prices p2
+                WHERE p2.model = p1.model AND p2.provider = p1.provider
+            )
+            ORDER BY model, provider
+            """))
+    cols = [
+        "model",
+        "provider",
+        "effective_from",
+        "input_per_million",
+        "output_per_million",
+        "cache_creation_per_million",
+        "cache_read_per_million",
+        "source",
+    ]
+    return {"prices": [dict(zip(cols, r)) for r in rows]}
+
+
+@router.get("/prices/history")  # type: ignore[misc]
+def list_price_history(
+    model: Optional[str] = Query(None),
+    store: Any = Depends(get_store),
+) -> Dict[str, Any]:
+    """Full price history, optionally filtered to a single ``model``."""
+    if model:
+        rows = list(
+            store.conn.execute(
+                "SELECT model, provider, effective_from, input_per_million, "
+                "output_per_million, cache_creation_per_million, "
+                "cache_read_per_million, source FROM model_prices "
+                "WHERE model = ? ORDER BY effective_from DESC",
+                (model,),
+            )
+        )
+    else:
+        rows = list(
+            store.conn.execute(
+                "SELECT model, provider, effective_from, input_per_million, "
+                "output_per_million, cache_creation_per_million, "
+                "cache_read_per_million, source FROM model_prices "
+                "ORDER BY model, effective_from DESC"
+            )
+        )
+    cols = [
+        "model",
+        "provider",
+        "effective_from",
+        "input_per_million",
+        "output_per_million",
+        "cache_creation_per_million",
+        "cache_read_per_million",
+        "source",
+    ]
+    return {"prices": [dict(zip(cols, r)) for r in rows]}
+
+
+@router.post("/prices")  # type: ignore[misc]
+def create_price(
+    payload: PriceCreateRequest,
+    store: Any = Depends(get_store),
+) -> Dict[str, Any]:
+    """Insert a new ``model_prices`` row, versioned by ``effective_from``.
+
+    A duplicate ``(model, provider, effective_from)`` returns 409.
+    """
+    if ModelPrice is None:  # pragma: no cover - guarded by get_store
+        raise HTTPException(status_code=503, detail="cost_tracking unavailable")
+    effective = payload.effective_from or datetime.now(timezone.utc)
+    price = ModelPrice(
+        model=payload.model,
+        provider=payload.provider,
+        effective_from=effective,
+        input_per_million=payload.input_per_million,
+        output_per_million=payload.output_per_million,
+        cache_creation_per_million=payload.cache_creation_per_million,
+        cache_read_per_million=payload.cache_read_per_million,
+        source=payload.source,
+    )
+    try:
+        store.record_price(price)
+    except Exception as exc:
+        # IntegrityError raised by sqlite3 on duplicate PK.
+        if (
+            "UNIQUE" in str(exc)
+            or "PRIMARY KEY" in str(exc)
+            or "constraint" in str(exc).lower()
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "price with that (model, provider, effective_from) "
+                    "already exists"
+                ),
+            )
+        raise
+    return {"status": "ok", "effective_from": effective.isoformat()}
+
+
+# -- export ------------------------------------------------------------------
+
+
+@router.get("/export/{experiment_id}")  # type: ignore[misc]
+def export_experiment_csv(
+    experiment_id: str,
+    store: Any = Depends(get_store),
+) -> StreamingResponse:
+    """CSV export of every ``token_events`` row for one experiment."""
+    cursor = store.conn.execute(
+        """
+        SELECT event_id, timestamp, agent_id, agent_role, operation,
+               task_id, session_id, turn_index, provider, model,
+               input_tokens, cache_creation_tokens, cache_read_tokens,
+               output_tokens, total_tokens, cost_usd, request_id, status
+        FROM v_event_cost
+        WHERE experiment_id = ?
+        ORDER BY timestamp, event_id
+        """,
+        (experiment_id,),
+    )
+    headers = [d[0] for d in cursor.description]
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(headers)
+    for row in cursor:
+        writer.writerow(row)
+    buf.seek(0)
+    return StreamingResponse(
+        iter([buf.getvalue()]),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": (f'attachment; filename="cost_{experiment_id}.csv"')
+        },
+    )

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -1,0 +1,270 @@
+"""
+Integration tests for Cato's ``/api/cost/*`` endpoints.
+
+These tests use FastAPI's TestClient + a tmp SQLite store seeded with
+deterministic data. The store dependency is overridden via
+``app.dependency_overrides`` so the tests never touch
+``~/.marcus/costs.db``.
+
+Tests are skipped if Marcus cost_tracking modules aren't importable.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+try:
+    from backend.cost_routes import COST_TRACKING_AVAILABLE
+except ImportError:
+    COST_TRACKING_AVAILABLE = False
+
+requires_marcus = pytest.mark.skipif(
+    not COST_TRACKING_AVAILABLE,
+    reason="Marcus cost_tracking modules unavailable",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Any:
+    """Tmp CostStore seeded with one Anthropic price and a few events."""
+    from src.cost_tracking.cost_store import (
+        CostStore,
+        Experiment,
+        ModelPrice,
+        TokenEvent,
+    )
+
+    s = CostStore(db_path=tmp_path / "costs.db")
+    s.record_price(
+        ModelPrice(
+            model="claude-sonnet-4-6",
+            provider="anthropic",
+            effective_from=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            input_per_million=3.0,
+            cache_creation_per_million=3.75,
+            cache_read_per_million=0.30,
+            output_per_million=15.0,
+            source="default",
+        )
+    )
+    s.record_experiment(
+        Experiment(
+            experiment_id="exp_1",
+            project_id="proj_1",
+            project_name="hangman",
+            started_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+            num_agents=2,
+            total_tasks=10,
+            completed_tasks=4,
+        )
+    )
+    base = dict(
+        experiment_id="exp_1",
+        project_id="proj_1",
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+    s.record_event(
+        TokenEvent(
+            agent_id="planner",
+            agent_role="planner",
+            operation="parse_prd",
+            input_tokens=1000,
+            output_tokens=500,
+            **base,
+        )
+    )
+    s.record_event(
+        TokenEvent(
+            agent_id="agent_1",
+            agent_role="worker",
+            operation="turn",
+            task_id="t_1",
+            session_id="s_1",
+            turn_index=1,
+            input_tokens=2000,
+            cache_read_tokens=500,
+            output_tokens=100,
+            **base,
+        )
+    )
+    s.record_event(
+        TokenEvent(
+            agent_id="agent_1",
+            agent_role="worker",
+            operation="turn",
+            task_id="t_1",
+            session_id="s_1",
+            turn_index=2,
+            input_tokens=300,
+            output_tokens=50,
+            **base,
+        )
+    )
+    return s
+
+
+@pytest.fixture
+def client(store: Any) -> TestClient:
+    """TestClient with store / aggregator dependencies overridden."""
+    from src.cost_tracking.cost_aggregator import CostAggregator
+
+    from backend.api import app
+    from backend.cost_routes import get_aggregator, get_store
+
+    app.dependency_overrides[get_store] = lambda: store
+    app.dependency_overrides[get_aggregator] = lambda: CostAggregator(store=store)
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# /api/cost/experiments
+# ---------------------------------------------------------------------------
+
+
+@requires_marcus
+class TestExperimentsList:
+    def test_lists_experiments(self, client: TestClient) -> None:
+        """Endpoint returns the seeded experiment with totals."""
+        resp = client.get("/api/cost/experiments")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 1
+        assert body["experiments"][0]["experiment_id"] == "exp_1"
+        assert (
+            body["experiments"][0]["total_tokens"]
+            == 1000 + 500 + 2000 + 500 + 100 + 300 + 50
+        )
+
+    def test_filter_by_project(self, client: TestClient) -> None:
+        """Unknown project returns empty list, not 404."""
+        resp = client.get("/api/cost/experiments?project_id=nope")
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 0
+
+
+@requires_marcus
+class TestExperimentSummary:
+    def test_returns_full_breakdown(self, client: TestClient) -> None:
+        """Endpoint returns the same shape as CostAggregator.experiment_summary."""
+        resp = client.get("/api/cost/experiments/exp_1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["experiment_id"] == "exp_1"
+        assert {
+            "summary",
+            "by_role",
+            "by_agent",
+            "by_task",
+            "by_operation",
+            "by_model",
+        } <= set(body.keys())
+
+    def test_unknown_returns_404(self, client: TestClient) -> None:
+        """Missing experiment_id yields a 404."""
+        resp = client.get("/api/cost/experiments/nope")
+        assert resp.status_code == 404
+
+
+@requires_marcus
+class TestProjectSummary:
+    def test_returns_project_totals(self, client: TestClient) -> None:
+        """Project endpoint returns totals + experiments list."""
+        resp = client.get("/api/cost/projects/proj_1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["project_id"] == "proj_1"
+        assert body["totals"]["events"] == 3
+        assert len(body["experiments"]) == 1
+
+
+@requires_marcus
+class TestSessionTurns:
+    def test_returns_ordered_turns(self, client: TestClient) -> None:
+        """Per-session turn trajectory is ordered by turn_index."""
+        resp = client.get("/api/cost/sessions/s_1/turns")
+        assert resp.status_code == 200
+        turns = resp.json()["turns"]
+        assert [t["turn_index"] for t in turns] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# /api/cost/prices  (GET + POST)
+# ---------------------------------------------------------------------------
+
+
+@requires_marcus
+class TestPrices:
+    def test_get_current_prices(self, client: TestClient) -> None:
+        """GET /prices returns the latest row per (model, provider)."""
+        resp = client.get("/api/cost/prices")
+        assert resp.status_code == 200
+        prices = resp.json()["prices"]
+        assert any(p["model"] == "claude-sonnet-4-6" for p in prices)
+
+    def test_post_inserts_new_price_version(self, client: TestClient) -> None:
+        """POST /prices inserts a versioned row that wins for new events."""
+        new = {
+            "model": "claude-sonnet-4-6",
+            "provider": "anthropic",
+            "effective_from": "2026-06-01T00:00:00+00:00",
+            "input_per_million": 2.5,
+            "output_per_million": 14.0,
+            "cache_creation_per_million": 3.0,
+            "cache_read_per_million": 0.25,
+            "source": "cato_user",
+        }
+        resp = client.post("/api/cost/prices", json=new)
+        assert resp.status_code == 200
+
+        # New row should appear in /prices/history
+        resp2 = client.get("/api/cost/prices/history?model=claude-sonnet-4-6")
+        assert resp2.status_code == 200
+        rows = resp2.json()["prices"]
+        assert any(r["source"] == "cato_user" for r in rows)
+
+    def test_duplicate_post_returns_409(self, client: TestClient) -> None:
+        """Re-POSTing the same (model, provider, effective_from) returns 409."""
+        new = {
+            "model": "x",
+            "provider": "y",
+            "effective_from": "2026-06-02T00:00:00+00:00",
+            "input_per_million": 1.0,
+            "output_per_million": 1.0,
+            "source": "cato_user",
+        }
+        first = client.post("/api/cost/prices", json=new)
+        assert first.status_code == 200
+        dup = client.post("/api/cost/prices", json=new)
+        assert dup.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# /api/cost/export
+# ---------------------------------------------------------------------------
+
+
+@requires_marcus
+class TestExport:
+    def test_csv_export(self, client: TestClient) -> None:
+        """CSV export returns all events for an experiment."""
+        resp = client.get("/api/cost/export/exp_1")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/csv")
+        rows = resp.text.strip().split("\n")
+        # Header + 3 events
+        assert len(rows) == 4
+        assert "agent_id" in rows[0]


### PR DESCRIPTION
## Summary

Surfaces Marcus's cost-tracking foundation (Marcus PRs [#497](https://github.com/lwgray/marcus/pull/497), [#498](https://github.com/lwgray/marcus/pull/498), [#499](https://github.com/lwgray/marcus/pull/499)) to the Cato dashboard. New FastAPI router exposes 8 endpoints under \`/api/cost/*\` so the frontend can pull token + cost data and edit pricing without going through SQLite directly.

## Endpoints

| Method | Path | Purpose |
|---|---|---|
| GET | \`/api/cost/experiments\` | List experiments with totals (optional \`project_id\` filter, \`limit\` cap 1000) |
| GET | \`/api/cost/experiments/{exp_id}\` | Full per-experiment breakdown — summary + by_role + by_agent + by_task + by_operation + by_model |
| GET | \`/api/cost/projects/{project_id}\` | Project rollup + experiments list |
| GET | \`/api/cost/sessions/{sid}/turns\` | Per-turn cost trajectory (for runaway-loop detection) |
| GET | \`/api/cost/prices\` | Current prices (latest \`effective_from\` per model/provider) |
| GET | \`/api/cost/prices/history\` | Full versioned history, optional \`model\` filter |
| POST | \`/api/cost/prices\` | Insert a new \`effective_from\`-versioned row (UI edits). 409 on duplicate key. |
| GET | \`/api/cost/export/{exp_id}\` | CSV stream of every \`token_events\` row for one experiment |

Response shapes match the Marcus #409 spec exactly, so the frontend can render results without further transformation.

## Architecture

- **Sidecar imports.** \`backend/cost_routes.py\` discovers Marcus on disk and imports \`CostStore\` / \`CostAggregator\` / \`ModelPrice\` directly, mirroring how the historical-analysis endpoints already wire to Marcus.
- **503 fallback.** If \`src/cost_tracking\` isn't on \`sys.path\`, the endpoints return 503 with a clear message rather than crashing the whole app.
- **Dependency injection.** Store and aggregator are FastAPI \`Depends\`, so tests override them to point at a tmp database. Production code uses \`~/.marcus/costs.db\` (or \`MARCUS_COST_DB\` env override).
- **Versioned pricing.** POST inserts a new \`(model, provider, effective_from)\` row. Marcus's \`v_event_cost\` view already picks the latest price effective ≤ event timestamp, so UI edits change rates for future events without rewriting historical cost.

## Test plan

- [x] \`pytest tests/test_cost_api.py\` — 10 passed
- [x] \`mypy backend/cost_routes.py\` — clean
- [x] Smoke: \`from backend.api import app\` — all 8 routes mount, Marcus cost-tracking discovered
- [ ] Manual: run dev server, hit endpoints with curl using real \`~/.marcus/costs.db\`

## What's not in this PR

- **SSE stream** (\`/api/cost/stream/{exp_id}\`) for the real-time tab — comes with the frontend in the next PR.
- **Historical trends + budget projection** endpoints — Tab 2 / 3 work.
- **Frontend.** \`CostDashboard.tsx\`, tab components, D3 charts, \`PricingSettings.tsx\` land in Phase 7 / 8.

## Requires

[Marcus #497](https://github.com/lwgray/marcus/pull/497), [#498](https://github.com/lwgray/marcus/pull/498), [#499](https://github.com/lwgray/marcus/pull/499) — all merged to \`develop\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)