### PR TITLE
feat(cost): persistent names + global CSS theme tokens (Marcus #515)

### DIFF
--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -131,14 +131,18 @@ def get_aggregator(store: Any = Depends(get_store)) -> Any:
 # the same source Cato's regular projects panel uses
 # (``aggregator._load_projects()`` in cato_src/core/aggregator.py).
 #
-# Cached with a 30s TTL: the file is small but reading it on every
-# dashboard tick is wasteful, and 30s matches the dashboard's poll
-# interval so the cache effectively no-ops repeat requests within a
-# poll.
+# Cache: 5s TTL keyed by the store identity. Was 30s — dropped after
+# Kaia review on PR #36 flagged that rename / fresh-snapshot lag was
+# user-visible at that TTL. 5s keeps poll loops cheap (one dashboard
+# poll = ~1 file read + 1 SQL scan) while making updates near-instant.
+# Keying by ``id(store)`` prevents test cross-talk: tests use
+# ``app.dependency_overrides[get_store]`` with tmp stores, and a
+# module-level cache without store keying would leak the previous
+# store's names into the next test.
 
-_PROJECT_NAMES_CACHE: Dict[str, str] = {}
-_PROJECT_NAMES_CACHE_AT: float = 0.0
-_PROJECT_NAMES_TTL_SEC = 30.0
+_PROJECT_NAMES_CACHES: Dict[int, Dict[str, str]] = {}
+_PROJECT_NAMES_CACHE_AT: Dict[int, float] = {}
+_PROJECT_NAMES_TTL_SEC = 5.0
 
 
 def _load_project_names(store: Optional[Any] = None) -> Dict[str, str]:
@@ -156,16 +160,15 @@ def _load_project_names(store: Optional[Any] = None) -> Dict[str, str]:
        was when work was attributed; the registry may have been
        renamed since).
 
-    Cached for ``_PROJECT_NAMES_TTL_SEC`` to keep poll loops cheap.
+    Cached for ``_PROJECT_NAMES_TTL_SEC`` per store identity.
     """
-    global _PROJECT_NAMES_CACHE, _PROJECT_NAMES_CACHE_AT
+    cache_key = id(store) if store is not None else 0
 
     now = time.monotonic()
-    if (
-        _PROJECT_NAMES_CACHE
-        and (now - _PROJECT_NAMES_CACHE_AT) < _PROJECT_NAMES_TTL_SEC
-    ):
-        return _PROJECT_NAMES_CACHE
+    cached = _PROJECT_NAMES_CACHES.get(cache_key)
+    cached_at = _PROJECT_NAMES_CACHE_AT.get(cache_key, 0.0)
+    if cached and (now - cached_at) < _PROJECT_NAMES_TTL_SEC:
+        return cached
 
     out: Dict[str, str] = {}
 
@@ -200,16 +203,15 @@ def _load_project_names(store: Optional[Any] = None) -> Dict[str, str]:
         except Exception as exc:  # pragma: no cover - sqlite errors logged
             logger.debug("project_names table unreadable: %s", exc)
 
-    _PROJECT_NAMES_CACHE = out
-    _PROJECT_NAMES_CACHE_AT = now
+    _PROJECT_NAMES_CACHES[cache_key] = out
+    _PROJECT_NAMES_CACHE_AT[cache_key] = now
     return out
 
 
 def clear_project_names_cache() -> None:
-    """Drop the project-name cache. Used by tests."""
-    global _PROJECT_NAMES_CACHE, _PROJECT_NAMES_CACHE_AT
-    _PROJECT_NAMES_CACHE = {}
-    _PROJECT_NAMES_CACHE_AT = 0.0
+    """Drop every project-name cache entry. Used by tests."""
+    _PROJECT_NAMES_CACHES.clear()
+    _PROJECT_NAMES_CACHE_AT.clear()
 
 
 def _enrich_project_names(rows: list, store: Optional[Any] = None) -> list:

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -141,14 +141,20 @@ _PROJECT_NAMES_CACHE_AT: float = 0.0
 _PROJECT_NAMES_TTL_SEC = 30.0
 
 
-def _load_project_names() -> Dict[str, str]:
-    """Map ``project_id`` → ``name`` from Marcus's project registry.
+def _load_project_names(store: Optional[Any] = None) -> Dict[str, str]:
+    """Map ``project_id`` → ``name`` for cost-row enrichment.
 
-    Reads ``<marcus_root>/data/marcus_state/projects.json`` (the same
-    file Marcus's :class:`ProjectRegistry` writes). Returns an empty
-    dict on any read failure — the dashboard then falls back to a
-    truncated project_id in the picker, which is the pre-existing
-    behavior.
+    Sources (merged, later wins):
+    1. Marcus's project registry (``data/marcus_state/projects.json``)
+       — names of *currently registered* projects. Same source the
+       regular Cato projects panel uses.
+    2. costs.db ``project_names`` table — snapshotted at every
+       ``PlannerContext`` push by Marcus PR #515. Names persist even
+       after the project is deleted from the registry, so this table
+       is the source of truth for everything else and overrides #1
+       when both have a name (the snapshot reflects the name as it
+       was when work was attributed; the registry may have been
+       renamed since).
 
     Cached for ``_PROJECT_NAMES_TTL_SEC`` to keep poll loops cheap.
     """
