### PR TITLE
feat(dashboard): Show Subtasks / Parents / All toggle on graph views

### DIFF
--- a/dashboard/src/components/AgentSwimLanesView.tsx
+++ b/dashboard/src/components/AgentSwimLanesView.tsx
@@ -1,6 +1,7 @@
 import { useVisualizationStore } from '../store/visualizationStore';
 import { Task as SnapshotTask } from '../services/dataService';
 import { getTaskStateAtTime, timeToLogScale } from '../utils/timelineUtils';
+import ViewModeToggle from './ViewModeToggle';
 import './AgentSwimLanesView.css';
 
 type TaskStatus = 'todo' | 'in_progress' | 'done' | 'blocked';
@@ -16,6 +17,7 @@ const AgentSwimLanesView = () => {
   if (!snapshot || !snapshot.start_time || !snapshot.end_time) {
     return (
       <div className="swimlanes-view">
+        <ViewModeToggle />
         <div className="swimlanes-container">
           <div className="no-data">No snapshot data available</div>
         </div>
@@ -142,6 +144,7 @@ const AgentSwimLanesView = () => {
 
   return (
     <div className="swimlanes-view">
+      <ViewModeToggle />
       <div className="swimlanes-container">
         <div className="swimlanes-content">
           {/* Time axis */}

--- a/dashboard/src/components/BoardView.tsx
+++ b/dashboard/src/components/BoardView.tsx
@@ -3,6 +3,7 @@ import { useVisualizationStore } from '../store/visualizationStore';
 import { Task } from '../services/dataService';
 import { getTaskStateAtTime } from '../utils/timelineUtils';
 import ArtifactPreviewModal from './ArtifactPreviewModal';
+import ViewModeToggle from './ViewModeToggle';
 import './BoardView.css';
 
 const COLUMNS: { key: Task['status']; label: string; color: string; icon: string }[] = [
@@ -137,6 +138,7 @@ const BoardView = () => {
   if (!snapshot) {
     return (
       <div className="board-view">
+        <ViewModeToggle />
         <div className="board-empty">No data available</div>
       </div>
     );
@@ -232,6 +234,7 @@ const BoardView = () => {
 
   return (
     <div className={`board-view ${selectedTask ? 'with-detail' : ''}`}>
+      <ViewModeToggle />
       {/* Board columns */}
       <div className="board-columns">
         {COLUMNS.map((col) => {

--- a/dashboard/src/components/NetworkGraphView.tsx
+++ b/dashboard/src/components/NetworkGraphView.tsx
@@ -3,6 +3,7 @@ import * as d3 from 'd3';
 import { useVisualizationStore } from '../store/visualizationStore';
 import { Task } from '../services/dataService';
 import { getTaskStateAtTime } from '../utils/timelineUtils';
+import ViewModeToggle from './ViewModeToggle';
 import './NetworkGraphView.css';
 
 type TaskStatus = 'todo' | 'in_progress' | 'done' | 'blocked';
@@ -606,6 +607,7 @@ const NetworkGraphView = () => {
 
   return (
     <div className="network-graph-view">
+      <ViewModeToggle />
       {designTasks.length > 0 && (
         <div className="design-origins-strip">
           <div className="strip-label">Design Origins</div>

--- a/dashboard/src/components/ViewModeToggle.css
+++ b/dashboard/src/components/ViewModeToggle.css
@@ -1,0 +1,42 @@
+.view-mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  background-color: #0f172a;
+  border-bottom: 1px solid #334155;
+  flex-shrink: 0;
+}
+
+.view-mode-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-right: 0.4rem;
+}
+
+.view-mode-button {
+  appearance: none;
+  background: transparent;
+  border: 1px solid #334155;
+  color: #94a3b8;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  border-radius: 0.3rem;
+  cursor: pointer;
+  transition: background-color 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.view-mode-button:hover {
+  color: #e2e8f0;
+  border-color: #475569;
+}
+
+.view-mode-button.active {
+  background: #1e3a8a;
+  border-color: #3b82f6;
+  color: #e0e7ff;
+}

--- a/dashboard/src/components/ViewModeToggle.tsx
+++ b/dashboard/src/components/ViewModeToggle.tsx
@@ -1,0 +1,32 @@
+import { useVisualizationStore } from '../store/visualizationStore';
+import './ViewModeToggle.css';
+
+const MODES: Array<{ key: 'subtasks' | 'parents' | 'all'; label: string }> = [
+  { key: 'subtasks', label: 'Subtasks' },
+  { key: 'parents', label: 'Parents' },
+  { key: 'all', label: 'All' },
+];
+
+const ViewModeToggle = () => {
+  const viewMode = useVisualizationStore((state) => state.viewMode);
+  const setViewMode = useVisualizationStore((state) => state.setViewMode);
+
+  return (
+    <div className="view-mode-toggle" role="group" aria-label="Task view mode">
+      <span className="view-mode-label">Show</span>
+      {MODES.map(({ key, label }) => (
+        <button
+          key={key}
+          type="button"
+          className={`view-mode-button ${viewMode === key ? 'active' : ''}`}
+          onClick={() => viewMode !== key && setViewMode(key)}
+          aria-pressed={viewMode === key}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default ViewModeToggle;

--- a/dashboard/src/store/visualizationStore.ts
+++ b/dashboard/src/store/visualizationStore.ts
@@ -49,6 +49,12 @@ interface VisualizationState {
   resetTimeOnTabSwitch: boolean;
   setResetTimeOnTabSwitch: (value: boolean) => void;
 
+  // Snapshot view mode — controls whether subtasks, parents, or all tasks
+  // are returned by the backend. Persisted in localStorage; changing it
+  // triggers a snapshot reload.
+  viewMode: 'subtasks' | 'parents' | 'all';
+  setViewMode: (mode: 'subtasks' | 'parents' | 'all') => void;
+
   // Project Info drawer state
   isProjectInfoOpen: boolean;
 
@@ -119,6 +125,16 @@ export const useVisualizationStore = create<VisualizationState>((set, get) => {
       localStorage.setItem('cato_resetTimeOnTabSwitch', String(value));
       set({ resetTimeOnTabSwitch: value });
     },
+    viewMode:
+      ((localStorage.getItem('cato_viewMode') as 'subtasks' | 'parents' | 'all') ||
+        'parents'),
+    setViewMode: (mode) => {
+      localStorage.setItem('cato_viewMode', mode);
+      set({ viewMode: mode });
+      // Reload current project under the new view
+      const { selectedProjectId, loadData } = get();
+      void loadData(selectedProjectId || undefined);
+    },
     lifecycleTask: null,
     setLifecycleTask: (task) => set({ lifecycleTask: task }),
     autoRefreshIntervalId: null,
@@ -132,7 +148,7 @@ export const useVisualizationStore = create<VisualizationState>((set, get) => {
         console.log('Fetching live snapshot from API...');
         const newSnapshot = await fetchSnapshot(
           projectId,
-          'subtasks', // Always use subtasks view
+          get().viewMode,
           1.0, // Power scale exponent (linear timeline)
           true // Use cache
         );


### PR DESCRIPTION
## Summary

Adds a **Show: Subtasks / Parents / All** segmented control in the header of NetworkGraphView, AgentSwimLanesView, and BoardView so users can pick how the snapshot is sliced. Selection persists in localStorage and triggers a snapshot reload immediately.

Before: \`loadData()\` was hard-coded to fetch with \`viewMode='subtasks'\` regardless of what the user wanted. After: the user picks once, and the choice survives reloads.

## What ships

| File | Change |
|---|---|
| \`components/ViewModeToggle.tsx\` + \`.css\` | New three-button segmented control. \`aria-pressed\` for accessibility, clicking the active button is a no-op. |
| \`store/visualizationStore.ts\` | Adds \`viewMode\` + \`setViewMode\` to state. Default \`'parents'\`. Persisted in localStorage. \`setViewMode\` calls \`loadData(selectedProjectId)\` so the snapshot reloads under the new view. |
| \`store/visualizationStore.ts\` | \`loadData()\` now passes \`get().viewMode\` to \`fetchSnapshot()\` instead of the hard-coded \`'subtasks'\`. |
| \`components/NetworkGraphView.tsx\` | Renders \`<ViewModeToggle />\` at the top |
| \`components/AgentSwimLanesView.tsx\` | Same |
| \`components/BoardView.tsx\` | Same |

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Manual: load the dashboard, click between Subtasks / Parents / All on each of the three views, verify the snapshot reloads and the choice persists across reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)