### PR TITLE
feat(cost): Historical / Budget / Pricing tabs (Marcus #409 phase 8)

### DIFF
--- a/dashboard/src/components/BudgetTab.css
+++ b/dashboard/src/components/BudgetTab.css
@@ -1,0 +1,125 @@
+.cost-budget {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 24px;
+}
+
+.budget-banner {
+  padding: 12px 16px;
+  border-radius: 6px;
+  font-weight: 500;
+}
+
+.budget-banner.banner-warning {
+  background: rgba(245, 158, 11, 0.12);
+  color: #b45309;
+  border: 1px solid rgba(245, 158, 11, 0.4);
+}
+
+.budget-banner.banner-over {
+  background: rgba(220, 38, 38, 0.12);
+  color: #b91c1c;
+  border: 1px solid rgba(220, 38, 38, 0.4);
+}
+
+.budget-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.budget-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 8px;
+  background: var(--bg-elevated, #ffffff);
+}
+
+.budget-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted, #64748b);
+}
+
+.budget-value {
+  font-size: 22px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.budget-value.negative {
+  color: #dc2626;
+}
+
+.budget-bar-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.budget-bar {
+  height: 10px;
+  background: var(--border-color, #e2e8f0);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.budget-bar-fill {
+  height: 100%;
+  background: #0ea5e9;
+  transition: width 0.3s ease-out;
+}
+
+.budget-bar-fill.fill-warning {
+  background: #f59e0b;
+}
+
+.budget-bar-fill.fill-over {
+  background: #dc2626;
+}
+
+.budget-bar-caption {
+  font-size: 12px;
+  color: var(--text-muted, #64748b);
+  font-variant-numeric: tabular-nums;
+}
+
+.budget-meta {
+  display: flex;
+  gap: 24px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-color, #e2e8f0);
+  font-size: 13px;
+}
+
+.budget-meta .meta-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #64748b);
+  margin-right: 6px;
+}
+
+.budget-meta .meta-value {
+  font-weight: 500;
+}
+
+.budget-hint {
+  padding: 12px 16px;
+  background: var(--bg-canvas, #f8fafc);
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--text-muted, #475569);
+}
+
+.budget-hint code {
+  background: var(--bg-elevated, #ffffff);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}

--- a/dashboard/src/components/BudgetTab.tsx
+++ b/dashboard/src/components/BudgetTab.tsx
@@ -1,0 +1,177 @@
+/**
+ * Tab 3 — Budget projection.
+ *
+ * Reads the active experiment's running totals plus its declared
+ * ``budget_usd`` (set at experiment creation) and shows:
+ * 1. Current spend / budget cap / remaining headroom
+ * 2. Projected total based on elapsed-vs-completed ratio
+ * 3. A threshold-crossing banner once spend exceeds 80% of budget
+ *
+ * No backend changes — derives everything from the experiment summary
+ * already exposed by ``/api/cost/experiments/{id}``.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  fetchExperimentSummary,
+  type ExperimentSummary,
+} from '../services/costService';
+import './BudgetTab.css';
+
+interface Props {
+  experimentId: string;
+}
+
+function formatUsd(v: number, decimals = 2): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function elapsedMinutes(startedAt: string, endedAt: string | null): number {
+  const start = new Date(startedAt).getTime();
+  const end = endedAt ? new Date(endedAt).getTime() : Date.now();
+  return Math.max(0, (end - start) / 60000);
+}
+
+const BudgetTab = ({ experimentId }: Props) => {
+  const [summary, setSummary] = useState<ExperimentSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const s = await fetchExperimentSummary(experimentId);
+        if (!cancelled) {
+          setSummary(s);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    };
+    tick();
+    const id = window.setInterval(tick, 10_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [experimentId]);
+
+  if (error) return <div className="cost-error">⚠ {error}</div>;
+  if (!summary) return <div className="cost-loading">Loading budget…</div>;
+
+  // budget_usd is on the experiment metadata returned by the summary;
+  // it is set at creation time (Marcus's Experiment dataclass field).
+  const budget = (summary as unknown as { budget_usd: number | null }).budget_usd;
+  const spent = summary.summary.total_cost_usd;
+  const isRunning = summary.ended_at === null;
+
+  // Projection: linear extrapolation from completed_tasks / total_tasks.
+  // Falls back to "n/a" if neither is known.
+  let projected: number | null = null;
+  if (
+    summary.completed_tasks != null &&
+    summary.total_tasks != null &&
+    summary.completed_tasks > 0
+  ) {
+    projected = spent * (summary.total_tasks / summary.completed_tasks);
+  }
+
+  const pct = budget && budget > 0 ? spent / budget : null;
+  const remaining = budget != null ? budget - spent : null;
+  const alertThreshold = pct != null && pct >= 0.8;
+  const overBudget = pct != null && pct >= 1.0;
+
+  const elapsed = elapsedMinutes(summary.started_at, summary.ended_at);
+
+  return (
+    <div className="cost-budget">
+      {alertThreshold && (
+        <div
+          className={`budget-banner ${
+            overBudget ? 'banner-over' : 'banner-warning'
+          }`}
+        >
+          {overBudget
+            ? `⚠ Over budget — spent ${formatUsd(spent)} of ${formatUsd(
+                budget!,
+              )} cap`
+            : `⚠ At ${(pct! * 100).toFixed(0)}% of budget`}
+        </div>
+      )}
+
+      <section className="budget-grid">
+        <div className="budget-card">
+          <span className="budget-label">Spent</span>
+          <span className="budget-value">{formatUsd(spent)}</span>
+        </div>
+        <div className="budget-card">
+          <span className="budget-label">Budget</span>
+          <span className="budget-value">
+            {budget != null ? formatUsd(budget) : '—'}
+          </span>
+        </div>
+        <div className="budget-card">
+          <span className="budget-label">Remaining</span>
+          <span
+            className={`budget-value ${
+              remaining != null && remaining < 0 ? 'negative' : ''
+            }`}
+          >
+            {remaining != null ? formatUsd(remaining) : '—'}
+          </span>
+        </div>
+        <div className="budget-card">
+          <span className="budget-label">Projected total</span>
+          <span className="budget-value">
+            {projected != null ? formatUsd(projected) : '—'}
+          </span>
+        </div>
+      </section>
+
+      {budget != null && budget > 0 && (
+        <section className="budget-bar-row">
+          <div className="budget-bar">
+            <div
+              className={`budget-bar-fill ${
+                overBudget ? 'fill-over' : alertThreshold ? 'fill-warning' : ''
+              }`}
+              style={{ width: `${Math.min(pct! * 100, 100)}%` }}
+            />
+          </div>
+          <div className="budget-bar-caption">
+            {(pct! * 100).toFixed(1)}% of {formatUsd(budget)}
+          </div>
+        </section>
+      )}
+
+      <section className="budget-meta">
+        <div>
+          <span className="meta-label">Status</span>
+          <span className="meta-value">{isRunning ? 'running' : 'done'}</span>
+        </div>
+        <div>
+          <span className="meta-label">Elapsed</span>
+          <span className="meta-value">{elapsed.toFixed(1)} min</span>
+        </div>
+        <div>
+          <span className="meta-label">Tasks</span>
+          <span className="meta-value">
+            {summary.completed_tasks ?? '?'} / {summary.total_tasks ?? '?'}
+          </span>
+        </div>
+      </section>
+
+      {budget == null && (
+        <p className="budget-hint">
+          No budget set on this experiment. Add a <code>budget_usd</code> when
+          you create the experiment to see projections and alerts.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default BudgetTab;

--- a/dashboard/src/components/CostDashboard.tsx
+++ b/dashboard/src/components/CostDashboard.tsx
@@ -1,13 +1,16 @@
 /**
  * Top-level cost dashboard page (Marcus issue #409).
  *
- * Phase 7 ships only Tab 1 — Real-time. Tabs 2-4 (Historical, Budget,
- * Pricing) land in the next PR. The tab strip is rendered now so the
- * picker is in place when those land.
+ * Four sub-tabs: Real-time (current experiment), Historical (all
+ * experiments), Budget (per-experiment projection vs. cap), and
+ * Pricing (current rate table + CRUD form).
  */
 
 import { useEffect, useState } from 'react';
 import { fetchExperiments, type ExperimentRow } from '../services/costService';
+import BudgetTab from './BudgetTab';
+import HistoricalTab from './HistoricalTab';
+import PricingTab from './PricingTab';
 import RealTimeTab from './RealTimeTab';
 import './CostDashboard.css';
 
@@ -93,24 +96,18 @@ const CostDashboard = () => {
         <button
           className={activeTab === 'historical' ? 'active' : ''}
           onClick={() => setActiveTab('historical')}
-          disabled
-          title="Coming in Phase 8"
         >
           Historical
         </button>
         <button
           className={activeTab === 'budget' ? 'active' : ''}
           onClick={() => setActiveTab('budget')}
-          disabled
-          title="Coming in Phase 8"
         >
           Budget
         </button>
         <button
           className={activeTab === 'pricing' ? 'active' : ''}
           onClick={() => setActiveTab('pricing')}
-          disabled
-          title="Coming in Phase 8"
         >
           Pricing
         </button>
@@ -125,6 +122,21 @@ const CostDashboard = () => {
             No experiments yet. Run one with the marcus skill and they'll appear here.
           </div>
         )}
+        {activeTab === 'historical' && (
+          <HistoricalTab onSelectExperiment={(id) => {
+            setSelectedExp(id);
+            setActiveTab('realtime');
+          }} />
+        )}
+        {activeTab === 'budget' && selectedExp && (
+          <BudgetTab experimentId={selectedExp} />
+        )}
+        {activeTab === 'budget' && !selectedExp && (
+          <div className="cost-empty">
+            Select an experiment to see its budget projection.
+          </div>
+        )}
+        {activeTab === 'pricing' && <PricingTab />}
       </div>
     </div>
   );

--- a/dashboard/src/components/CostTimeSeries.css
+++ b/dashboard/src/components/CostTimeSeries.css
@@ -1,0 +1,25 @@
+.cost-timeseries {
+  font-family: var(--font-mono, ui-monospace, 'SF Mono', monospace);
+}
+
+.cost-timeseries .grid {
+  stroke: var(--border-color, #e2e8f0);
+  stroke-dasharray: 2 4;
+}
+
+.cost-timeseries .axis-label {
+  font-size: 11px;
+  fill: var(--text-muted, #64748b);
+}
+
+.cost-timeseries .bar-group:hover rect {
+  opacity: 1;
+}
+
+.cost-timeseries-empty {
+  padding: 32px;
+  color: var(--text-muted, #64748b);
+  font-size: 13px;
+  font-style: italic;
+  text-align: center;
+}

--- a/dashboard/src/components/CostTimeSeries.tsx
+++ b/dashboard/src/components/CostTimeSeries.tsx
@@ -1,0 +1,165 @@
+/**
+ * Per-experiment cost time series.
+ *
+ * Renders one bar per experiment along an absolute time axis (started_at).
+ * Bars are colored by project so multi-project history is legible at a
+ * glance. Used by the Historical tab.
+ */
+
+import { useMemo } from 'react';
+import * as d3 from 'd3';
+import type { ExperimentRow } from '../services/costService';
+import './CostTimeSeries.css';
+
+interface Props {
+  experiments: ExperimentRow[];
+  width?: number;
+  height?: number;
+  onSelect?: (experimentId: string) => void;
+}
+
+const MARGIN = { top: 16, right: 16, bottom: 40, left: 56 };
+
+function formatUsd(v: number): string {
+  if (v >= 1) return `$${v.toFixed(2)}`;
+  return `$${v.toFixed(4)}`;
+}
+
+const CostTimeSeries = ({
+  experiments,
+  width = 800,
+  height = 260,
+  onSelect,
+}: Props) => {
+  const innerW = width - MARGIN.left - MARGIN.right;
+  const innerH = height - MARGIN.top - MARGIN.bottom;
+
+  const parsed = useMemo(
+    () =>
+      experiments
+        .map((e) => ({
+          ...e,
+          ts: new Date(e.started_at).getTime(),
+        }))
+        .sort((a, b) => a.ts - b.ts),
+    [experiments],
+  );
+
+  const xScale = useMemo(() => {
+    const min = d3.min(parsed, (d) => d.ts) ?? Date.now();
+    const max = d3.max(parsed, (d) => d.ts) ?? Date.now();
+    return d3.scaleTime().domain([new Date(min), new Date(max)]).range([0, innerW]);
+  }, [parsed, innerW]);
+
+  const yScale = useMemo(() => {
+    const max = d3.max(parsed, (d) => d.total_cost_usd) ?? 0.01;
+    return d3.scaleLinear().domain([0, max * 1.1]).range([innerH, 0]);
+  }, [parsed, innerH]);
+
+  const projectColor = useMemo(() => {
+    const projects = Array.from(new Set(parsed.map((d) => d.project_id)));
+    const palette = d3.schemeTableau10;
+    const map = new Map<string, string>();
+    projects.forEach((p, i) => map.set(p, palette[i % palette.length]));
+    return map;
+  }, [parsed]);
+
+  if (parsed.length === 0) {
+    return (
+      <div className="cost-timeseries-empty">
+        No experiments to chart yet.
+      </div>
+    );
+  }
+
+  const yTicks = yScale.ticks(5);
+  const xTicks = xScale.ticks(Math.min(parsed.length, 8));
+
+  return (
+    <svg
+      className="cost-timeseries"
+      width="100%"
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      aria-label="Cost over time, by experiment"
+    >
+      <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+        {/* Horizontal grid */}
+        {yTicks.map((t) => (
+          <line
+            key={`yg-${t}`}
+            x1={0}
+            x2={innerW}
+            y1={yScale(t)}
+            y2={yScale(t)}
+            className="grid"
+          />
+        ))}
+
+        {/* Bars */}
+        {parsed.map((d) => {
+          const x = xScale(d.ts);
+          const y = yScale(d.total_cost_usd);
+          const barW = Math.max(6, innerW / Math.max(parsed.length, 8) * 0.6);
+          const barH = innerH - y;
+          return (
+            <g
+              key={d.experiment_id}
+              transform={`translate(${x - barW / 2},${y})`}
+              onClick={() => onSelect?.(d.experiment_id)}
+              style={{ cursor: onSelect ? 'pointer' : 'default' }}
+              className="bar-group"
+            >
+              <rect
+                width={barW}
+                height={barH}
+                fill={projectColor.get(d.project_id) ?? '#64748b'}
+                opacity={0.85}
+                rx={2}
+              >
+                <title>
+                  {d.project_name ?? d.experiment_id}
+                  {'\n'}
+                  {new Date(d.ts).toLocaleString()}
+                  {'\n'}
+                  {formatUsd(d.total_cost_usd)} — {d.total_tokens.toLocaleString()} tok
+                </title>
+              </rect>
+            </g>
+          );
+        })}
+
+        {/* Y-axis labels */}
+        {yTicks.map((t) => (
+          <text
+            key={`yl-${t}`}
+            x={-8}
+            y={yScale(t)}
+            dominantBaseline="middle"
+            textAnchor="end"
+            className="axis-label"
+          >
+            {formatUsd(t)}
+          </text>
+        ))}
+
+        {/* X-axis labels */}
+        {xTicks.map((t) => (
+          <text
+            key={`xl-${t.getTime()}`}
+            x={xScale(t)}
+            y={innerH + 16}
+            textAnchor="middle"
+            className="axis-label"
+          >
+            {d3.timeFormat('%b %d')(t)}
+          </text>
+        ))}
+      </g>
+    </svg>
+  );
+};
+
+export default CostTimeSeries;

--- a/dashboard/src/components/HistoricalTab.css
+++ b/dashboard/src/components/HistoricalTab.css
@@ -1,0 +1,53 @@
+.cost-historical {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 24px;
+}
+
+.historical-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 8px;
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.cost-table th,
+.cost-table td {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+}
+
+.cost-table th {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #64748b);
+  font-weight: 600;
+}
+
+.cost-table td.cost-cell {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  text-align: right;
+}
+
+.cost-table tr:hover td {
+  background: var(--bg-canvas, #f8fafc);
+}
+
+.cost-historical .empty {
+  padding: 16px;
+  color: var(--text-muted, #64748b);
+  font-style: italic;
+}

--- a/dashboard/src/components/HistoricalTab.tsx
+++ b/dashboard/src/components/HistoricalTab.tsx
@@ -1,0 +1,143 @@
+/**
+ * Tab 2 — Historical view.
+ *
+ * Aggregates every experiment in the cost store and renders:
+ * 1. Headline totals (lifetime cost, total tokens, experiment count).
+ * 2. A time-series bar chart of cost per experiment.
+ * 3. Per-project rollup table.
+ *
+ * No new backend endpoint needed — derives everything from
+ * ``/api/cost/experiments`` (no project filter, capped at 1000).
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { fetchExperiments, type ExperimentRow } from '../services/costService';
+import CostTimeSeries from './CostTimeSeries';
+import './HistoricalTab.css';
+
+interface Props {
+  onSelectExperiment?: (id: string) => void;
+}
+
+function formatUsd(v: number, decimals = 2): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function formatTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}
+
+const HistoricalTab = ({ onSelectExperiment }: Props) => {
+  const [experiments, setExperiments] = useState<ExperimentRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchExperiments(undefined, 1000)
+      .then(({ experiments: exps }) => {
+        if (!cancelled) {
+          setExperiments(exps);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Totals + per-project rollup, computed in-memory.
+  const { totalCost, totalTokens, byProject } = useMemo(() => {
+    let totalCost = 0;
+    let totalTokens = 0;
+    const byProject = new Map<
+      string,
+      { project_name: string | null; cost: number; tokens: number; count: number }
+    >();
+    for (const e of experiments) {
+      totalCost += e.total_cost_usd;
+      totalTokens += e.total_tokens;
+      const cur = byProject.get(e.project_id) ?? {
+        project_name: e.project_name,
+        cost: 0,
+        tokens: 0,
+        count: 0,
+      };
+      cur.cost += e.total_cost_usd;
+      cur.tokens += e.total_tokens;
+      cur.count += 1;
+      byProject.set(e.project_id, cur);
+    }
+    const rows = Array.from(byProject.entries())
+      .map(([project_id, v]) => ({ project_id, ...v }))
+      .sort((a, b) => b.cost - a.cost);
+    return { totalCost, totalTokens, byProject: rows };
+  }, [experiments]);
+
+  if (error) {
+    return <div className="cost-error">⚠ {error}</div>;
+  }
+
+  return (
+    <div className="cost-historical">
+      <header className="historical-stats">
+        <div className="cost-stat cost-stat-primary">
+          <span className="cost-stat-label">Lifetime cost</span>
+          <span className="cost-stat-value">{formatUsd(totalCost)}</span>
+        </div>
+        <div className="cost-stat">
+          <span className="cost-stat-label">Total tokens</span>
+          <span className="cost-stat-value">{formatTokens(totalTokens)}</span>
+        </div>
+        <div className="cost-stat">
+          <span className="cost-stat-label">Experiments</span>
+          <span className="cost-stat-value">{experiments.length}</span>
+        </div>
+      </header>
+
+      <section className="cost-panel">
+        <h3>Cost per experiment</h3>
+        <CostTimeSeries
+          experiments={experiments}
+          onSelect={onSelectExperiment}
+        />
+      </section>
+
+      <section className="cost-panel">
+        <h3>By project</h3>
+        {byProject.length === 0 ? (
+          <p className="empty">No experiments yet.</p>
+        ) : (
+          <table className="cost-table">
+            <thead>
+              <tr>
+                <th>Project</th>
+                <th>Runs</th>
+                <th>Tokens</th>
+                <th>Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {byProject.map((p) => (
+                <tr key={p.project_id}>
+                  <td>{p.project_name ?? p.project_id}</td>
+                  <td>{p.count}</td>
+                  <td>{formatTokens(p.tokens)}</td>
+                  <td className="cost-cell">{formatUsd(p.cost)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default HistoricalTab;

--- a/dashboard/src/components/PricingTab.css
+++ b/dashboard/src/components/PricingTab.css
@@ -1,0 +1,141 @@
+.cost-pricing {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 24px;
+}
+
+.cost-pricing .empty {
+  padding: 16px;
+  color: var(--text-muted, #64748b);
+  font-style: italic;
+}
+
+.cost-pricing .hint {
+  font-size: 13px;
+  color: var(--text-muted, #64748b);
+  margin: 0 0 12px;
+}
+
+.cost-pricing .cost-error.inline {
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  background: rgba(220, 38, 38, 0.08);
+  border: 1px solid rgba(220, 38, 38, 0.3);
+  border-radius: 6px;
+  color: #b91c1c;
+  font-size: 13px;
+}
+
+.cost-pricing .model-cell {
+  font-family: var(--font-mono, ui-monospace, 'SF Mono', monospace);
+  font-size: 12px;
+}
+
+.cost-pricing .price-cell {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.source-tag {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 500;
+}
+
+.source-default {
+  background: rgba(100, 116, 139, 0.15);
+  color: #475569;
+}
+
+.source-cato_user {
+  background: rgba(14, 165, 233, 0.15);
+  color: #0369a1;
+}
+
+.source-contract {
+  background: rgba(124, 58, 237, 0.15);
+  color: #6d28d9;
+}
+
+/* Form */
+
+.price-form {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.price-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.price-form label > span {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #64748b);
+}
+
+.price-form input,
+.price-form select {
+  padding: 6px 8px;
+  font-size: 13px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 4px;
+  background: var(--bg-elevated, #ffffff);
+  font-family: inherit;
+}
+
+.price-form input:focus,
+.price-form select:focus {
+  outline: 2px solid rgba(14, 165, 233, 0.4);
+  outline-offset: 0;
+  border-color: #0ea5e9;
+}
+
+.form-footer {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-color, #e2e8f0);
+  margin-top: 8px;
+}
+
+.form-footer button {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  background: #0ea5e9;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.form-footer button:hover:not(:disabled) {
+  background: #0284c7;
+}
+
+.form-footer button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.form-msg {
+  font-size: 13px;
+}
+
+.form-error {
+  color: #b91c1c;
+}
+
+.form-success {
+  color: #15803d;
+}

--- a/dashboard/src/components/PricingTab.tsx
+++ b/dashboard/src/components/PricingTab.tsx
@@ -1,0 +1,280 @@
+/**
+ * Tab 4 — Pricing.
+ *
+ * Two panels:
+ * 1. Current-prices table (the latest ``effective_from`` row per
+ *    model+provider). Powers the cost calculations everywhere else.
+ * 2. "Add new rate" form that POSTs to ``/api/cost/prices``. Marcus's
+ *    versioning means inserting a new ``effective_from`` overrides the
+ *    seed price for future events without rewriting history.
+ *
+ * Per #409's pricing model, prices are versioned by ``effective_from``
+ * and the latest row wins. Edits are append-only.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  createPrice,
+  fetchCurrentPrices,
+  type ModelPriceRow,
+  type PriceCreatePayload,
+} from '../services/costService';
+import './PricingTab.css';
+
+function formatPrice(v: number | null): string {
+  if (v == null) return '—';
+  if (v >= 1) return `$${v.toFixed(2)}`;
+  return `$${v.toFixed(4)}`;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+const EMPTY_FORM: PriceCreatePayload = {
+  model: '',
+  provider: 'anthropic',
+  input_per_million: 0,
+  output_per_million: 0,
+  cache_creation_per_million: null,
+  cache_read_per_million: null,
+  source: 'cato_user',
+};
+
+const PricingTab = () => {
+  const [prices, setPrices] = useState<ModelPriceRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState<PriceCreatePayload>(EMPTY_FORM);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formSuccess, setFormSuccess] = useState<string | null>(null);
+
+  const load = async () => {
+    try {
+      const { prices } = await fetchCurrentPrices();
+      setPrices(prices);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+    setFormSuccess(null);
+
+    if (!form.model.trim() || !form.provider.trim()) {
+      setFormError('Model and provider are required.');
+      return;
+    }
+    if (form.input_per_million < 0 || form.output_per_million < 0) {
+      setFormError('Prices must be non-negative.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await createPrice(form);
+      setFormSuccess(
+        `Inserted ${form.model} (${form.provider}) effective ` +
+          `${formatDate(result.effective_from)}`,
+      );
+      setForm(EMPTY_FORM);
+      await load();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="cost-pricing">
+      <section className="cost-panel">
+        <h3>Current prices</h3>
+        {error && <div className="cost-error inline">⚠ {error}</div>}
+        {prices.length === 0 ? (
+          <p className="empty">No prices loaded yet — Marcus's seed should populate on first server start.</p>
+        ) : (
+          <table className="cost-table">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>Provider</th>
+                <th>Effective from</th>
+                <th>Input / M</th>
+                <th>Cache create / M</th>
+                <th>Cache read / M</th>
+                <th>Output / M</th>
+                <th>Source</th>
+              </tr>
+            </thead>
+            <tbody>
+              {prices.map((p) => (
+                <tr key={`${p.model}-${p.provider}-${p.effective_from}`}>
+                  <td className="model-cell">{p.model}</td>
+                  <td>{p.provider}</td>
+                  <td>{formatDate(p.effective_from)}</td>
+                  <td className="price-cell">{formatPrice(p.input_per_million)}</td>
+                  <td className="price-cell">
+                    {formatPrice(p.cache_creation_per_million)}
+                  </td>
+                  <td className="price-cell">
+                    {formatPrice(p.cache_read_per_million)}
+                  </td>
+                  <td className="price-cell">{formatPrice(p.output_per_million)}</td>
+                  <td>
+                    <span className={`source-tag source-${p.source ?? 'default'}`}>
+                      {p.source ?? 'default'}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <section className="cost-panel">
+        <h3>Add new rate</h3>
+        <p className="hint">
+          Inserts a versioned row. Old experiments keep their original cost;
+          new events use this rate going forward.
+        </p>
+
+        <form className="price-form" onSubmit={handleSubmit}>
+          <label>
+            <span>Model</span>
+            <input
+              type="text"
+              required
+              value={form.model}
+              onChange={(e) => setForm({ ...form, model: e.target.value })}
+              placeholder="claude-sonnet-4-6"
+            />
+          </label>
+          <label>
+            <span>Provider</span>
+            <select
+              value={form.provider}
+              onChange={(e) => setForm({ ...form, provider: e.target.value })}
+            >
+              <option value="anthropic">anthropic</option>
+              <option value="openai">openai</option>
+              <option value="cloud">cloud</option>
+              <option value="local">local</option>
+            </select>
+          </label>
+          <label>
+            <span>Input $/M</span>
+            <input
+              type="number"
+              step="0.0001"
+              min="0"
+              required
+              value={form.input_per_million}
+              onChange={(e) =>
+                setForm({ ...form, input_per_million: Number(e.target.value) })
+              }
+            />
+          </label>
+          <label>
+            <span>Output $/M</span>
+            <input
+              type="number"
+              step="0.0001"
+              min="0"
+              required
+              value={form.output_per_million}
+              onChange={(e) =>
+                setForm({ ...form, output_per_million: Number(e.target.value) })
+              }
+            />
+          </label>
+          <label>
+            <span>Cache create $/M</span>
+            <input
+              type="number"
+              step="0.0001"
+              min="0"
+              value={form.cache_creation_per_million ?? ''}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  cache_creation_per_million:
+                    e.target.value === '' ? null : Number(e.target.value),
+                })
+              }
+              placeholder="(none)"
+            />
+          </label>
+          <label>
+            <span>Cache read $/M</span>
+            <input
+              type="number"
+              step="0.0001"
+              min="0"
+              value={form.cache_read_per_million ?? ''}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  cache_read_per_million:
+                    e.target.value === '' ? null : Number(e.target.value),
+                })
+              }
+              placeholder="(none)"
+            />
+          </label>
+          <label>
+            <span>Source</span>
+            <select
+              value={form.source ?? 'cato_user'}
+              onChange={(e) => setForm({ ...form, source: e.target.value })}
+            >
+              <option value="cato_user">cato_user</option>
+              <option value="contract">contract</option>
+            </select>
+          </label>
+          <label>
+            <span>Effective from</span>
+            <input
+              type="datetime-local"
+              value={form.effective_from?.slice(0, 16) ?? ''}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  effective_from: e.target.value
+                    ? new Date(e.target.value).toISOString()
+                    : undefined,
+                })
+              }
+            />
+          </label>
+
+          <div className="form-footer">
+            <button type="submit" disabled={submitting}>
+              {submitting ? 'Adding…' : 'Add rate'}
+            </button>
+            {formError && <span className="form-msg form-error">{formError}</span>}
+            {formSuccess && (
+              <span className="form-msg form-success">{formSuccess}</span>
+            )}
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+};
+
+export default PricingTab;

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -140,3 +140,60 @@ export async function fetchSessionTurns(
 ): Promise<{ session_id: string; turns: TurnPoint[] }> {
   return _get(`/api/cost/sessions/${encodeURIComponent(sessionId)}/turns`);
 }
+
+// ---------------------------------------------------------------------------
+// Pricing
+// ---------------------------------------------------------------------------
+
+export interface ModelPriceRow {
+  model: string;
+  provider: string;
+  effective_from: string;
+  input_per_million: number;
+  output_per_million: number;
+  cache_creation_per_million: number | null;
+  cache_read_per_million: number | null;
+  source: string | null;
+}
+
+export interface PriceCreatePayload {
+  model: string;
+  provider: string;
+  effective_from?: string; // ISO; defaults to "now" server-side
+  input_per_million: number;
+  output_per_million: number;
+  cache_creation_per_million?: number | null;
+  cache_read_per_million?: number | null;
+  source?: string;
+}
+
+/** Current pricing table (latest ``effective_from`` per model+provider). */
+export async function fetchCurrentPrices(): Promise<{ prices: ModelPriceRow[] }> {
+  return _get('/api/cost/prices');
+}
+
+/** Full price history, optionally filtered to one model. */
+export async function fetchPriceHistory(
+  model?: string,
+): Promise<{ prices: ModelPriceRow[] }> {
+  const params = new URLSearchParams();
+  if (model) params.set('model', model);
+  const qs = params.toString();
+  return _get(`/api/cost/prices/history${qs ? `?${qs}` : ''}`);
+}
+
+/** Insert a new versioned price row. Throws on 409 (duplicate effective_from). */
+export async function createPrice(
+  payload: PriceCreatePayload,
+): Promise<{ status: string; effective_from: string }> {
+  const resp = await fetch(`${API_BASE_URL}/api/cost/prices`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!resp.ok) {
+    const detail = await resp.text();
+    throw new Error(`HTTP ${resp.status}: ${detail}`);
+  }
+  return resp.json();
+}


### PR DESCRIPTION
## Summary

Final piece of the cost dashboard. PR #30 shipped Tab 1 (Real-time); this PR fills in the remaining three sub-tabs — **Historical**, **Budget**, **Pricing** — and enables the previously-disabled buttons in the tab strip. No new backend endpoints needed; everything derives from \`/api/cost/experiments\`, \`/api/cost/experiments/{id}\`, \`/api/cost/prices\`, and the POST endpoint already landed in PR #28.

## What ships

### Tab 2 — Historical
- New \`CostTimeSeries\` D3 chart: one bar per experiment along an absolute time axis, colored by project so multi-project history is legible at a glance. Click a bar to jump to that experiment's Real-time view.
- Lifetime totals (cost / tokens / experiment count).
- Per-project rollup table sorted by spend descending.

### Tab 3 — Budget
- Reads \`experiment.budget_usd\` (set at experiment creation in Marcus).
- Four cards: current spend, budget cap, remaining headroom, projected total (linear extrapolation from \`completed_tasks / total_tasks\`).
- Threshold banner at 80% (warning, amber) and 100% (over budget, red).
- Progress bar with matching color transitions.
- 10-second poll so a running experiment crosses thresholds without a manual refresh.
- Graceful fallback hint when no budget is declared on the experiment.

### Tab 4 — Pricing
- Current-prices table showing the latest \`effective_from\` row per (model, provider). Source tags color-coded: \`default\` (gray), \`cato_user\` (sky), \`contract\` (violet).
- Insert form posts to \`/api/cost/prices\`. All 7 fields including optional cache prices and an \`effective_from\` datetime picker.
- Client-side validation (model + provider required, non-negative prices). Server-side 409 conflicts surface as inline form errors.

### Service layer
- \`fetchCurrentPrices\`, \`fetchPriceHistory\`, \`createPrice\` in \`costService.ts\`.

### Wiring
- All three previously-disabled buttons in \`CostDashboard\` are now active.
- Render branches for each tab. \`Historical\`'s \`onSelectExperiment\` callback hops to Real-time for the chosen experiment.

## Test plan

- [x] \`tsc --noEmit\` clean across all new files
- [ ] Manual: \`npm run dev\` in dashboard/, click each of the four sub-tabs, verify data renders correctly
- [ ] Manual: Pricing form — submit a new rate, verify it shows up in the table immediately
- [ ] Manual: Pricing form — submit a duplicate \`(model, provider, effective_from)\`, verify 409 surfaces as inline error
- [ ] Manual: Historical — click a bar, verify it switches to Real-time with that experiment selected

## What this closes

Marcus issue #409 is now fully implemented end-to-end:
- Marcus side: SQLite cost foundation (#497), worker JSONL ingester (#498), MCP tool (#499)
- Cato side: REST endpoints (PR #28), Real-time tab (PR #30), and this PR for the remaining three tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)