@@ -161,39 +167,38 @@ def _load_project_names() -> Dict[str, str]:
     ):
         return _PROJECT_NAMES_CACHE
 
-    if _marcus_root is None:
-        return {}
-
-    projects_file = _marcus_root / "data" / "marcus_state" / "projects.json"
-    if not projects_file.exists():
-        return {}
-
-    try:
-        with projects_file.open("r", encoding="utf-8") as fh:
-            raw = json.load(fh)
-    except (OSError, json.JSONDecodeError) as exc:
-        logger.debug("projects.json unreadable: %s", exc)
-        return {}
-
     out: Dict[str, str] = {}
-    for key, value in raw.items():
-        # projects.json is a dict keyed by project_id with a sentinel
-        # 'active_project' entry. Skip non-dict values and unkeyed rows.
-        if key == "active_project" or not isinstance(value, dict):
-            continue
-        pid = value.get("id")
-        name = value.get("name")
-        if pid and name:
-            # Marcus normalizes project_id to dashless hex at the write
-            # path now (see canonical_project_id in cost_recorder.py), so
-            # all new token_events rows match the second key below. We
-            # index both variants anyway:
-            #   - dashless covers new writes + legacy .hex auto-discovery
-            #   - dashed covers the projects.json key itself (some Cato
-            #     code paths look it up by registry id directly)
-            # Cheap defense-in-depth against drift.
-            out[pid] = name
-            out[pid.replace("-", "")] = name
+
+    # Source 1: projects.json (live registry).
+    if _marcus_root is not None:
+        projects_file = _marcus_root / "data" / "marcus_state" / "projects.json"
+        if projects_file.exists():
+            try:
+                with projects_file.open("r", encoding="utf-8") as fh:
+                    raw = json.load(fh)
+                for key, value in raw.items():
+                    if key == "active_project" or not isinstance(value, dict):
+                        continue
+                    pid = value.get("id")
+                    name = value.get("name")
+                    if pid and name:
+                        # Index both dashed + dashless variants because
+                        # legacy data has both forms (see canonical_project_id).
+                        out[pid] = name
+                        out[pid.replace("-", "")] = name
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.debug("projects.json unreadable: %s", exc)
+
+    # Source 2: costs.db project_names table (snapshot — overrides
+    # registry for projects that were deleted but still have cost data).
+    if store is not None:
+        try:
+            for pid, name in store.conn.execute(
+                "SELECT project_id, name FROM project_names"
+            ):
+                out[pid] = name
+        except Exception as exc:  # pragma: no cover - sqlite errors logged
+            logger.debug("project_names table unreadable: %s", exc)
 
     _PROJECT_NAMES_CACHE = out
     _PROJECT_NAMES_CACHE_AT = now
@@ -207,14 +212,15 @@ def clear_project_names_cache() -> None:
     _PROJECT_NAMES_CACHE_AT = 0.0
 
 
-def _enrich_project_names(rows: list) -> list:
-    """Overlay registry names on cost rows when no MLflow name exists.
+def _enrich_project_names(rows: list, store: Optional[Any] = None) -> list:
+    """Overlay snapshotted/registry names on cost rows.
 
     Mutates each row in-place: if ``project_name`` is None / missing,
