### PR TITLE
feat(cost): real-time cost dashboard tab (Marcus #409 phase 7)

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -6,6 +6,7 @@ import ConversationView from './components/ConversationView';
 import HealthCheckDashboard from './components/HealthCheckDashboard';
 import QualityDashboard from './components/QualityDashboard';
 import BoardView from './components/BoardView';
+import CostDashboard from './components/CostDashboard';
 import TimelineControls from './components/TimelineControls';
 import MetricsPanel from './components/MetricsPanel';
 import ProjectInfoDrawer from './components/ProjectInfoDrawer';
@@ -80,6 +81,12 @@ function App() {
               Quality
             </button>
           )}
+          <button
+            className={currentLayer === 'cost' ? 'active' : ''}
+            onClick={() => setCurrentLayer('cost')}
+          >
+            💰 Cost
+          </button>
           {contextTasks.length > 0 && (
             <button
               className={`project-info-trigger ${isProjectInfoOpen ? 'active' : ''}`}
@@ -93,7 +100,7 @@ function App() {
       </header>
 
       <div className="app-content">
-        <div className={`visualization-container ${currentLayer === 'quality' || currentLayer === 'board' ? 'full-width' : ''}`}>
+        <div className={`visualization-container ${currentLayer === 'quality' || currentLayer === 'board' || currentLayer === 'cost' ? 'full-width' : ''}`}>
           {/* Live mode views */}
           {currentLayer === 'network' && <NetworkGraphView />}
           {currentLayer === 'swimlanes' && <AgentSwimLanesView />}
@@ -101,6 +108,7 @@ function App() {
           {currentLayer === 'board' && <BoardView />}
           {currentLayer === 'health' && <HealthCheckDashboard />}
           {currentLayer === 'quality' && <QualityDashboard />}
+          {currentLayer === 'cost' && <CostDashboard />}
         </div>
 
         {/* Task Lifecycle Panel — inline sidebar, pushes content left */}

--- a/dashboard/src/components/AgentSpendBars.css
+++ b/dashboard/src/components/AgentSpendBars.css
@@ -1,0 +1,25 @@
+.agent-spend-bars {
+  font-family: var(--font-mono, ui-monospace, 'SF Mono', monospace);
+}
+
+.agent-spend-bars .agent-label {
+  font-size: 12px;
+  fill: var(--text-color, #1e293b);
+}
+
+.agent-spend-bars .agent-cost {
+  font-size: 11px;
+  fill: var(--text-muted, #475569);
+}
+
+.agent-spend-bars .agent-spend-row:hover rect {
+  opacity: 1;
+}
+
+.agent-spend-empty {
+  padding: 24px;
+  color: var(--text-muted, #64748b);
+  font-size: 13px;
+  font-style: italic;
+  text-align: center;
+}

--- a/dashboard/src/components/AgentSpendBars.tsx
+++ b/dashboard/src/components/AgentSpendBars.tsx
@@ -1,0 +1,122 @@
+/**
+ * Horizontal bar chart of per-agent spend in the active experiment.
+ *
+ * Renders one row per ``AgentSlice`` from the experiment summary, sorted
+ * by ``cost_usd`` descending. Uses D3 to compute the scale and React to
+ * render the SVG primitives — same hybrid the rest of Cato uses
+ * (NetworkGraphView, AgentSwimLanesView).
+ */
+
+import { useMemo } from 'react';
+import * as d3 from 'd3';
+import type { AgentSlice } from '../services/costService';
+import './AgentSpendBars.css';
+
+interface Props {
+  agents: AgentSlice[];
+  /** Total height in px. Defaults to 32 × number of rows + margins. */
+  height?: number;
+  /** Click handler — frontend wires this to an agent drill-in panel. */
+  onAgentClick?: (agentId: string) => void;
+}
+
+const MARGIN = { top: 8, right: 64, bottom: 8, left: 140 };
+const ROW_HEIGHT = 28;
+
+const ROLE_COLORS: Record<string, string> = {
+  planner: '#7c3aed',     // purple
+  worker: '#0ea5e9',      // sky
+  creator: '#10b981',     // emerald
+  monitor: '#f59e0b',     // amber
+  subagent: '#8b5cf6',    // violet
+};
+
+function formatUsd(v: number): string {
+  if (v >= 1) return `$${v.toFixed(2)}`;
+  return `$${v.toFixed(4)}`;
+}
+
+const AgentSpendBars = ({ agents, height, onAgentClick }: Props) => {
+  // Sort defensively — backend already orders by cost_usd DESC but the
+  // parent may have remapped.
+  const sorted = useMemo(
+    () => [...agents].sort((a, b) => b.cost_usd - a.cost_usd),
+    [agents],
+  );
+
+  const totalHeight =
+    height ?? sorted.length * ROW_HEIGHT + MARGIN.top + MARGIN.bottom;
+  const width = 640;
+  const innerWidth = width - MARGIN.left - MARGIN.right;
+
+  const xScale = useMemo(() => {
+    const maxCost = d3.max(sorted, (d) => d.cost_usd) ?? 0.0001;
+    return d3.scaleLinear().domain([0, maxCost]).range([0, innerWidth]);
+  }, [sorted, innerWidth]);
+
+  if (sorted.length === 0) {
+    return (
+      <div className="agent-spend-empty">
+        No agent activity yet — events will appear when the next worker turn lands.
+      </div>
+    );
+  }
+
+  return (
+    <svg
+      className="agent-spend-bars"
+      width="100%"
+      height={totalHeight}
+      viewBox={`0 0 ${width} ${totalHeight}`}
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      aria-label="Per-agent spend"
+    >
+      <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+        {sorted.map((a, i) => {
+          const y = i * ROW_HEIGHT;
+          const barWidth = xScale(a.cost_usd);
+          const color = ROLE_COLORS[a.role] ?? '#64748b';
+          return (
+            <g
+              key={a.agent_id}
+              className="agent-spend-row"
+              transform={`translate(0,${y})`}
+              onClick={() => onAgentClick?.(a.agent_id)}
+              style={{ cursor: onAgentClick ? 'pointer' : 'default' }}
+            >
+              <text
+                className="agent-label"
+                x={-8}
+                y={ROW_HEIGHT / 2}
+                textAnchor="end"
+                dominantBaseline="middle"
+              >
+                {a.agent_id}
+              </text>
+              <rect
+                x={0}
+                y={4}
+                width={barWidth}
+                height={ROW_HEIGHT - 8}
+                fill={color}
+                opacity={0.85}
+                rx={3}
+              />
+              <text
+                className="agent-cost"
+                x={barWidth + 8}
+                y={ROW_HEIGHT / 2}
+                dominantBaseline="middle"
+              >
+                {formatUsd(a.cost_usd)}
+              </text>
+            </g>
+          );
+        })}
+      </g>
+    </svg>
+  );
+};
+
+export default AgentSpendBars;

--- a/dashboard/src/components/CostDashboard.css
+++ b/dashboard/src/components/CostDashboard.css
@@ -1,0 +1,107 @@
+.cost-dashboard {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: auto;
+  background: var(--bg-canvas, #f8fafc);
+}
+
+.cost-dashboard-error {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted, #64748b);
+}
+
+.cost-dashboard-error h2 {
+  font-size: 18px;
+  margin: 0 0 8px;
+  color: var(--text-color, #1e293b);
+}
+
+.cost-dashboard-error .hint {
+  font-size: 12px;
+  margin-top: 12px;
+  font-style: italic;
+}
+
+.cost-dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-dashboard-header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.cost-experiment-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.cost-experiment-picker label {
+  color: var(--text-muted, #64748b);
+}
+
+.cost-experiment-picker select {
+  padding: 6px 10px;
+  font-size: 13px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 6px;
+  background: var(--bg-elevated, #ffffff);
+  min-width: 240px;
+}
+
+.cost-tab-strip {
+  display: flex;
+  gap: 4px;
+  padding: 8px 24px 0;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-tab-strip button {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  border: none;
+  background: transparent;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  color: var(--text-muted, #64748b);
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.cost-tab-strip button:hover:not(:disabled) {
+  color: var(--text-color, #1e293b);
+}
+
+.cost-tab-strip button.active {
+  color: var(--accent-color, #0ea5e9);
+  border-bottom-color: var(--accent-color, #0ea5e9);
+}
+
+.cost-tab-strip button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cost-tab-content {
+  flex: 1;
+  overflow: auto;
+}
+
+.cost-empty {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted, #64748b);
+  font-size: 14px;
+}

--- a/dashboard/src/components/CostDashboard.tsx
+++ b/dashboard/src/components/CostDashboard.tsx
@@ -1,0 +1,133 @@
+/**
+ * Top-level cost dashboard page (Marcus issue #409).
+ *
+ * Phase 7 ships only Tab 1 — Real-time. Tabs 2-4 (Historical, Budget,
+ * Pricing) land in the next PR. The tab strip is rendered now so the
+ * picker is in place when those land.
+ */
+
+import { useEffect, useState } from 'react';
+import { fetchExperiments, type ExperimentRow } from '../services/costService';
+import RealTimeTab from './RealTimeTab';
+import './CostDashboard.css';
+
+type CostTab = 'realtime' | 'historical' | 'budget' | 'pricing';
+
+const CostDashboard = () => {
+  const [activeTab, setActiveTab] = useState<CostTab>('realtime');
+  const [experiments, setExperiments] = useState<ExperimentRow[]>([]);
+  const [selectedExp, setSelectedExp] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch experiment list on mount and refresh every 30s so a new run
+  // appears in the picker without the user reloading the page.
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const { experiments: exps } = await fetchExperiments();
+        if (cancelled) return;
+        setExperiments(exps);
+        setError(null);
+        if (selectedExp === null && exps.length > 0) {
+          setSelectedExp(exps[0].experiment_id);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    };
+
+    load();
+    const id = window.setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [selectedExp]);
+
+  if (error && experiments.length === 0) {
+    return (
+      <div className="cost-dashboard cost-dashboard-error">
+        <h2>Cost dashboard unavailable</h2>
+        <p>{error}</p>
+        <p className="hint">
+          The cost backend may be disabled — check that Marcus is running and
+          ~/.marcus/costs.db exists.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="cost-dashboard">
+      <div className="cost-dashboard-header">
+        <h2>Cost</h2>
+        <div className="cost-experiment-picker">
+          <label htmlFor="cost-exp-select">Experiment:</label>
+          <select
+            id="cost-exp-select"
+            value={selectedExp ?? ''}
+            onChange={(e) => setSelectedExp(e.target.value || null)}
+          >
+            {experiments.length === 0 && <option value="">— none yet —</option>}
+            {experiments.map((exp) => (
+              <option key={exp.experiment_id} value={exp.experiment_id}>
+                {exp.project_name ?? exp.experiment_id} — $
+                {exp.total_cost_usd.toFixed(2)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="cost-tab-strip">
+        <button
+          className={activeTab === 'realtime' ? 'active' : ''}
+          onClick={() => setActiveTab('realtime')}
+        >
+          Real-time
+        </button>
+        <button
+          className={activeTab === 'historical' ? 'active' : ''}
+          onClick={() => setActiveTab('historical')}
+          disabled
+          title="Coming in Phase 8"
+        >
+          Historical
+        </button>
+        <button
+          className={activeTab === 'budget' ? 'active' : ''}
+          onClick={() => setActiveTab('budget')}
+          disabled
+          title="Coming in Phase 8"
+        >
+          Budget
+        </button>
+        <button
+          className={activeTab === 'pricing' ? 'active' : ''}
+          onClick={() => setActiveTab('pricing')}
+          disabled
+          title="Coming in Phase 8"
+        >
+          Pricing
+        </button>
+      </div>
+
+      <div className="cost-tab-content">
+        {activeTab === 'realtime' && selectedExp && (
+          <RealTimeTab experimentId={selectedExp} />
+        )}
+        {activeTab === 'realtime' && !selectedExp && (
+          <div className="cost-empty">
+            No experiments yet. Run one with the marcus skill and they'll appear here.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CostDashboard;

--- a/dashboard/src/components/RealTimeTab.css
+++ b/dashboard/src/components/RealTimeTab.css
@@ -1,0 +1,194 @@
+.cost-realtime {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 24px;
+  font-family: var(--font-sans, system-ui, -apple-system, sans-serif);
+}
+
+.cost-loading,
+.cost-error {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-muted, #64748b);
+}
+
+.cost-error {
+  color: var(--error-color, #dc2626);
+}
+
+/* Headline */
+
+.cost-headline {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 8px;
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-headline-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.cost-experiment-name {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.cost-status-pill {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.cost-status-pill.running {
+  background: rgba(34, 197, 94, 0.15);
+  color: #16a34a;
+}
+
+.cost-status-pill.done {
+  background: rgba(100, 116, 139, 0.15);
+  color: #475569;
+}
+
+.cost-headline-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.cost-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cost-stat-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted, #64748b);
+}
+
+.cost-stat-value {
+  font-size: 22px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.cost-stat-primary .cost-stat-value {
+  color: #0ea5e9;
+}
+
+/* Tokens row */
+
+.cost-tokens-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.cost-token-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 16px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-token-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #64748b);
+}
+
+.cost-token-value {
+  font-size: 18px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Breakdown row */
+
+.cost-breakdown {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 12px;
+}
+
+.cost-panel {
+  padding: 16px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 8px;
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-panel h3 {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #475569);
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.cost-session-hint {
+  font-size: 11px;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text-muted, #64748b);
+  font-weight: 400;
+}
+
+.cost-role-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cost-role-list li {
+  display: grid;
+  grid-template-columns: 12px 1fr auto auto;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.role-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #94a3b8;
+}
+
+.role-dot.role-planner { background: #7c3aed; }
+.role-dot.role-worker  { background: #0ea5e9; }
+.role-dot.role-creator { background: #10b981; }
+.role-dot.role-monitor { background: #f59e0b; }
+.role-dot.role-subagent{ background: #8b5cf6; }
+
+.role-cost {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.role-events {
+  font-size: 11px;
+  color: var(--text-muted, #64748b);
+}

--- a/dashboard/src/components/RealTimeTab.tsx
+++ b/dashboard/src/components/RealTimeTab.tsx
@@ -1,0 +1,230 @@
+/**
+ * Tab 1 — Real-time experiment view.
+ *
+ * Polls Cato's ``/api/cost/experiments/{id}`` every 5s for the active
+ * experiment and renders the headline numbers plus two D3 charts:
+ * per-agent spend bars and a per-turn cost trajectory for the most
+ * recent session.
+ *
+ * Why polling, not SSE: Marcus's coordination model is board-mediated
+ * and pull-based; polling fits that paradigm and is much simpler to
+ * debug. We can layer SSE on later if real time matters more.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  fetchExperimentSummary,
+  fetchSessionTurns,
+  type ExperimentSummary,
+  type TurnPoint,
+} from '../services/costService';
+import AgentSpendBars from './AgentSpendBars';
+import TurnTrajectory from './TurnTrajectory';
+import './RealTimeTab.css';
+
+interface Props {
+  experimentId: string;
+  /** Poll interval in ms. Default 5000. Set to 0 to disable polling. */
+  pollIntervalMs?: number;
+}
+
+function formatUsd(v: number, decimals = 2): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function formatTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}
+
+function formatPct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+const RealTimeTab = ({ experimentId, pollIntervalMs = 5000 }: Props) => {
+  const [summary, setSummary] = useState<ExperimentSummary | null>(null);
+  const [turns, setTurns] = useState<TurnPoint[]>([]);
+  const [selectedSession, setSelectedSession] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Poll the experiment summary.
+  useEffect(() => {
+    let cancelled = false;
+
+    const tick = async () => {
+      try {
+        const s = await fetchExperimentSummary(experimentId);
+        if (!cancelled) {
+          setSummary(s);
+          setError(null);
+          // Pick the agent with the most turns as default session source.
+          // This is a heuristic — we surface a session picker once
+          // sessions become a first-class concept in the UI.
+          if (selectedSession === null) {
+            const topAgent = s.by_agent.find((a) => a.sessions > 0);
+            if (topAgent) {
+              // Use the agent_id-keyed convention: agents working a task
+              // commonly run one session. The session list isn't in the
+              // summary today; the trajectory chart stays empty until
+              // the user picks one via /api/cost/sessions/{id}/turns.
+              // For Phase 7, we leave selectedSession null until the
+              // session picker lands in Tabs 2-4.
+            }
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    };
+
+    tick();
+    if (pollIntervalMs > 0) {
+      const id = window.setInterval(tick, pollIntervalMs);
+      return () => {
+        cancelled = true;
+        window.clearInterval(id);
+      };
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [experimentId, pollIntervalMs, selectedSession]);
+
+  // Fetch turns when a session is selected.
+  useEffect(() => {
+    if (!selectedSession) {
+      setTurns([]);
+      return;
+    }
+    let cancelled = false;
+    fetchSessionTurns(selectedSession)
+      .then((d) => {
+        if (!cancelled) setTurns(d.turns);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedSession]);
+
+  if (error) {
+    return <div className="cost-error">⚠ {error}</div>;
+  }
+  if (!summary) {
+    return <div className="cost-loading">Loading cost data…</div>;
+  }
+
+  const s = summary.summary;
+  const isRunning = summary.ended_at === null;
+
+  return (
+    <div className="cost-realtime">
+      {/* Headline strip */}
+      <header className="cost-headline">
+        <div className="cost-headline-title">
+          <span className="cost-experiment-name">
+            {summary.project_name ?? summary.experiment_id}
+          </span>
+          <span
+            className={`cost-status-pill ${isRunning ? 'running' : 'done'}`}
+          >
+            {isRunning ? '● running' : '✓ done'}
+          </span>
+        </div>
+        <div className="cost-headline-metrics">
+          <div className="cost-stat">
+            <span className="cost-stat-label">Total tokens</span>
+            <span className="cost-stat-value">{formatTokens(s.total_tokens)}</span>
+          </div>
+          <div className="cost-stat cost-stat-primary">
+            <span className="cost-stat-label">Total cost</span>
+            <span className="cost-stat-value">{formatUsd(s.total_cost_usd, 2)}</span>
+          </div>
+          <div className="cost-stat">
+            <span className="cost-stat-label">Cache hit rate</span>
+            <span className="cost-stat-value">{formatPct(s.cache_hit_rate)}</span>
+          </div>
+          <div className="cost-stat">
+            <span className="cost-stat-label">Events</span>
+            <span className="cost-stat-value">{s.total_events}</span>
+          </div>
+        </div>
+      </header>
+
+      {/* Token breakdown row */}
+      <section className="cost-tokens-row">
+        <div className="cost-token-card">
+          <span className="cost-token-label">Input</span>
+          <span className="cost-token-value">{formatTokens(s.input_tokens)}</span>
+        </div>
+        <div className="cost-token-card">
+          <span className="cost-token-label">Cache created</span>
+          <span className="cost-token-value">
+            {formatTokens(s.cache_creation_tokens)}
+          </span>
+        </div>
+        <div className="cost-token-card">
+          <span className="cost-token-label">Cache read</span>
+          <span className="cost-token-value">
+            {formatTokens(s.cache_read_tokens)}
+          </span>
+        </div>
+        <div className="cost-token-card">
+          <span className="cost-token-label">Output</span>
+          <span className="cost-token-value">{formatTokens(s.output_tokens)}</span>
+        </div>
+      </section>
+
+      {/* Role + agent breakdowns */}
+      <section className="cost-breakdown">
+        <div className="cost-panel">
+          <h3>Cost by role</h3>
+          <ul className="cost-role-list">
+            {summary.by_role.map((r) => (
+              <li key={r.role}>
+                <span className={`role-dot role-${r.role}`}></span>
+                <span className="role-name">{r.role}</span>
+                <span className="role-cost">{formatUsd(r.cost_usd, 4)}</span>
+                <span className="role-events">({r.events} events)</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="cost-panel cost-panel-wide">
+          <h3>Cost by agent</h3>
+          <AgentSpendBars
+            agents={summary.by_agent}
+            onAgentClick={(agentId) => {
+              // First-pass: clicking an agent sets the session source
+              // to the agent_id. The session_id is not in the summary
+              // payload today; for Phase 7 we leave the chart empty
+              // until the session-picker lands in Tabs 2-4.
+              setSelectedSession(agentId);
+            }}
+          />
+        </div>
+      </section>
+
+      {/* Turn trajectory */}
+      <section className="cost-panel">
+        <h3>
+          Per-turn trajectory
+          {selectedSession && (
+            <span className="cost-session-hint">session: {selectedSession}</span>
+          )}
+        </h3>
+        <TurnTrajectory turns={turns} />
+      </section>
+    </div>
+  );
+};
+
+export default RealTimeTab;

--- a/dashboard/src/components/TurnTrajectory.css
+++ b/dashboard/src/components/TurnTrajectory.css
@@ -1,0 +1,44 @@
+.turn-trajectory {
+  font-family: var(--font-mono, ui-monospace, 'SF Mono', monospace);
+}
+
+.turn-trajectory .grid {
+  stroke: var(--border-color, #e2e8f0);
+  stroke-dasharray: 2 4;
+}
+
+.turn-trajectory .area {
+  fill: rgba(14, 165, 233, 0.12);
+}
+
+.turn-trajectory .line {
+  fill: none;
+  stroke: #0ea5e9;
+  stroke-width: 2;
+}
+
+.turn-trajectory .point {
+  fill: #0ea5e9;
+  stroke: white;
+  stroke-width: 1.5;
+}
+
+.turn-trajectory .axis-label,
+.turn-trajectory .axis-caption {
+  font-size: 11px;
+  fill: var(--text-muted, #64748b);
+}
+
+.turn-trajectory .axis-caption {
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.turn-trajectory-empty {
+  padding: 24px;
+  color: var(--text-muted, #64748b);
+  font-size: 13px;
+  font-style: italic;
+  text-align: center;
+}

--- a/dashboard/src/components/TurnTrajectory.tsx
+++ b/dashboard/src/components/TurnTrajectory.tsx
@@ -1,0 +1,149 @@
+/**
+ * Per-turn cost trajectory for a single Claude Code session.
+ *
+ * Renders a D3 line chart with turn_index on the x-axis and cost_usd
+ * on the y-axis, plus a faint area under the line. Used in the
+ * real-time tab to spot runaway loops — a session whose cost climbs
+ * sharply across consecutive turns is usually stuck.
+ */
+
+import { useMemo } from 'react';
+import * as d3 from 'd3';
+import type { TurnPoint } from '../services/costService';
+import './TurnTrajectory.css';
+
+interface Props {
+  turns: TurnPoint[];
+  width?: number;
+  height?: number;
+}
+
+const MARGIN = { top: 16, right: 16, bottom: 24, left: 48 };
+
+const TurnTrajectory = ({ turns, width = 640, height = 220 }: Props) => {
+  const innerW = width - MARGIN.left - MARGIN.right;
+  const innerH = height - MARGIN.top - MARGIN.bottom;
+
+  const xScale = useMemo(() => {
+    const maxTurn = d3.max(turns, (d) => d.turn_index) ?? 1;
+    return d3.scaleLinear().domain([1, Math.max(maxTurn, 1)]).range([0, innerW]);
+  }, [turns, innerW]);
+
+  const yScale = useMemo(() => {
+    const maxCost = d3.max(turns, (d) => d.cost_usd) ?? 0.001;
+    return d3.scaleLinear().domain([0, maxCost * 1.1]).range([innerH, 0]);
+  }, [turns, innerH]);
+
+  const linePath = useMemo(() => {
+    return d3
+      .line<TurnPoint>()
+      .x((d) => xScale(d.turn_index))
+      .y((d) => yScale(d.cost_usd))
+      .curve(d3.curveMonotoneX)(turns);
+  }, [turns, xScale, yScale]);
+
+  const areaPath = useMemo(() => {
+    return d3
+      .area<TurnPoint>()
+      .x((d) => xScale(d.turn_index))
+      .y0(innerH)
+      .y1((d) => yScale(d.cost_usd))
+      .curve(d3.curveMonotoneX)(turns);
+  }, [turns, xScale, yScale, innerH]);
+
+  if (turns.length === 0) {
+    return (
+      <div className="turn-trajectory-empty">
+        Pick a session to see its per-turn cost.
+      </div>
+    );
+  }
+
+  // 5 horizontal gridlines.
+  const yTicks = yScale.ticks(5);
+  const xTicks = xScale.ticks(Math.min(turns.length, 8));
+
+  return (
+    <svg
+      className="turn-trajectory"
+      width="100%"
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      aria-label="Per-turn cost trajectory"
+    >
+      <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+        {/* Gridlines */}
+        {yTicks.map((t) => (
+          <line
+            key={`yg-${t}`}
+            x1={0}
+            x2={innerW}
+            y1={yScale(t)}
+            y2={yScale(t)}
+            className="grid"
+          />
+        ))}
+
+        {/* Area + line */}
+        {areaPath && <path d={areaPath} className="area" />}
+        {linePath && <path d={linePath} className="line" />}
+
+        {/* Points */}
+        {turns.map((t) => (
+          <circle
+            key={`p-${t.turn_index}`}
+            cx={xScale(t.turn_index)}
+            cy={yScale(t.cost_usd)}
+            r={3}
+            className="point"
+          >
+            <title>
+              turn {t.turn_index} — ${t.cost_usd.toFixed(4)} ({t.total_tokens} tok)
+            </title>
+          </circle>
+        ))}
+
+        {/* Y axis labels */}
+        {yTicks.map((t) => (
+          <text
+            key={`yl-${t}`}
+            x={-8}
+            y={yScale(t)}
+            dominantBaseline="middle"
+            textAnchor="end"
+            className="axis-label"
+          >
+            ${t.toFixed(3)}
+          </text>
+        ))}
+
+        {/* X axis labels */}
+        {xTicks.map((t) => (
+          <text
+            key={`xl-${t}`}
+            x={xScale(t)}
+            y={innerH + 16}
+            textAnchor="middle"
+            className="axis-label"
+          >
+            {t}
+          </text>
+        ))}
+
+        {/* X axis caption */}
+        <text
+          x={innerW / 2}
+          y={innerH + 32}
+          textAnchor="middle"
+          className="axis-caption"
+        >
+          turn
+        </text>
+      </g>
+    </svg>
+  );
+};
+
+export default TurnTrajectory;

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -1,0 +1,142 @@
+/**
+ * Cost-tracking data service for the Cato dashboard (Marcus issue #409).
+ *
+ * Wraps the /api/cost/* endpoints exposed by backend/cost_routes.py with
+ * typed fetchers. Response shapes mirror Marcus's CostAggregator return
+ * values exactly, so React components consume them directly.
+ */
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:4301';
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+export interface ExperimentRow {
+  experiment_id: string;
+  project_id: string;
+  project_name: string | null;
+  started_at: string;
+  ended_at: string | null;
+  num_agents: number | null;
+  total_tasks: number | null;
+  completed_tasks: number | null;
+  blocked_tasks: number | null;
+  total_tokens: number;
+  total_cost_usd: number;
+}
+
+export interface RoleSlice {
+  role: string;
+  events: number;
+  tokens: number;
+  cost_usd: number;
+}
+
+export interface AgentSlice {
+  agent_id: string;
+  role: string;
+  events: number;
+  tokens: number;
+  cost_usd: number;
+  tasks_worked: number;
+  sessions: number;
+  turns: number;
+}
+
+export interface TaskSlice {
+  task_id: string;
+  events: number;
+  tokens: number;
+  cost_usd: number;
+}
+
+export interface OperationSlice {
+  operation: string;
+  events: number;
+  tokens: number;
+  cost_usd: number;
+}
+
+export interface ModelSlice {
+  model: string;
+  provider: string;
+  events: number;
+  tokens: number;
+  cost_usd: number;
+}
+
+export interface ExperimentSummary {
+  experiment_id: string;
+  project_id: string;
+  project_name: string | null;
+  started_at: string;
+  ended_at: string | null;
+  num_agents: number | null;
+  total_tasks: number | null;
+  completed_tasks: number | null;
+  blocked_tasks: number | null;
+  summary: {
+    total_events: number;
+    total_tokens: number;
+    input_tokens: number;
+    cache_creation_tokens: number;
+    cache_read_tokens: number;
+    output_tokens: number;
+    total_cost_usd: number;
+    cache_hit_rate: number;
+  };
+  by_role: RoleSlice[];
+  by_agent: AgentSlice[];
+  by_task: TaskSlice[];
+  by_operation: OperationSlice[];
+  by_model: ModelSlice[];
+}
+
+export interface TurnPoint {
+  turn_index: number;
+  total_tokens: number;
+  cost_usd: number;
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// Fetchers
+// ---------------------------------------------------------------------------
+
+async function _get<T>(path: string): Promise<T> {
+  const resp = await fetch(`${API_BASE_URL}${path}`);
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status} ${resp.statusText} (${path})`);
+  }
+  return resp.json() as Promise<T>;
+}
+
+/**
+ * List experiments with token + cost totals attached.
+ *
+ * @param projectId Optional project filter.
+ * @param limit Cap at 1000. Default 100.
+ */
+export async function fetchExperiments(
+  projectId?: string,
+  limit = 100,
+): Promise<{ experiments: ExperimentRow[]; count: number }> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (projectId) params.set('project_id', projectId);
+  return _get(`/api/cost/experiments?${params}`);
+}
+
+/** Full per-experiment breakdown (summary + by_role / agent / task / etc.). */
+export async function fetchExperimentSummary(
+  experimentId: string,
+): Promise<ExperimentSummary> {
+  return _get(`/api/cost/experiments/${encodeURIComponent(experimentId)}`);
+}
+
+/** Per-turn cost trajectory for one Claude Code session. */
+export async function fetchSessionTurns(
+  sessionId: string,
+): Promise<{ session_id: string; turns: TurnPoint[] }> {
+  return _get(`/api/cost/sessions/${encodeURIComponent(sessionId)}/turns`);
+}

--- a/dashboard/src/store/visualizationStore.ts
+++ b/dashboard/src/store/visualizationStore.ts
@@ -12,7 +12,8 @@ export type ViewLayer =
   | 'fidelity'
   | 'decisions'
   | 'failures'
-  | 'redundancy';
+  | 'redundancy'
+  | 'cost';
 export type TaskView = 'subtasks' | 'parents' | 'all';
 
 interface VisualizationState {


### PR DESCRIPTION
## Summary

First-pass UI on top of the \`/api/cost/*\` backend that landed in #28. New top-level **Cost** tab in the Cato dashboard renders Marcus's planner + worker token spend in near-real-time (5s polling). Future sub-tabs (Historical, Budget, Pricing) are reserved in the strip but disabled until Phase 8.

## What ships

| File | Purpose |
|---|---|
| \`services/costService.ts\` | Typed fetchers for \`/api/cost/experiments\`, \`/experiments/{id}\`, \`/sessions/{id}/turns\` |
| \`components/CostDashboard.tsx\` | Top-level page. Experiment picker + sub-tab router |
| \`components/RealTimeTab.tsx\` | Headline totals, token-breakdown row, by-role list, by-agent bar chart, per-turn line chart |
| \`components/AgentSpendBars.tsx\` | D3 horizontal bar chart, color-coded by agent role |
| \`components/TurnTrajectory.tsx\` | D3 line + area chart for per-turn cost (runaway-loop detection) |

App wiring: \`'cost'\` added to \`ViewLayer\`, a new 💰 Cost button in the tab strip, full-width canvas matching the Quality and Board layouts.

## Why polling instead of SSE

Cato's existing data pattern is pull-based (\`/api/snapshot\`, \`/api/projects\`, etc.) and Marcus's coordination model is board-mediated. Polling at 5s aligns with both and is simpler to debug. SSE can layer on later if/when sub-second updates matter — the backend already supports the shape per #409.

## What's stubbed for now

- **Session picker.** Clicking an agent in the by-agent bar chart sets a session ID, but the per-turn chart only renders when a real session ID is selected. Phase 8 adds a proper picker on the agent drill-in.
- **Historical / Budget / Pricing tabs.** Buttons present but disabled with a tooltip pointing to Phase 8.

## Empty + error states

Handled at three layers so failure modes never blank the canvas:

- Dashboard: 503 from backend → "Cost dashboard unavailable" page with a hint.
- Tab: no experiment selected → "Run one with the marcus skill and they'll appear here."
- Chart: no agent activity / no session selected → italic prompts.

## Test plan

- [x] tsc --noEmit clean on all new files
- [x] Imports verified — no broken references
- [ ] Manual smoke: \`npm run dev\` in dashboard/, start Marcus + Cato backend, click 💰 Cost, verify experiment list populates and headline numbers match \`curl /api/cost/experiments\`
- [ ] Visual check: D3 charts render correctly for an experiment with 2+ agents

## Requires

Cato PR #28 — already merged to \`develop\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)