### PR TITLE
feat(cost): project as primary axis in dashboard + API (Marcus #409)

### DIFF
--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -156,6 +156,43 @@ class PriceCreateRequest(BaseModel):
 router = APIRouter(prefix="/api/cost", tags=["cost"])
 
 
+@router.get("/projects")  # type: ignore[misc]
+def list_projects(
+    limit: int = Query(100, ge=1, le=1000),
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """List every project that has cost activity, sorted by spend desc.
+
+    Project is Marcus's primary identity (GH-388 + spawn_agents.py), so
+    this is the dashboard's main entry point. Each row carries event
+    count, experiment count, agent count, tokens, cost, and first/last
+    activity timestamps. Excludes the ``'unassigned'`` bucket — surfaced
+    separately via ``/api/cost/projects/unassigned``.
+
+    Parameters
+    ----------
+    limit : int
+        Cap at 1000. Default 100.
+    """
+    rows = aggregator.list_projects(limit=limit)
+    return {"projects": rows, "count": len(rows)}
+
+
+@router.get("/projects/unassigned")  # type: ignore[misc]
+def unassigned_totals(
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """Cost of LLM calls Marcus made without an active PlannerContext.
+
+    Surfaces the "no project resolved" bucket as a first-class panel so
+    the gap is observable rather than silent. A high number here means
+    a code path is making LLM calls outside the MCP request lifecycle
+    (or a project-creation tool ran without a target project_id).
+    """
+    totals: Dict[str, Any] = aggregator.unassigned_totals()
+    return totals
+
+
 @router.get("/experiments")  # type: ignore[misc]
 def list_experiments(
     project_id: Optional[str] = Query(None),

--- a/dashboard/src/components/CostDashboard.css
+++ b/dashboard/src/components/CostDashboard.css
@@ -105,3 +105,44 @@
   color: var(--text-muted, #64748b);
   font-size: 14px;
 }
+
+/* Phase-9 project-axis additions */
+
+.cost-pickers {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.cost-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.cost-picker label {
+  color: var(--text-muted, #64748b);
+}
+
+.cost-picker select {
+  padding: 6px 10px;
+  font-size: 13px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 6px;
+  background: var(--bg-elevated, #ffffff);
+  min-width: 220px;
+  font-variant-numeric: tabular-nums;
+}
+
+.cost-unassigned-banner {
+  margin-left: auto;
+  padding: 6px 10px;
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.4);
+  color: #b45309;
+  border-radius: 6px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  cursor: help;
+}

--- a/dashboard/src/components/CostDashboard.css
+++ b/dashboard/src/components/CostDashboard.css
@@ -110,7 +110,8 @@
 
 .cost-pickers {
   display: flex;
-  gap: 16px;
+  flex-wrap: wrap;
+  gap: 12px 16px;
   align-items: center;
 }
 
@@ -136,6 +137,9 @@
 }
 
 .cost-unassigned-banner {
+  /* Take a full row on narrow viewports so the banner can't be pushed
+     off-screen by a long picker chain. (Kaia PR #33 review.) */
+  flex-basis: 100%;
   margin-left: auto;
   padding: 6px 10px;
   background: rgba(245, 158, 11, 0.12);

--- a/dashboard/src/components/CostDashboard.tsx
+++ b/dashboard/src/components/CostDashboard.tsx
@@ -1,13 +1,29 @@
 /**
  * Top-level cost dashboard page (Marcus issue #409).
  *
- * Four sub-tabs: Real-time (current experiment), Historical (all
- * experiments), Budget (per-experiment projection vs. cap), and
- * Pricing (current rate table + CRUD form).
+ * Project is the primary axis (per Marcus CLAUDE.md GH-388 and
+ * spawn_agents.py) — experiment is a secondary tracking handle that
+ * may or may not be set depending on whether the run opted into
+ * MLflow tracking. The picker leads with project; once a project is
+ * selected, the user can optionally drill into a specific experiment
+ * (MLflow run) within it.
+ *
+ * Sub-tabs:
+ *   - Real-time  → live view of the active MLflow run (when one exists)
+ *   - Historical → cross-project totals + per-experiment time series
+ *   - Budget     → projection vs. cap for the active run
+ *   - Pricing    → current rate table + insert form
  */
 
 import { useEffect, useState } from 'react';
-import { fetchExperiments, type ExperimentRow } from '../services/costService';
+import {
+  fetchProjectSummary,
+  fetchProjects,
+  fetchUnassignedTotals,
+  type ProjectRow,
+  type ProjectSummary,
+  type UnassignedTotals,
+} from '../services/costService';
 import BudgetTab from './BudgetTab';
 import HistoricalTab from './HistoricalTab';
 import PricingTab from './PricingTab';
@@ -16,25 +32,42 @@ import './CostDashboard.css';
 
 type CostTab = 'realtime' | 'historical' | 'budget' | 'pricing';
 
+function formatUsd(v: number, decimals = 2): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function formatTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}
+
 const CostDashboard = () => {
   const [activeTab, setActiveTab] = useState<CostTab>('realtime');
-  const [experiments, setExperiments] = useState<ExperimentRow[]>([]);
+  const [projects, setProjects] = useState<ProjectRow[]>([]);
+  const [unassigned, setUnassigned] = useState<UnassignedTotals | null>(null);
+  const [selectedProject, setSelectedProject] = useState<string | null>(null);
+  const [projectSummary, setProjectSummary] = useState<ProjectSummary | null>(null);
   const [selectedExp, setSelectedExp] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Fetch experiment list on mount and refresh every 30s so a new run
-  // appears in the picker without the user reloading the page.
+  // Poll project list + unassigned totals every 30s so new runs appear
+  // without a page reload and the unassigned indicator stays current.
   useEffect(() => {
     let cancelled = false;
 
     const load = async () => {
       try {
-        const { experiments: exps } = await fetchExperiments();
+        const [{ projects: ps }, una] = await Promise.all([
+          fetchProjects(),
+          fetchUnassignedTotals(),
+        ]);
         if (cancelled) return;
-        setExperiments(exps);
+        setProjects(ps);
+        setUnassigned(una);
         setError(null);
-        if (selectedExp === null && exps.length > 0) {
-          setSelectedExp(exps[0].experiment_id);
+        if (selectedProject === null && ps.length > 0) {
+          setSelectedProject(ps[0].project_id);
         }
       } catch (err) {
         if (!cancelled) {
@@ -43,15 +76,45 @@ const CostDashboard = () => {
       }
     };
 
-    load();
+    void load();
     const id = window.setInterval(load, 30_000);
     return () => {
       cancelled = true;
       window.clearInterval(id);
     };
-  }, [selectedExp]);
+  }, [selectedProject]);
 
-  if (error && experiments.length === 0) {
+  // When the selected project changes, fetch its summary (totals +
+  // experiment list) and auto-select the most recent experiment for
+  // the Real-time tab.
+  useEffect(() => {
+    if (!selectedProject) {
+      setProjectSummary(null);
+      setSelectedExp(null);
+      return;
+    }
+    let cancelled = false;
+    fetchProjectSummary(selectedProject)
+      .then((s) => {
+        if (cancelled) return;
+        setProjectSummary(s);
+        if (s.experiments.length > 0) {
+          setSelectedExp(s.experiments[0].experiment_id);
+        } else {
+          setSelectedExp(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedProject]);
+
+  if (error && projects.length === 0) {
     return (
       <div className="cost-dashboard cost-dashboard-error">
         <h2>Cost dashboard unavailable</h2>
@@ -68,22 +131,55 @@ const CostDashboard = () => {
     <div className="cost-dashboard">
       <div className="cost-dashboard-header">
         <h2>Cost</h2>
-        <div className="cost-experiment-picker">
-          <label htmlFor="cost-exp-select">Experiment:</label>
-          <select
-            id="cost-exp-select"
-            value={selectedExp ?? ''}
-            onChange={(e) => setSelectedExp(e.target.value || null)}
-          >
-            {experiments.length === 0 && <option value="">— none yet —</option>}
-            {experiments.map((exp) => (
-              <option key={exp.experiment_id} value={exp.experiment_id}>
-                {exp.project_name ?? exp.experiment_id} — $
-                {exp.total_cost_usd.toFixed(2)}
-              </option>
-            ))}
-          </select>
+
+        <div className="cost-pickers">
+          <div className="cost-picker">
+            <label htmlFor="cost-project-select">Project:</label>
+            <select
+              id="cost-project-select"
+              value={selectedProject ?? ''}
+              onChange={(e) => setSelectedProject(e.target.value || null)}
+            >
+              {projects.length === 0 && (
+                <option value="">— none yet —</option>
+              )}
+              {projects.map((p) => (
+                <option key={p.project_id} value={p.project_id}>
+                  {p.project_id.slice(0, 12)} — {formatUsd(p.total_cost_usd)}
+                  {' '}({p.experiments} {p.experiments === 1 ? 'run' : 'runs'})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {projectSummary && projectSummary.experiments.length > 0 && (
+            <div className="cost-picker">
+              <label htmlFor="cost-exp-select">Run:</label>
+              <select
+                id="cost-exp-select"
+                value={selectedExp ?? ''}
+                onChange={(e) => setSelectedExp(e.target.value || null)}
+              >
+                {projectSummary.experiments.map((exp) => (
+                  <option key={exp.experiment_id} value={exp.experiment_id}>
+                    {exp.experiment_id.slice(0, 16)} — {formatUsd(exp.total_cost_usd)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
+
+        {unassigned && unassigned.events > 0 && (
+          <div
+            className="cost-unassigned-banner"
+            title="LLM calls Marcus made without an active project context. Usually a code path running outside the MCP request lifecycle, or a project-creation tool. Investigate the gap."
+          >
+            ⚠ Unassigned: {unassigned.events} events,{' '}
+            {formatTokens(unassigned.total_tokens)} tokens,{' '}
+            {formatUsd(unassigned.total_cost_usd, 4)}
+          </div>
+        )}
       </div>
 
       <div className="cost-tab-strip">
@@ -117,23 +213,32 @@ const CostDashboard = () => {
         {activeTab === 'realtime' && selectedExp && (
           <RealTimeTab experimentId={selectedExp} />
         )}
-        {activeTab === 'realtime' && !selectedExp && (
+        {activeTab === 'realtime' && !selectedExp && selectedProject && (
           <div className="cost-empty">
-            No experiments yet. Run one with the marcus skill and they'll appear here.
+            This project has events but no MLflow run was registered.
+            See the project totals on the Historical tab.
+          </div>
+        )}
+        {activeTab === 'realtime' && !selectedProject && (
+          <div className="cost-empty">
+            No projects yet. Run one with the marcus skill and it'll appear here.
           </div>
         )}
         {activeTab === 'historical' && (
-          <HistoricalTab onSelectExperiment={(id) => {
-            setSelectedExp(id);
-            setActiveTab('realtime');
-          }} />
+          <HistoricalTab
+            onSelectExperiment={(id) => {
+              setSelectedExp(id);
+              setActiveTab('realtime');
+            }}
+          />
         )}
         {activeTab === 'budget' && selectedExp && (
           <BudgetTab experimentId={selectedExp} />
         )}
         {activeTab === 'budget' && !selectedExp && (
           <div className="cost-empty">
-            Select an experiment to see its budget projection.
+            Select a project (and an MLflow run inside it) to see budget
+            projection.
           </div>
         )}
         {activeTab === 'pricing' && <PricingTab />}

--- a/dashboard/src/components/CostDashboard.tsx
+++ b/dashboard/src/components/CostDashboard.tsx
@@ -53,26 +53,43 @@ const CostDashboard = () => {
 
   // Poll project list + unassigned totals every 30s so new runs appear
   // without a page reload and the unassigned indicator stays current.
+  //
+  // Kaia PR #33 review:
+  // - Effect no longer depends on selectedProject (the previous version
+  //   re-subscribed on every selection change for no useful reason; the
+  //   auto-select happens via the functional setState below).
+  // - fetchUnassignedTotals is wrapped in a defensive catch so a 503
+  //   from that endpoint doesn't blank the project picker. Worst case:
+  //   the unassigned banner doesn't appear even though there's a gap.
   useEffect(() => {
     let cancelled = false;
 
     const load = async () => {
       try {
-        const [{ projects: ps }, una] = await Promise.all([
-          fetchProjects(),
-          fetchUnassignedTotals(),
-        ]);
+        const { projects: ps } = await fetchProjects();
         if (cancelled) return;
         setProjects(ps);
-        setUnassigned(una);
         setError(null);
-        if (selectedProject === null && ps.length > 0) {
-          setSelectedProject(ps[0].project_id);
-        }
+        // Auto-select the most expensive project the first time we see
+        // any. Functional setState avoids depending on selectedProject
+        // in the effect's deps array.
+        setSelectedProject((current) =>
+          current === null && ps.length > 0 ? ps[0].project_id : current,
+        );
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : String(err));
         }
+        return;
+      }
+
+      // Fetch unassigned totals independently; failure here is not
+      // fatal — we just skip the banner this tick.
+      try {
+        const una = await fetchUnassignedTotals();
+        if (!cancelled) setUnassigned(una);
+      } catch {
+        // intentionally swallowed
       }
     };
 
@@ -82,7 +99,7 @@ const CostDashboard = () => {
       cancelled = true;
       window.clearInterval(id);
     };
-  }, [selectedProject]);
+  }, []);
 
   // When the selected project changes, fetch its summary (totals +
   // experiment list) and auto-select the most recent experiment for
@@ -145,7 +162,15 @@ const CostDashboard = () => {
               )}
               {projects.map((p) => (
                 <option key={p.project_id} value={p.project_id}>
-                  {p.project_id.slice(0, 12)} — {formatUsd(p.total_cost_usd)}
+                  {/*
+                    Prefer the human-readable project_name from the
+                    experiments table; fall back to a truncated id only
+                    when no MLflow run ever registered one. (Kaia review
+                    of #33: 12-char IDs of 19-digit numbers were
+                    indistinguishable in the picker.)
+                  */}
+                  {p.project_name ?? `${p.project_id.slice(0, 12)}…`}
+                  {' '}— {formatUsd(p.total_cost_usd)}
                   {' '}({p.experiments} {p.experiments === 1 ? 'run' : 'runs'})
                 </option>
               ))}
@@ -154,7 +179,16 @@ const CostDashboard = () => {
 
           {projectSummary && projectSummary.experiments.length > 0 && (
             <div className="cost-picker">
-              <label htmlFor="cost-exp-select">Run:</label>
+              <label
+                htmlFor="cost-exp-select"
+                title={
+                  'MLflow run within the selected project. Most recent ' +
+                  "first. Empty when the project's runs never called " +
+                  'start_experiment — see Historical for project totals.'
+                }
+              >
+                Run:
+              </label>
               <select
                 id="cost-exp-select"
                 value={selectedExp ?? ''}

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -142,6 +142,57 @@ export async function fetchSessionTurns(
 }
 
 // ---------------------------------------------------------------------------
+// Projects (primary axis — Marcus #409)
+// ---------------------------------------------------------------------------
+
+export interface ProjectRow {
+  project_id: string;
+  events: number;
+  experiments: number;
+  agents: number;
+  total_tokens: number;
+  total_cost_usd: number;
+  first_event_at: string;
+  last_event_at: string;
+}
+
+export interface UnassignedTotals {
+  events: number;
+  total_tokens: number;
+  total_cost_usd: number;
+}
+
+export interface ProjectSummary {
+  project_id: string;
+  totals: {
+    experiments: number;
+    events: number;
+    total_tokens: number;
+    total_cost_usd: number;
+  };
+  experiments: ExperimentRow[];
+}
+
+/** List projects with cost rollups (primary picker for the dashboard). */
+export async function fetchProjects(
+  limit = 100,
+): Promise<{ projects: ProjectRow[]; count: number }> {
+  return _get(`/api/cost/projects?limit=${limit}`);
+}
+
+/** Totals for events without an active PlannerContext. */
+export async function fetchUnassignedTotals(): Promise<UnassignedTotals> {
+  return _get('/api/cost/projects/unassigned');
+}
+
+/** Project rollup + per-experiment list. */
+export async function fetchProjectSummary(
+  projectId: string,
+): Promise<ProjectSummary> {
+  return _get(`/api/cost/projects/${encodeURIComponent(projectId)}`);
+}
+
+// ---------------------------------------------------------------------------
 // Pricing
 // ---------------------------------------------------------------------------
 

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -147,6 +147,13 @@ export async function fetchSessionTurns(
 
 export interface ProjectRow {
   project_id: string;
+  /**
+   * Human-readable name pulled from the experiments table when an
+   * MLflow run was registered for this project. NULL for projects
+   * whose runs never called start_experiment — the picker falls back
+   * to a truncated project_id in that case.
+   */
+  project_name: string | null;
   events: number;
   experiments: number;
   agents: number;

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -136,6 +136,82 @@ def client(store: Any) -> TestClient:
 
 
 @requires_marcus
+class TestProjectsList:
+    """/api/cost/projects — primary entry point for the dashboard."""
+
+    def test_lists_projects_with_totals(self, client: TestClient) -> None:
+        """One row per distinct project_id, derived from token_events."""
+        resp = client.get("/api/cost/projects")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 1
+        assert body["projects"][0]["project_id"] == "proj_1"
+        assert (
+            body["projects"][0]["total_tokens"]
+            == 1000 + 500 + 2000 + 500 + 100 + 300 + 50
+        )
+
+    def test_excludes_unassigned_from_project_list(
+        self, store: Any, client: TestClient
+    ) -> None:
+        """Events in the 'unassigned' bucket do not appear as a project."""
+        from src.cost_tracking.cost_store import TokenEvent
+
+        store.record_event(
+            TokenEvent(
+                experiment_id="unassigned",
+                project_id="unassigned",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=10,
+                output_tokens=10,
+            )
+        )
+        resp = client.get("/api/cost/projects")
+        ids = {p["project_id"] for p in resp.json()["projects"]}
+        assert "unassigned" not in ids
+
+
+@requires_marcus
+class TestUnassignedTotals:
+    """/api/cost/projects/unassigned — gap visibility."""
+
+    def test_returns_zeros_when_empty(self, client: TestClient) -> None:
+        """No unassigned events → zero totals (200, not 404)."""
+        resp = client.get("/api/cost/projects/unassigned")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["events"] == 0
+        assert body["total_cost_usd"] == 0.0
+
+    def test_sums_unassigned_events(self, store: Any, client: TestClient) -> None:
+        """An event tagged 'unassigned' shows up in the totals."""
+        from src.cost_tracking.cost_store import TokenEvent
+
+        store.record_event(
+            TokenEvent(
+                experiment_id="unassigned",
+                project_id="unassigned",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=1_000_000,
+                output_tokens=0,
+            )
+        )
+        resp = client.get("/api/cost/projects/unassigned")
+        body = resp.json()
+        assert body["events"] == 1
+        # 1M input * $3/M = $3
+        assert body["total_cost_usd"] == pytest.approx(3.0, rel=1e-6)
+
+
+@requires_marcus
 class TestExperimentsList:
     def test_lists_experiments(self, client: TestClient) -> None:
         """Endpoint returns the seeded experiment with totals."""


### PR DESCRIPTION
## Summary

Mirrors Marcus [PR #503](https://github.com/lwgray/marcus/pull/503) on the Cato side. After a Kaia review caught that I had the data model wrong, Marcus's identity is \`project_id\` (CLAUDE.md GH-388 + \`spawn_agents.py\`) — \`experiment_id\` is an MLflow tracking handle, not a join key. This PR swaps the cost dashboard to lead with **project**.

## Backend (\`backend/cost_routes.py\`)

Two new endpoints:

| Method | Path | Purpose |
|---|---|---|
| GET | \`/api/cost/projects\` | List projects with cost rollups, sorted by spend desc. Excludes \`'unassigned'\`. |
| GET | \`/api/cost/projects/unassigned\` | Totals for events without an active \`PlannerContext\` — makes the gap observable. |

Both delegate to the new \`list_projects\` / \`unassigned_totals\` aggregator methods in Marcus.

## Frontend (\`CostDashboard.tsx\`)

- **Project picker** is now the primary control in the header (shows project, total cost, run count).
- **Run picker** appears as a secondary control only when the project has MLflow runs registered. Powers the Real-time and Budget tabs as before.
- **Unassigned banner** with tooltip surfaces the bucket whenever it has events. Points at the likely cause (code path outside MCP lifecycle, or a project-creation tool).
- **Real-time tab** gracefully handles "project with events but no MLflow run" — empty state directs the user to Historical for project totals.
- Other tabs (Historical, Budget, Pricing) unchanged on the surface.

## Service additions

\`fetchProjects\`, \`fetchUnassignedTotals\`, \`fetchProjectSummary\` + matching types in \`costService.ts\`.

## Test plan

- [x] 4 new integration tests (\`TestProjectsList\`, \`TestUnassignedTotals\`)
- [x] All 14 cost-api tests pass
- [x] \`tsc --noEmit\` clean across the new TypeScript
- [x] \`mypy backend/cost_routes.py\` clean
- [ ] Manual: open the dashboard, verify Project picker lists projects sorted by spend, switch between projects and see the Run picker update accordingly, verify Unassigned banner appears if Marcus has made any LLM call outside an MCP request

## Requires

Marcus PR #503 (already merged) — provides the \`list_projects\` and \`unassigned_totals\` aggregator methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)