-    fill it from the registry. Otherwise leave it (an MLflow run with
-    an explicit project_name wins because it was set by the user).
+    fill it from the merged name sources (project_names table first,
+    then projects.json). MLflow-explicit names from the aggregator
+    still win because we only fill missing rows.
     """
-    names = _load_project_names()
+    names = _load_project_names(store=store)
     for row in rows:
         if not row.get("project_name") and row.get("project_id") in names:
             row["project_name"] = names[row["project_id"]]
@@ -296,6 +302,7 @@ def trigger_ingest(
 def list_projects(
     limit: int = Query(100, ge=1, le=1000),
     aggregator: Any = Depends(get_aggregator),
+    store: Any = Depends(get_store),
 ) -> Dict[str, Any]:
     """List every project that has cost activity, sorted by spend desc.
 
@@ -311,7 +318,7 @@ def list_projects(
         Cap at 1000. Default 100.
     """
     rows = aggregator.list_projects(limit=limit)
-    _enrich_project_names(rows)
+    _enrich_project_names(rows, store=store)
     return {"projects": rows, "count": len(rows)}
 
 
@@ -374,6 +381,7 @@ def experiment_summary(
 def project_summary(
     project_id: str,
     aggregator: Any = Depends(get_aggregator),
+    store: Any = Depends(get_store),
 ) -> Dict[str, Any]:
     """Project rollup + list of experiment summaries.
 
@@ -381,7 +389,7 @@ def project_summary(
     project picker; the project-first dashboard tabs use
     ``/projects/{id}/summary`` for the full per-project breakdown.
     """
-    names = _load_project_names()
+    names = _load_project_names(store=store)
     return {
         "project_id": project_id,
         "project_name": names.get(project_id),
@@ -430,14 +438,15 @@ def put_project_budget(
 def project_full_summary(
     project_id: str,
     aggregator: Any = Depends(get_aggregator),
+    store: Any = Depends(get_store),
 ) -> Dict[str, Any]:
     """Full per-project breakdown — drives Real-time/Historical/Budget tabs.
 
     Same shape as ``/experiments/{id}`` (summary + by_role / by_agent /
     by_task / by_operation / by_model) but scoped to project_id, the
     only universal identity in Marcus's coordination model (#503).
-    Project-name is overlaid from Marcus's project registry (same
-    source the regular projects panel uses).
+    Project-name is overlaid from Marcus's project_names snapshot
+    (PR #515) with fallback to projects.json.
 
     Raises
     ------
@@ -447,7 +456,7 @@ def project_full_summary(
     summary: Optional[Dict[str, Any]] = aggregator.project_summary(project_id)
     if summary is None:
         raise HTTPException(status_code=404, detail="project not found")
-    names = _load_project_names()
+    names = _load_project_names(store=store)
     summary["project_name"] = names.get(project_id)
     return summary
 

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1,3 +1,26 @@
+/* Theme tokens. Cato historically used hardcoded hex everywhere; the
+   cost dashboard CSS introduced ``var()`` references with light-theme
+   fallbacks that always applied because nothing defined the vars,
+   producing low-contrast text on Cato's dark background. Defining the
+   tokens here makes every ``var(--…)`` resolve to the dark palette
+   that matches the rest of the app. */
+:root {
+  --bg-canvas: #0f172a;
+  --bg-elevated: #1e293b;
+  --bg-hover: #334155;
+
+  --text-primary: #f1f5f9;
+  --text-color: #f1f5f9;
+  --text-muted: #cbd5e1;
+
+  --border-color: #475569;
+
+  --primary: #3b82f6;
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+}
+
 * {
   margin: 0;
   padding: 0;

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -396,6 +396,53 @@ class TestProjectNameEnrichment:
         orphan = next(p for p in projects if p["project_id"] == "proj_no_mlflow")
         assert orphan["project_name"] == "registry-named-project"
 
+    def test_project_names_table_overrides_registry(
+        self,
+        store: Any,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Snapshotted name (project_names table) wins over registry.
+
+        After Marcus PR #515 lands, project_names captures the name as
+        of when work was attributed. The dashboard should prefer that
+        snapshot over the registry so renames / deletions don't break
+        the display.
+        """
+        from src.cost_tracking.cost_store import TokenEvent
+
+        from backend import cost_routes
+
+        # Seed an event + a snapshotted name for a project not in the
+        # registry.
+        store.record_event(
+            TokenEvent(
+                experiment_id="exp_snap",
+                project_id="snap_proj",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=10,
+                output_tokens=5,
+                request_id="req_snap",
+            )
+        )
+        store.upsert_project_name("snap_proj", "snapshotted-name")
+
+        fake_root = tmp_path / "marcus"
+        (fake_root / "data" / "marcus_state").mkdir(parents=True)
+        (fake_root / "data" / "marcus_state" / "projects.json").write_text("{}")
+        monkeypatch.setattr(cost_routes, "_marcus_root", fake_root)
+        cost_routes.clear_project_names_cache()
+
+        resp = client.get("/api/cost/projects")
+        assert resp.status_code == 200
+        names = {p["project_id"]: p["project_name"] for p in resp.json()["projects"]}
+        assert names["snap_proj"] == "snapshotted-name"
+
     def test_existing_mlflow_name_takes_precedence(
         self, client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -443,6 +443,39 @@ class TestProjectNameEnrichment:
         names = {p["project_id"]: p["project_name"] for p in resp.json()["projects"]}
         assert names["snap_proj"] == "snapshotted-name"
 
+    def test_cache_is_keyed_by_store_identity(
+        self,
+        store: Any,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Different stores don't share cache entries (Kaia review on #36).
+
+        The module-level cache used to be a single dict; tests using
+        ``app.dependency_overrides[get_store]`` with tmp stores could
+        leak names across tests. Keying by ``id(store)`` isolates them.
+        """
+        from src.cost_tracking.cost_store import CostStore
+
+        from backend import cost_routes
+
+        # First store sees one name.
+        store.upsert_project_name("p1", "from-store-1")
+        cost_routes.clear_project_names_cache()
+        names_a = cost_routes._load_project_names(store=store)
+        assert names_a.get("p1") == "from-store-1"
+
+        # Second store has a different (or no) name for the same id.
+        # Without per-store keying, the cache would return store-1's
+        # entry here.
+        other_store = CostStore(db_path=tmp_path / "other.db")
+        other_store.upsert_project_name("p1", "from-store-2")
+        names_b = cost_routes._load_project_names(store=other_store)
+        assert names_b.get("p1") == "from-store-2"
+        # And the first store's cache still resolves to its own value.
+        names_a_again = cost_routes._load_project_names(store=store)
+        assert names_a_again.get("p1") == "from-store-1"
+
     def test_existing_mlflow_name_takes_precedence(
         self, client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

User feedback after #35 landed: *\"'Unnamed' is unacceptable, every token has to be accounted for. Plus you still didn't fix the text color.\"*

Two fixes:

### 1. Read \`project_names\` snapshot from costs.db

Cato's name overlay used to read only from Marcus's project registry (\`projects.json\`). When a project was deleted from the registry its cost data persisted but its name was lost, so the picker rendered opaque hex IDs.

Now reads from \`costs.db\`'s \`project_names\` table **first** (snapshotted by Marcus PR #515 on every \`PlannerContext\` push) and falls back to \`projects.json\` for projects that haven't been touched yet.

**Result:** every cost row has a real name forever, regardless of whether the project still exists in the registry.

### 2. Global CSS theme tokens

The cost dashboard CSS used \`var(--text-primary, #f1f5f9)\` etc. with light-theme fallbacks. Cato never defined those tokens at \`:root\`, so every \`var()\` always hit its fallback — producing low-contrast text on Cato's dark background.

Defining the tokens once in \`index.css\` makes every existing \`var()\` reference resolve to the dark palette that matches the rest of the app. **No per-file CSS rewrites needed.**

## Depends on
- Marcus PR #515 — adds the \`project_names\` table + \`upsert_project_name\` method

## Test plan
- [x] \`pytest tests/test_cost_api.py\` — 22 pass (1 new asserting snapshot beats registry)
- [x] \`tsc --noEmit\` clean
- [x] Backend endpoints verified live: snapshot → name overlay → picker shows real names

🤖 Generated with [Claude Code](https://claude.com/claude-code)