### PR TITLE
feat(cost): operation taxonomy drill-down in Real-time tab (Marcus #409)

### DIFF
--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -45,6 +45,13 @@ COST_TRACKING_AVAILABLE = False
 CostStore: Any = None
 CostAggregator: Any = None
 ModelPrice: Any = None
+# Bound at module scope (not just inside the success branch) so that
+# ``list_operations()`` can reference it unconditionally. If Marcus
+# discovery fails entirely — outer try raises, or no _marcus_root is
+# found — this stays ``None`` and the endpoint returns an empty
+# mapping instead of crashing with NameError. Kaia review on
+# ``feat/marcus-409-operations-taxonomy``.
+_marcus_all_operations: Any = None
 
 try:
     import sys
@@ -74,16 +81,20 @@ try:
 
         # Operation taxonomy: imported defensively so older Marcus
         # checkouts without this module still load the cost routes.
-        # ``all_operations`` is None when unavailable; the
-        # ``/api/cost/operations`` endpoint returns an empty mapping
-        # in that case so the dashboard degrades gracefully to "no
-        # tooltip" instead of crashing.
+        # ``_marcus_all_operations`` stays ``None`` (its module-scope
+        # default) when unavailable; the ``/api/cost/operations``
+        # endpoint returns an empty mapping in that case so the
+        # dashboard degrades gracefully to "no tooltip" instead of
+        # crashing. The two-step import-then-assign pattern (rather
+        # than ``import ... as _marcus_all_operations``) avoids a
+        # mypy ``no-redef`` error against the module-scope
+        # declaration on line 54.
         try:
-            from src.cost_tracking.operations import (
-                all_operations as _marcus_all_operations,  # type: ignore[no-redef]
-            )
+            from src.cost_tracking.operations import all_operations
+
+            _marcus_all_operations = all_operations
         except ImportError:
-            _marcus_all_operations = None  # type: ignore[assignment]
+            pass  # leave as None (set at module scope)
 
         COST_TRACKING_AVAILABLE = True
         logger.info("Cato cost-tracking enabled (Marcus at %s)", _marcus_root)

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -72,6 +72,19 @@ try:
             ModelPrice,
         )
 
+        # Operation taxonomy: imported defensively so older Marcus
+        # checkouts without this module still load the cost routes.
+        # ``all_operations`` is None when unavailable; the
+        # ``/api/cost/operations`` endpoint returns an empty mapping
+        # in that case so the dashboard degrades gracefully to "no
+        # tooltip" instead of crashing.
+        try:
+            from src.cost_tracking.operations import (
+                all_operations as _marcus_all_operations,  # type: ignore[no-redef]
+            )
+        except ImportError:
+            _marcus_all_operations = None  # type: ignore[assignment]
+
         COST_TRACKING_AVAILABLE = True
         logger.info("Cato cost-tracking enabled (Marcus at %s)", _marcus_root)
     else:
@@ -474,6 +487,33 @@ def session_turns(
 
 
 # -- pricing endpoints -------------------------------------------------------
+
+
+@router.get("/operations")  # type: ignore[misc]
+def list_operations() -> Dict[str, Any]:
+    """Return the canonical operation taxonomy for cost-event drill-down.
+
+    Sourced from ``src.cost_tracking.operations`` in Marcus. Returns an
+    empty mapping when Marcus is older and lacks the module — the
+    dashboard treats unknown operation keys gracefully (synthesized
+    label, generic tooltip).
+
+    The mapping shape is::
+
+        {
+            "operations": {
+                "<key>": {
+                    "label": "Human label",
+                    "description": "What this LLM call does and why.",
+                    "category": "decomposition" | "runtime" | "monitoring" | "other",
+                },
+                ...
+            }
+        }
+    """
+    if _marcus_all_operations is None:
+        return {"operations": {}}
+    return {"operations": _marcus_all_operations()}
 
 
 @router.get("/prices")  # type: ignore[misc]

--- a/dashboard/src/components/CostDashboard.tsx
+++ b/dashboard/src/components/CostDashboard.tsx
@@ -1,34 +1,30 @@
 /**
  * Top-level cost dashboard page (Marcus issue #409).
  *
- * Project-first: project_id is the only universal identity in Marcus's
- * coordination model (Marcus CLAUDE.md GH-388, spawn_agents.py, and
- * the #503 project-axis refactor). Marcus's main code path doesn't
- * open MLflow experiments, so the experiment dimension is no longer
- * surfaced in the UI — every tab renders from project-level data.
+ * Project-first (Marcus #503): project_id is the only universal
+ * identity. The picker is unified with Cato's main header dropdown —
+ * pick a project once at the top of the page and the Cost view
+ * reflects that choice. There is no local picker.
  *
- * Sub-tabs (all keyed off the selected project):
- *   - Real-time  → live spend, agents working, per-role breakdown
- *   - Historical → cross-project totals + per-project time series
- *   - Budget     → cost so far vs. spend rate / projection
- *   - Pricing    → current rate table + insert form
+ * The view now contains only two tabs: Real-time (live spend +
+ * per-call breakdown) and Budget (cap + projection). Historical and
+ * Pricing are accessed from the settings gear in the header (full-
+ * screen modals) since they're cross-project / global views, not
+ * tied to the active project.
  */
 
 import { useEffect, useRef, useState } from 'react';
+import { useVisualizationStore } from '../store/visualizationStore';
 import {
-  fetchProjects,
   fetchUnassignedTotals,
   triggerIngest,
-  type ProjectRow,
   type UnassignedTotals,
 } from '../services/costService';
 import BudgetTab from './BudgetTab';
-import HistoricalTab from './HistoricalTab';
-import PricingTab from './PricingTab';
 import RealTimeTab from './RealTimeTab';
 import './CostDashboard.css';
 
-type CostTab = 'realtime' | 'historical' | 'budget' | 'pricing';
+type CostTab = 'realtime' | 'budget';
 
 function formatUsd(v: number, decimals = 2): string {
   return `$${v.toFixed(decimals)}`;
@@ -40,45 +36,33 @@ function formatTokens(v: number): string {
   return String(v);
 }
 
-function formatProjectDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return '';
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-}
-
 /**
- * Render a project label for the picker. Order of preference:
- * 1. explicit project_name (MLflow / registry overlay)
- * 2. "Unnamed · <first-event date>" — gives temporal context for
- *    projects deleted from the registry but still in token_events
- * Tokens are appended to either so users can identify by spend.
+ * Normalize a project_id to the canonical (dashless hex) form the
+ * cost DB uses. Cato's main picker emits Marcus's project_id in
+ * whichever form the registry stored it (often dashed UUID); the
+ * cost data is dashless. See Marcus canonical_project_id.
  */
-function projectLabel(p: ProjectRow): string {
-  const tokens = formatTokens(p.total_tokens);
-  const cost = formatUsd(p.total_cost_usd);
-  if (p.project_name) {
-    return `${p.project_name} — ${cost} (${tokens} tokens)`;
-  }
-  const date = formatProjectDate(p.first_event_at);
-  const prefix = date ? `Unnamed · ${date}` : 'Unnamed';
-  return `${prefix} — ${cost} (${tokens} tokens)`;
+function canonicalProjectId(pid: string | null): string | null {
+  if (!pid) return null;
+  return pid.replace(/-/g, '');
 }
 
 const CostDashboard = () => {
   const [activeTab, setActiveTab] = useState<CostTab>('realtime');
-  const [projects, setProjects] = useState<ProjectRow[]>([]);
   const [unassigned, setUnassigned] = useState<UnassignedTotals | null>(null);
   const [unassignedOpen, setUnassignedOpen] = useState(false);
-  const [selectedProject, setSelectedProject] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [initialLoading, setInitialLoading] = useState(true);
+
+  // Unified picker: read the active project from the global store.
+  // No local selectedProject state, no local <select>. Switching the
+  // main header picker propagates here automatically.
+  const globalProjectId = useVisualizationStore(
+    (state) => state.selectedProjectId,
+  );
+  const projectId = canonicalProjectId(globalProjectId);
 
   // First-paint perf: triggerIngest sweeps ~/.claude/projects/<sess>.jsonl
-  // and was previously awaited *before* fetchProjects, which made the
-  // initial load take 10+ seconds on accounts with many session files.
-  // Now we fire ingest in the background and let the picker render
-  // immediately from whatever is already in costs.db. The next poll
-  // tick picks up any rows ingest added.
+  // and was previously awaited before initial render. Now we fire in
+  // the background; the next 30s poll picks up any new rows.
   const ingestInFlight = useRef(false);
   useEffect(() => {
     let cancelled = false;
@@ -96,30 +80,7 @@ const CostDashboard = () => {
     };
 
     const load = async () => {
-      // Kick off ingest in parallel — do not await.
       fireIngestInBackground();
-
-      try {
-        const { projects: ps } = await fetchProjects();
-        if (cancelled) return;
-        setProjects(ps);
-        setError(null);
-        // Auto-select the most expensive project the first time we see
-        // any. Functional setState avoids depending on selectedProject
-        // in the effect's deps array.
-        setSelectedProject((current) =>
-          current === null && ps.length > 0 ? ps[0].project_id : current,
-        );
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
-        }
-      } finally {
-        if (!cancelled) setInitialLoading(false);
-      }
-
-      // Fetch unassigned totals independently; failure here is not
-      // fatal — we just skip the banner this tick.
       try {
         const una = await fetchUnassignedTotals();
         if (!cancelled) setUnassigned(una);
@@ -136,66 +97,25 @@ const CostDashboard = () => {
     };
   }, []);
 
-  if (error && projects.length === 0) {
-    return (
-      <div className="cost-dashboard cost-dashboard-error">
-        <h2>Cost dashboard unavailable</h2>
-        <p>{error}</p>
-        <p className="hint">
-          The cost backend may be disabled — check that Marcus is running and
-          ~/.marcus/costs.db exists.
-        </p>
-      </div>
-    );
-  }
-
   return (
     <div className="cost-dashboard">
       <div className="cost-dashboard-header">
         <h2>Cost</h2>
 
-        <div className="cost-pickers">
-          <div className="cost-picker">
-            <label htmlFor="cost-project-select">Project:</label>
-            <select
-              id="cost-project-select"
-              value={selectedProject ?? ''}
-              onChange={(e) => setSelectedProject(e.target.value || null)}
-            >
-              {projects.length === 0 && (
-                <option value="">
-                  {initialLoading ? '— loading… —' : '— none yet —'}
-                </option>
-              )}
-              {projects.map((p) => (
-                <option key={p.project_id} value={p.project_id}>
-                  {/*
-                    Name resolution: experiments.project_name (MLflow) →
-                    Marcus project registry → "Unnamed · <date>" fallback
-                    for projects deleted from the registry but still in
-                    token_events. See cost_routes._load_project_names.
-                  */}
-                  {projectLabel(p)}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {unassigned && unassigned.events > 0 && (
-            <button
-              type="button"
-              className="cost-unassigned-icon"
-              onClick={() => setUnassignedOpen((v) => !v)}
-              title={
-                'Unassigned cost — LLM calls Marcus made without an ' +
-                'active project context. Click for details.'
-              }
-              aria-label="Unassigned cost details"
-            >
-              ⚠
-            </button>
-          )}
-        </div>
+        {unassigned && unassigned.events > 0 && (
+          <button
+            type="button"
+            className="cost-unassigned-icon"
+            onClick={() => setUnassignedOpen((v) => !v)}
+            title={
+              'Unassigned cost — LLM calls Marcus made without an ' +
+              'active project context. Click for details.'
+            }
+            aria-label="Unassigned cost details"
+          >
+            ⚠
+          </button>
+        )}
 
         {unassignedOpen && unassigned && (
           <div className="cost-unassigned-popover" role="dialog">
@@ -203,7 +123,8 @@ const CostDashboard = () => {
             <p className="hint">
               Calls Marcus made without an active project context — usually
               a code path running outside the MCP request lifecycle, or a
-              project-creation tool.
+              project-creation tool. Historical view in Settings shows
+              project-by-project breakdown including deleted projects.
             </p>
             <dl className="cost-unassigned-stats">
               <div>
@@ -238,44 +159,40 @@ const CostDashboard = () => {
           Real-time
         </button>
         <button
-          className={activeTab === 'historical' ? 'active' : ''}
-          onClick={() => setActiveTab('historical')}
-        >
-          Historical
-        </button>
-        <button
           className={activeTab === 'budget' ? 'active' : ''}
           onClick={() => setActiveTab('budget')}
         >
           Budget
         </button>
-        <button
-          className={activeTab === 'pricing' ? 'active' : ''}
-          onClick={() => setActiveTab('pricing')}
-        >
-          Pricing
-        </button>
       </div>
 
       <div className="cost-tab-content">
-        {activeTab === 'realtime' && selectedProject && (
-          <RealTimeTab projectId={selectedProject} />
+        {activeTab === 'realtime' && projectId && (
+          <RealTimeTab projectId={projectId} />
         )}
-        {activeTab === 'realtime' && !selectedProject && (
+        {activeTab === 'realtime' && !projectId && (
           <div className="cost-empty">
-            No projects yet. Run one with the marcus skill and it'll appear here.
+            <p>No project selected.</p>
+            <p className="hint">
+              Pick a project from the dropdown at the top of the page to
+              see its live cost data. Historical totals (including deleted
+              projects) are available in <strong>Settings → Historical
+              Cost</strong>.
+            </p>
           </div>
         )}
-        {activeTab === 'historical' && <HistoricalTab />}
-        {activeTab === 'budget' && selectedProject && (
-          <BudgetTab projectId={selectedProject} />
+        {activeTab === 'budget' && projectId && (
+          <BudgetTab projectId={projectId} />
         )}
-        {activeTab === 'budget' && !selectedProject && (
+        {activeTab === 'budget' && !projectId && (
           <div className="cost-empty">
-            Select a project to see budget projection.
+            <p>No project selected.</p>
+            <p className="hint">
+              Pick a project at the top to see its budget cap and spend
+              projection.
+            </p>
           </div>
         )}
-        {activeTab === 'pricing' && <PricingTab />}
       </div>
     </div>
   );

--- a/dashboard/src/components/HeaderControls.tsx
+++ b/dashboard/src/components/HeaderControls.tsx
@@ -2,6 +2,98 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useVisualizationStore } from '../store/visualizationStore';
 import { fetchSettings, updateSettings } from '../services/dataService';
 import ExportButton from './ExportButton';
+import HistoricalTab from './HistoricalTab';
+import PricingTab from './PricingTab';
+
+/** Full-screen overlay modal for cross-project / global cost views.
+ *
+ * Historical (lifetime cost rollup) and Pricing (rate table) used to
+ * live inside the Cost dashboard tab strip. They were moved here so
+ * the Cost view stays focused on the *active project*: Real-time +
+ * Budget only. These two are global tools and belong with other
+ * settings-level controls.
+ */
+const CostOverlay = ({
+  kind,
+  onClose,
+}: {
+  kind: 'historical' | 'pricing';
+  onClose: () => void;
+}) => {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.65)',
+        zIndex: 200,
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        paddingTop: '4vh',
+        paddingBottom: '4vh',
+        overflowY: 'auto',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: '#0f172a',
+          border: '1px solid #334155',
+          borderRadius: '0.5rem',
+          width: 'min(1100px, 95vw)',
+          maxHeight: '92vh',
+          overflowY: 'auto',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '0.75rem 1.25rem',
+            borderBottom: '1px solid #334155',
+            position: 'sticky',
+            top: 0,
+            background: '#0f172a',
+          }}
+        >
+          <h2 style={{ margin: 0, color: '#e2e8f0', fontSize: '1.1rem' }}>
+            {kind === 'historical' ? '📊 Historical Cost' : '💲 Pricing Rates'}
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              background: 'transparent',
+              border: '1px solid #475569',
+              color: '#e2e8f0',
+              borderRadius: '0.25rem',
+              padding: '0.25rem 0.65rem',
+              cursor: 'pointer',
+              fontSize: '0.9rem',
+            }}
+          >
+            ✕ Close
+          </button>
+        </div>
+        <div style={{ padding: '1rem 1.25rem' }}>
+          {kind === 'historical' ? <HistoricalTab /> : <PricingTab />}
+        </div>
+      </div>
+    </div>
+  );
+};
 
 /**
  * Header controls component to prevent flickering during data refreshes.
@@ -41,6 +133,14 @@ const HeaderControls = () => {
   const [cutoffDate, setCutoffDate] = useState<string>('');
   const [settingsSaving, setSettingsSaving] = useState(false);
   const settingsRef = useRef<HTMLDivElement>(null);
+
+  // Cost overlays launched from the settings panel. ``costOverlay``
+  // is the only piece of state introduced for Change 2 — when set,
+  // a full-screen modal renders Historical or Pricing on top of
+  // everything else.
+  const [costOverlay, setCostOverlay] = useState<
+    'historical' | 'pricing' | null
+  >(null);
 
   useEffect(() => {
     fetchSettings().then(s => setCutoffDate(s.history_cutoff_date ?? '')).catch(() => {});
@@ -194,6 +294,50 @@ const HeaderControls = () => {
                 >
                   {settingsSaving ? 'Saving…' : 'Save'}
                 </button>
+
+                {/* Cross-project / global cost views. These used to live
+                    in the Cost tab strip but were moved here so the
+                    Cost view can stay focused on the active project
+                    (Real-time + Budget only). */}
+                <div style={{
+                  marginTop: '0.75rem',
+                  paddingTop: '0.75rem',
+                  borderTop: '1px solid #334155',
+                }}>
+                  <div style={{ color: '#94a3b8', fontSize: '0.75rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '0.5rem' }}>
+                    Cost tools
+                  </div>
+                  <button
+                    onClick={() => {
+                      setCostOverlay('historical');
+                      setSettingsOpen(false);
+                    }}
+                    style={{
+                      width: '100%', padding: '0.5rem 0.75rem',
+                      borderRadius: '0.25rem', marginBottom: '0.4rem',
+                      background: '#334155', border: '1px solid #475569',
+                      color: '#e2e8f0', cursor: 'pointer', fontSize: '0.9rem',
+                      textAlign: 'left',
+                    }}
+                  >
+                    📊 Historical Cost
+                  </button>
+                  <button
+                    onClick={() => {
+                      setCostOverlay('pricing');
+                      setSettingsOpen(false);
+                    }}
+                    style={{
+                      width: '100%', padding: '0.5rem 0.75rem',
+                      borderRadius: '0.25rem',
+                      background: '#334155', border: '1px solid #475569',
+                      color: '#e2e8f0', cursor: 'pointer', fontSize: '0.9rem',
+                      textAlign: 'left',
+                    }}
+                  >
+                    💲 Pricing Rates
+                  </button>
+                </div>
               </div>
             )}
           </div>
@@ -203,6 +347,12 @@ const HeaderControls = () => {
         <div className="error-banner">
           ⚠️ Error loading data: {loadError}
         </div>
+      )}
+      {costOverlay && (
+        <CostOverlay
+          kind={costOverlay}
+          onClose={() => setCostOverlay(null)}
+        />
       )}
       {loadingStatus && (
         <div

--- a/dashboard/src/components/OperationsPanel.tsx
+++ b/dashboard/src/components/OperationsPanel.tsx
@@ -22,26 +22,13 @@ import type {
   OperationCatalogEntry,
   OperationSlice,
 } from '../services/costService';
-
-type CategoryKey =
-  | 'decomposition'
-  | 'runtime'
-  | 'monitoring'
-  | 'other';
-
-const ALL_CATEGORIES: CategoryKey[] = [
-  'decomposition',
-  'runtime',
-  'monitoring',
-  'other',
-];
-
-const CATEGORY_LABELS: Record<CategoryKey, string> = {
-  decomposition: 'Decomposition',
-  runtime: 'Runtime',
-  monitoring: 'Monitoring',
-  other: 'Other',
-};
+import {
+  ALL_CATEGORIES,
+  CATEGORY_LABELS,
+  bucketByCategory,
+  pickColdOffender,
+  type CategoryKey,
+} from './operationsPanel.logic';
 
 interface Props {
   operations: OperationSlice[];
@@ -68,28 +55,6 @@ function cacheCellClass(rate: number): string {
   return 'cache-cell';
 }
 
-/**
- * Compute the "cold-cache opportunity" for one operation.
- *
- * ``cache_creation_tokens * (1 - cache_hit_rate)`` approximates
- * tokens we'd save by tightening the prompt so it hits the cache.
- * The row with the highest score is the best prompt-tightening
- * target — heavy AND cold.
- */
-function coldCacheScore(op: OperationSlice): number {
-  const creation = op.cache_creation_tokens ?? 0;
-  const rate = op.cache_hit_rate ?? 0;
-  return creation * (1 - rate);
-}
-
-interface CategoryGroup {
-  category: CategoryKey;
-  ops: OperationSlice[];
-  totalCost: number;
-  totalTokens: number;
-  totalCalls: number;
-}
-
 const OperationsPanel = ({ operations, catalog }: Props) => {
   // Default: all categories visible. Pills toggle off-states.
   const [visibleCategories, setVisibleCategories] = useState<
@@ -98,53 +63,31 @@ const OperationsPanel = ({ operations, catalog }: Props) => {
   // Default: all categories expanded. Headers toggle collapse.
   const [collapsed, setCollapsed] = useState<Set<CategoryKey>>(new Set());
 
-  // Map operations into category groups. Operations whose key isn't
-  // in the catalog fall into 'other' so they're still visible — the
-  // recorder logs a WARNING for those, so they're rare and worth
-  // surfacing.
-  const groups = useMemo<CategoryGroup[]>(() => {
-    const buckets: Record<CategoryKey, OperationSlice[]> = {
-      decomposition: [],
-      runtime: [],
-      monitoring: [],
-      other: [],
-    };
-    for (const op of operations) {
-      const cat =
-        (catalog[op.operation]?.category as CategoryKey | undefined) ??
-        'other';
-      buckets[cat].push(op);
-    }
-    return ALL_CATEGORIES.map((cat) => {
-      const ops = buckets[cat];
-      return {
-        category: cat,
-        ops,
-        totalCost: ops.reduce((s, o) => s + o.cost_usd, 0),
-        totalTokens: ops.reduce((s, o) => s + o.tokens, 0),
-        totalCalls: ops.reduce((s, o) => s + o.events, 0),
-      };
-    }).filter((g) => g.ops.length > 0);
-  }, [operations, catalog]);
+  // Map operations into category groups. Pure logic in
+  // ``operationsPanel.logic.ts`` — see that file's docstring for the
+  // ``'other'`` fallback semantics and the rationale for empty-bucket
+  // filtering.
+  const groups = useMemo(
+    () => bucketByCategory(operations, catalog),
+    [operations, catalog],
+  );
 
-  // Find the worst cold-cache offender across all visible operations.
-  // Compute *before* filtering so the badge always points at the
-  // global worst, even if the user has the relevant category off
-  // (avoids the chip jumping around as filters change).
-  const coldOffenderKey = useMemo<string | null>(() => {
-    let bestKey: string | null = null;
-    let bestScore = 0;
-    for (const op of operations) {
-      const score = coldCacheScore(op);
-      // Threshold: only badge rows with > 1k saveable tokens. Below
-      // that the "biggest offender" is noise.
-      if (score > bestScore && score > 1000) {
-        bestScore = score;
-        bestKey = op.operation;
-      }
-    }
-    return bestKey;
-  }, [operations]);
+  // Find the worst cold-cache offender across all operations.
+  // Compute *before* visibility filtering so the badge always points
+  // at the global worst, even if the user has the relevant category
+  // off (avoids the chip jumping around as filters change). The
+  // pure logic is in ``operationsPanel.logic.ts``; it skips
+  // unregistered/typo operations and applies the 1000-token
+  // threshold.
+  const coldOffenderKey = useMemo(
+    () => pickColdOffender(operations, catalog),
+    [operations, catalog],
+  );
+
+  // ID prefix for table elements so aria-controls on each group
+  // header points at the correct table. Using a stable per-category
+  // suffix means the relationship is stable across re-renders.
+  const tableIdFor = (cat: CategoryKey) => `cost-operations-table-${cat}`;
 
   const toggleCategory = (cat: CategoryKey) => {
     setVisibleCategories((prev) => {
@@ -200,10 +143,24 @@ const OperationsPanel = ({ operations, catalog }: Props) => {
         })}
       </div>
 
-      {groups
-        .filter((g) => visibleCategories.has(g.category))
-        .map((g) => {
+      {(() => {
+        const visibleGroups = groups.filter((g) =>
+          visibleCategories.has(g.category),
+        );
+        if (visibleGroups.length === 0) {
+          // All categories filtered off — keep the toolbar usable but
+          // tell the user why the table area is empty. Kaia review on
+          // PR #39.
+          return (
+            <p className="cost-panel-hint cost-operation-empty">
+              No operations match the active filters. Click a category
+              pill above to bring its rows back.
+            </p>
+          );
+        }
+        return visibleGroups.map((g) => {
           const isCollapsed = collapsed.has(g.category);
+          const tableId = tableIdFor(g.category);
           return (
             <div key={g.category} className="cost-operation-group">
               <button
@@ -211,6 +168,7 @@ const OperationsPanel = ({ operations, catalog }: Props) => {
                 className={`cost-operation-group-header cat-${g.category}`}
                 onClick={() => toggleCollapsed(g.category)}
                 aria-expanded={!isCollapsed}
+                aria-controls={tableId}
               >
                 <span className="cost-operation-group-chevron">
                   {isCollapsed ? '▶' : '▼'}
@@ -226,7 +184,10 @@ const OperationsPanel = ({ operations, catalog }: Props) => {
               </button>
 
               {!isCollapsed && (
-                <table className="cost-table cost-table-dense">
+                <table
+                  id={tableId}
+                  className="cost-table cost-table-dense"
+                >
                   <thead>
                     <tr>
                       <th>Operation</th>
@@ -294,7 +255,8 @@ const OperationsPanel = ({ operations, catalog }: Props) => {
               )}
             </div>
           );
-        })}
+        });
+      })()}
     </section>
   );
 };

--- a/dashboard/src/components/OperationsPanel.tsx
+++ b/dashboard/src/components/OperationsPanel.tsx
@@ -1,0 +1,302 @@
+/**
+ * Per-LLM-call drill-down panel for the Real-time tab.
+ *
+ * Renders the ``by_operation`` slice grouped by category
+ * (decomposition / runtime / monitoring / other), with:
+ *
+ * - Filter pills at the top — toggle whole categories on/off.
+ * - Collapsible category sections with per-category aggregates,
+ *   so the table stays scannable past 40 operations.
+ * - A 🔥 badge on the single worst cold-cache offender (the
+ *   operation with the highest ``cache_creation_tokens *
+ *   (1 - cache_hit_rate)``) — that's the prompt-tightening
+ *   target Kaia called out in her review.
+ *
+ * The component is purely presentational: it owns its filter /
+ * collapse UI state, but the data comes from a parent prop and the
+ * catalog from a separate prop so it can be tested in isolation.
+ */
+
+import { useMemo, useState } from 'react';
+import type {
+  OperationCatalogEntry,
+  OperationSlice,
+} from '../services/costService';
+
+type CategoryKey =
+  | 'decomposition'
+  | 'runtime'
+  | 'monitoring'
+  | 'other';
+
+const ALL_CATEGORIES: CategoryKey[] = [
+  'decomposition',
+  'runtime',
+  'monitoring',
+  'other',
+];
+
+const CATEGORY_LABELS: Record<CategoryKey, string> = {
+  decomposition: 'Decomposition',
+  runtime: 'Runtime',
+  monitoring: 'Monitoring',
+  other: 'Other',
+};
+
+interface Props {
+  operations: OperationSlice[];
+  catalog: Record<string, OperationCatalogEntry>;
+}
+
+function formatUsd(v: number, decimals = 2): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function formatTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}
+
+function formatPct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+function cacheCellClass(rate: number): string {
+  if (rate < 0.3) return 'cache-cell cache-cold';
+  if (rate > 0.7) return 'cache-cell cache-hot';
+  return 'cache-cell';
+}
+
+/**
+ * Compute the "cold-cache opportunity" for one operation.
+ *
+ * ``cache_creation_tokens * (1 - cache_hit_rate)`` approximates
+ * tokens we'd save by tightening the prompt so it hits the cache.
+ * The row with the highest score is the best prompt-tightening
+ * target — heavy AND cold.
+ */
+function coldCacheScore(op: OperationSlice): number {
+  const creation = op.cache_creation_tokens ?? 0;
+  const rate = op.cache_hit_rate ?? 0;
+  return creation * (1 - rate);
+}
+
+interface CategoryGroup {
+  category: CategoryKey;
+  ops: OperationSlice[];
+  totalCost: number;
+  totalTokens: number;
+  totalCalls: number;
+}
+
+const OperationsPanel = ({ operations, catalog }: Props) => {
+  // Default: all categories visible. Pills toggle off-states.
+  const [visibleCategories, setVisibleCategories] = useState<
+    Set<CategoryKey>
+  >(new Set(ALL_CATEGORIES));
+  // Default: all categories expanded. Headers toggle collapse.
+  const [collapsed, setCollapsed] = useState<Set<CategoryKey>>(new Set());
+
+  // Map operations into category groups. Operations whose key isn't
+  // in the catalog fall into 'other' so they're still visible — the
+  // recorder logs a WARNING for those, so they're rare and worth
+  // surfacing.
+  const groups = useMemo<CategoryGroup[]>(() => {
+    const buckets: Record<CategoryKey, OperationSlice[]> = {
+      decomposition: [],
+      runtime: [],
+      monitoring: [],
+      other: [],
+    };
+    for (const op of operations) {
+      const cat =
+        (catalog[op.operation]?.category as CategoryKey | undefined) ??
+        'other';
+      buckets[cat].push(op);
+    }
+    return ALL_CATEGORIES.map((cat) => {
+      const ops = buckets[cat];
+      return {
+        category: cat,
+        ops,
+        totalCost: ops.reduce((s, o) => s + o.cost_usd, 0),
+        totalTokens: ops.reduce((s, o) => s + o.tokens, 0),
+        totalCalls: ops.reduce((s, o) => s + o.events, 0),
+      };
+    }).filter((g) => g.ops.length > 0);
+  }, [operations, catalog]);
+
+  // Find the worst cold-cache offender across all visible operations.
+  // Compute *before* filtering so the badge always points at the
+  // global worst, even if the user has the relevant category off
+  // (avoids the chip jumping around as filters change).
+  const coldOffenderKey = useMemo<string | null>(() => {
+    let bestKey: string | null = null;
+    let bestScore = 0;
+    for (const op of operations) {
+      const score = coldCacheScore(op);
+      // Threshold: only badge rows with > 1k saveable tokens. Below
+      // that the "biggest offender" is noise.
+      if (score > bestScore && score > 1000) {
+        bestScore = score;
+        bestKey = op.operation;
+      }
+    }
+    return bestKey;
+  }, [operations]);
+
+  const toggleCategory = (cat: CategoryKey) => {
+    setVisibleCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  };
+
+  const toggleCollapsed = (cat: CategoryKey) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  };
+
+  if (operations.length === 0) return null;
+
+  return (
+    <section className="cost-panel">
+      <h3>
+        Tokens by operation{' '}
+        <small className="cost-panel-hint">
+          Grouped by category. Click a pill to filter, a header to collapse.
+          🔥 marks the biggest cold-cache opportunity — the row where
+          tightening the prompt would save the most tokens.
+        </small>
+      </h3>
+
+      <div className="cost-operation-filters" role="toolbar">
+        {groups.map((g) => {
+          const active = visibleCategories.has(g.category);
+          return (
+            <button
+              key={g.category}
+              type="button"
+              className={`cost-operation-pill cat-${g.category} ${
+                active ? 'is-active' : 'is-inactive'
+              }`}
+              onClick={() => toggleCategory(g.category)}
+              aria-pressed={active}
+              title={`Toggle ${CATEGORY_LABELS[g.category]} (${g.ops.length} ops)`}
+            >
+              {CATEGORY_LABELS[g.category]}{' '}
+              <span className="cost-operation-pill-count">
+                {g.ops.length}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {groups
+        .filter((g) => visibleCategories.has(g.category))
+        .map((g) => {
+          const isCollapsed = collapsed.has(g.category);
+          return (
+            <div key={g.category} className="cost-operation-group">
+              <button
+                type="button"
+                className={`cost-operation-group-header cat-${g.category}`}
+                onClick={() => toggleCollapsed(g.category)}
+                aria-expanded={!isCollapsed}
+              >
+                <span className="cost-operation-group-chevron">
+                  {isCollapsed ? '▶' : '▼'}
+                </span>
+                <span className="cost-operation-group-title">
+                  {CATEGORY_LABELS[g.category]}
+                </span>
+                <span className="cost-operation-group-stats">
+                  {g.ops.length} ops · {g.totalCalls} calls ·{' '}
+                  {formatTokens(g.totalTokens)} tokens ·{' '}
+                  {formatUsd(g.totalCost, 4)}
+                </span>
+              </button>
+
+              {!isCollapsed && (
+                <table className="cost-table cost-table-dense">
+                  <thead>
+                    <tr>
+                      <th>Operation</th>
+                      <th>Calls</th>
+                      <th>Input</th>
+                      <th>Cache create</th>
+                      <th>Cache read</th>
+                      <th>Output</th>
+                      <th>Cache %</th>
+                      <th>Cost</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {g.ops.map((op) => {
+                      const entry = catalog[op.operation];
+                      const label = entry?.label ?? op.operation;
+                      const tooltip = entry
+                        ? `${entry.label} — ${entry.description}`
+                        : `Unregistered operation '${op.operation}'. ` +
+                          'Add it to Marcus operations.py for a description.';
+                      const isColdOffender =
+                        op.operation === coldOffenderKey;
+                      return (
+                        <tr
+                          key={op.operation}
+                          className={
+                            isColdOffender ? 'cost-operation-cold-offender' : ''
+                          }
+                        >
+                          <td>
+                            <span
+                              className="cost-operation-label"
+                              title={tooltip}
+                            >
+                              {label}
+                            </span>
+                            {isColdOffender && (
+                              <span
+                                className="cost-operation-offender-badge"
+                                title={
+                                  'Highest cold-cache opportunity. ' +
+                                  'Tightening this prompt to fit the ' +
+                                  'cache window would save the most ' +
+                                  'tokens of any operation.'
+                                }
+                              >
+                                🔥
+                              </span>
+                            )}
+                          </td>
+                          <td>{op.events}</td>
+                          <td>{formatTokens(op.input_tokens ?? 0)}</td>
+                          <td>{formatTokens(op.cache_creation_tokens ?? 0)}</td>
+                          <td>{formatTokens(op.cache_read_tokens ?? 0)}</td>
+                          <td>{formatTokens(op.output_tokens ?? 0)}</td>
+                          <td className={cacheCellClass(op.cache_hit_rate ?? 0)}>
+                            {formatPct(op.cache_hit_rate ?? 0)}
+                          </td>
+                          <td>{formatUsd(op.cost_usd, 4)}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          );
+        })}
+    </section>
+  );
+};
+
+export default OperationsPanel;

--- a/dashboard/src/components/RealTimeTab.css
+++ b/dashboard/src/components/RealTimeTab.css
@@ -280,3 +280,155 @@
   background: rgba(148, 163, 184, 0.15);
   color: var(--text-muted, #94a3b8);
 }
+
+/* Filter pill row above the operations table. Each pill toggles the
+   visibility of one category. Inactive (toggled-off) pills dim out
+   so the active filter is unambiguous at a glance. */
+.cost-operation-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 12px;
+}
+
+.cost-operation-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-elevated, #ffffff);
+  color: var(--text-primary, #1e293b);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: opacity 120ms, background 120ms;
+}
+
+.cost-operation-pill.is-inactive {
+  opacity: 0.4;
+  background: transparent;
+}
+
+.cost-operation-pill.cat-decomposition.is-active {
+  border-color: rgba(59, 130, 246, 0.5);
+  background: rgba(59, 130, 246, 0.1);
+  color: #3b82f6;
+}
+
+.cost-operation-pill.cat-runtime.is-active {
+  border-color: rgba(34, 197, 94, 0.5);
+  background: rgba(34, 197, 94, 0.1);
+  color: #22c55e;
+}
+
+.cost-operation-pill.cat-monitoring.is-active {
+  border-color: rgba(168, 85, 247, 0.5);
+  background: rgba(168, 85, 247, 0.1);
+  color: #a855f7;
+}
+
+.cost-operation-pill.cat-other.is-active {
+  border-color: rgba(148, 163, 184, 0.5);
+  background: rgba(148, 163, 184, 0.1);
+  color: var(--text-muted, #94a3b8);
+}
+
+.cost-operation-pill-count {
+  display: inline-block;
+  min-width: 18px;
+  padding: 0 4px;
+  border-radius: 9px;
+  background: rgba(148, 163, 184, 0.2);
+  font-size: 10px;
+  font-weight: 600;
+  text-align: center;
+}
+
+/* Collapsible category groups within the operations table. Each
+   group has a header (chevron + label + aggregates) and an embedded
+   dense table. Headers are buttons so the whole bar is clickable. */
+.cost-operation-group {
+  margin: 0 0 16px;
+}
+
+.cost-operation-group-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 6px 10px;
+  margin: 0 0 4px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+  background: var(--bg-elevated, #ffffff);
+  color: var(--text-primary, #1e293b);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  text-align: left;
+  transition: background 120ms;
+}
+
+.cost-operation-group-header:hover {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.cost-operation-group-chevron {
+  color: var(--text-muted, #94a3b8);
+  font-size: 10px;
+  width: 12px;
+  display: inline-block;
+}
+
+.cost-operation-group-title {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 11px;
+}
+
+.cost-operation-group-header.cat-decomposition .cost-operation-group-title {
+  color: #3b82f6;
+}
+
+.cost-operation-group-header.cat-runtime .cost-operation-group-title {
+  color: #22c55e;
+}
+
+.cost-operation-group-header.cat-monitoring .cost-operation-group-title {
+  color: #a855f7;
+}
+
+.cost-operation-group-header.cat-other .cost-operation-group-title {
+  color: var(--text-muted, #94a3b8);
+}
+
+.cost-operation-group-stats {
+  margin-left: auto;
+  color: var(--text-muted, #94a3b8);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+}
+
+/* Cold-cache offender badge: the 🔥 marks the single operation row
+   where tightening the prompt would save the most tokens
+   (cache_creation_tokens × (1 - cache_hit_rate)). The whole row gets
+   a subtle warning tint so it pops in a scan. */
+.cost-operation-offender-badge {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 12px;
+  cursor: help;
+}
+
+.cost-operation-cold-offender {
+  background: rgba(239, 68, 68, 0.06);
+}
+
+.cost-operation-cold-offender:hover {
+  background: rgba(239, 68, 68, 0.1);
+}

--- a/dashboard/src/components/RealTimeTab.css
+++ b/dashboard/src/components/RealTimeTab.css
@@ -432,3 +432,14 @@
 .cost-operation-cold-offender:hover {
   background: rgba(239, 68, 68, 0.1);
 }
+
+/* Empty state when all category filter pills are toggled off. Keeps
+   the toolbar visible (so the user can flip a pill back on) but
+   replaces the table area with a hint. */
+.cost-operation-empty {
+  margin: 12px 0;
+  padding: 16px;
+  text-align: center;
+  border: 1px dashed var(--border-color, #e2e8f0);
+  border-radius: 6px;
+}

--- a/dashboard/src/components/RealTimeTab.css
+++ b/dashboard/src/components/RealTimeTab.css
@@ -237,3 +237,46 @@
   font-size: 11px;
   color: var(--text-muted, #94a3b8);
 }
+
+/* Operation drill-down cells: `.cost-operation-label` is the primary
+   human label (hover for full description from the catalog).
+   `.cost-operation-cat` is a small tag chip showing which category
+   (decomposition / runtime / monitoring / other) the call belongs to,
+   so users can scan for "which setup-time call burned all those
+   cache-creation tokens?" without expanding rows. */
+.cost-operation-label {
+  cursor: help;
+  border-bottom: 1px dotted var(--text-muted, #94a3b8);
+}
+
+.cost-operation-cat {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  vertical-align: middle;
+}
+
+.cost-operation-cat.cat-decomposition {
+  background: rgba(59, 130, 246, 0.15);
+  color: #3b82f6;
+}
+
+.cost-operation-cat.cat-runtime {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+}
+
+.cost-operation-cat.cat-monitoring {
+  background: rgba(168, 85, 247, 0.15);
+  color: #a855f7;
+}
+
+.cost-operation-cat.cat-other {
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--text-muted, #94a3b8);
+}

--- a/dashboard/src/components/RealTimeTab.tsx
+++ b/dashboard/src/components/RealTimeTab.tsx
@@ -12,7 +12,9 @@
 
 import { useEffect, useState } from 'react';
 import {
+  fetchOperationCatalog,
   fetchProjectFullSummary,
+  type OperationCatalogEntry,
   type ProjectFullSummary,
 } from '../services/costService';
 import AgentSpendBars from './AgentSpendBars';
@@ -46,6 +48,26 @@ const RealTimeTab = ({ projectId, pollIntervalMs = 5000 }: Props) => {
   // from a generic error — render a friendly empty state.
   const [noActivity, setNoActivity] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  // Operation taxonomy (label + description per operation key). Loaded
+  // once on first render; survives polling. Empty when Marcus is older
+  // and lacks the operations module — falls through to raw keys.
+  const [opCatalog, setOpCatalog] = useState<
+    Record<string, OperationCatalogEntry>
+  >({});
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchOperationCatalog()
+      .then((c) => {
+        if (!cancelled) setOpCatalog(c.operations);
+      })
+      .catch(() => {
+        // intentionally swallowed — endpoint may not exist on old Marcus
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -211,20 +233,43 @@ const RealTimeTab = ({ projectId, pollIntervalMs = 5000 }: Props) => {
               </tr>
             </thead>
             <tbody>
-              {summary.by_operation.map((op) => (
-                <tr key={op.operation}>
-                  <td>{op.operation}</td>
-                  <td>{op.events}</td>
-                  <td>{formatTokens(op.input_tokens ?? 0)}</td>
-                  <td>{formatTokens(op.cache_creation_tokens ?? 0)}</td>
-                  <td>{formatTokens(op.cache_read_tokens ?? 0)}</td>
-                  <td>{formatTokens(op.output_tokens ?? 0)}</td>
-                  <td className={cacheCellClass(op.cache_hit_rate ?? 0)}>
-                    {formatPct(op.cache_hit_rate ?? 0)}
-                  </td>
-                  <td>{formatUsd(op.cost_usd, 4)}</td>
-                </tr>
-              ))}
+              {summary.by_operation.map((op) => {
+                const entry = opCatalog[op.operation];
+                const label = entry?.label ?? op.operation;
+                const tooltip = entry
+                  ? `${entry.label} — ${entry.description}`
+                  : `Unregistered operation '${op.operation}'. ` +
+                    'Add it to Marcus operations.py for a description.';
+                return (
+                  <tr key={op.operation}>
+                    <td>
+                      <span
+                        className="cost-operation-label"
+                        title={tooltip}
+                      >
+                        {label}
+                      </span>
+                      {entry && (
+                        <span
+                          className={`cost-operation-cat cat-${entry.category}`}
+                          title={`Category: ${entry.category}`}
+                        >
+                          {entry.category}
+                        </span>
+                      )}
+                    </td>
+                    <td>{op.events}</td>
+                    <td>{formatTokens(op.input_tokens ?? 0)}</td>
+                    <td>{formatTokens(op.cache_creation_tokens ?? 0)}</td>
+                    <td>{formatTokens(op.cache_read_tokens ?? 0)}</td>
+                    <td>{formatTokens(op.output_tokens ?? 0)}</td>
+                    <td className={cacheCellClass(op.cache_hit_rate ?? 0)}>
+                      {formatPct(op.cache_hit_rate ?? 0)}
+                    </td>
+                    <td>{formatUsd(op.cost_usd, 4)}</td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </section>

--- a/dashboard/src/components/RealTimeTab.tsx
+++ b/dashboard/src/components/RealTimeTab.tsx
@@ -18,6 +18,7 @@ import {
   type ProjectFullSummary,
 } from '../services/costService';
 import AgentSpendBars from './AgentSpendBars';
+import OperationsPanel from './OperationsPanel';
 import './RealTimeTab.css';
 
 interface Props {
@@ -209,71 +210,11 @@ const RealTimeTab = ({ projectId, pollIntervalMs = 5000 }: Props) => {
         </div>
       </section>
 
-      {summary.by_operation.length > 0 && (
-        <section className="cost-panel">
-          <h3>
-            Tokens by operation{' '}
-            <small className="cost-panel-hint">
-              Sorted by total tokens — the heaviest call is the prompt-
-              tightening target. Low cache-hit % on a heavy row means
-              that operation isn't benefiting from the prompt cache.
-            </small>
-          </h3>
-          <table className="cost-table cost-table-dense">
-            <thead>
-              <tr>
-                <th>Operation</th>
-                <th>Calls</th>
-                <th>Input</th>
-                <th>Cache create</th>
-                <th>Cache read</th>
-                <th>Output</th>
-                <th>Cache %</th>
-                <th>Cost</th>
-              </tr>
-            </thead>
-            <tbody>
-              {summary.by_operation.map((op) => {
-                const entry = opCatalog[op.operation];
-                const label = entry?.label ?? op.operation;
-                const tooltip = entry
-                  ? `${entry.label} — ${entry.description}`
-                  : `Unregistered operation '${op.operation}'. ` +
-                    'Add it to Marcus operations.py for a description.';
-                return (
-                  <tr key={op.operation}>
-                    <td>
-                      <span
-                        className="cost-operation-label"
-                        title={tooltip}
-                      >
-                        {label}
-                      </span>
-                      {entry && (
-                        <span
-                          className={`cost-operation-cat cat-${entry.category}`}
-                          title={`Category: ${entry.category}`}
-                        >
-                          {entry.category}
-                        </span>
-                      )}
-                    </td>
-                    <td>{op.events}</td>
-                    <td>{formatTokens(op.input_tokens ?? 0)}</td>
-                    <td>{formatTokens(op.cache_creation_tokens ?? 0)}</td>
-                    <td>{formatTokens(op.cache_read_tokens ?? 0)}</td>
-                    <td>{formatTokens(op.output_tokens ?? 0)}</td>
-                    <td className={cacheCellClass(op.cache_hit_rate ?? 0)}>
-                      {formatPct(op.cache_hit_rate ?? 0)}
-                    </td>
-                    <td>{formatUsd(op.cost_usd, 4)}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </section>
-      )}
+      <OperationsPanel
+        operations={summary.by_operation}
+        catalog={opCatalog}
+      />
+
 
       {summary.by_model.length > 0 && (
         <section className="cost-panel">

--- a/dashboard/src/components/operationsPanel.logic.test.ts
+++ b/dashboard/src/components/operationsPanel.logic.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for OperationsPanel's pure logic.
+ *
+ * Kaia review on PR #39 flagged the panel's branching as
+ * uncovered. These tests exercise the helpers that don't require
+ * React or DOM: ``coldCacheScore``, ``pickColdOffender``, and
+ * ``bucketByCategory``. Run with ``npm test``.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+  OperationCatalogEntry,
+  OperationSlice,
+} from '../services/costService';
+import {
+  ALL_CATEGORIES,
+  bucketByCategory,
+  coldCacheScore,
+  pickColdOffender,
+} from './operationsPanel.logic';
+
+// -----------------------------------------------------------------
+// Test fixtures
+// -----------------------------------------------------------------
+
+function makeOp(over: Partial<OperationSlice>): OperationSlice {
+  return {
+    operation: 'decompose_prd',
+    events: 1,
+    tokens: 0,
+    input_tokens: 0,
+    cache_creation_tokens: 0,
+    cache_read_tokens: 0,
+    output_tokens: 0,
+    cache_hit_rate: 0,
+    cost_usd: 0,
+    ...over,
+  };
+}
+
+const CATALOG: Record<string, OperationCatalogEntry> = {
+  decompose_prd: {
+    label: 'Decompose PRD',
+    description: 'parses the PRD',
+    category: 'decomposition',
+  },
+  analyze_blocker: {
+    label: 'Analyze blocker',
+    description: 'reads a blocker report',
+    category: 'runtime',
+  },
+  validate_work: {
+    label: 'Validate work',
+    description: 'validates an agent submission',
+    category: 'monitoring',
+  },
+};
+
+// -----------------------------------------------------------------
+// coldCacheScore
+// -----------------------------------------------------------------
+
+describe('coldCacheScore', () => {
+  it('returns 0 when there are no creation tokens', () => {
+    expect(coldCacheScore(makeOp({ cache_creation_tokens: 0 }))).toBe(0);
+  });
+
+  it('returns 0 when hit rate is 100%', () => {
+    expect(
+      coldCacheScore(
+        makeOp({ cache_creation_tokens: 5000, cache_hit_rate: 1.0 }),
+      ),
+    ).toBe(0);
+  });
+
+  it('returns the full creation cost when hit rate is 0%', () => {
+    expect(
+      coldCacheScore(
+        makeOp({ cache_creation_tokens: 5000, cache_hit_rate: 0 }),
+      ),
+    ).toBe(5000);
+  });
+
+  it('scales linearly between extremes', () => {
+    expect(
+      coldCacheScore(
+        makeOp({ cache_creation_tokens: 10000, cache_hit_rate: 0.4 }),
+      ),
+    ).toBeCloseTo(6000, 5);
+  });
+
+  it('treats missing fields as zero', () => {
+    // OperationSlice fields are optional; the function must not blow
+    // up on rows from older API versions.
+    expect(coldCacheScore({ operation: 'x', events: 0, tokens: 0, cost_usd: 0 })).toBe(0);
+  });
+});
+
+// -----------------------------------------------------------------
+// pickColdOffender
+// -----------------------------------------------------------------
+
+describe('pickColdOffender', () => {
+  it('returns null when no operations exceed the threshold', () => {
+    const ops = [
+      makeOp({ operation: 'decompose_prd', cache_creation_tokens: 500 }),
+    ];
+    expect(pickColdOffender(ops, CATALOG)).toBeNull();
+  });
+
+  it('returns the highest-scoring registered operation above threshold', () => {
+    const ops = [
+      makeOp({
+        operation: 'decompose_prd',
+        cache_creation_tokens: 12000,
+        cache_hit_rate: 0,
+      }),
+      makeOp({
+        operation: 'analyze_blocker',
+        cache_creation_tokens: 5000,
+        cache_hit_rate: 0,
+      }),
+    ];
+    expect(pickColdOffender(ops, CATALOG)).toBe('decompose_prd');
+  });
+
+  it('skips unregistered (typo) operations even when they would win', () => {
+    // Kaia review on PR #39: a typo'd op with huge spend should not
+    // win the badge. The recorder already warned in logs; the UI
+    // doesn't double down on the typo.
+    const ops = [
+      makeOp({
+        operation: 'decopmose_prd', // typo — not in catalog
+        cache_creation_tokens: 100_000,
+        cache_hit_rate: 0,
+      }),
+      makeOp({
+        operation: 'analyze_blocker',
+        cache_creation_tokens: 5000,
+        cache_hit_rate: 0,
+      }),
+    ];
+    expect(pickColdOffender(ops, CATALOG)).toBe('analyze_blocker');
+  });
+
+  it('returns null when only unregistered operations are present', () => {
+    const ops = [
+      makeOp({
+        operation: 'totally_made_up',
+        cache_creation_tokens: 50_000,
+        cache_hit_rate: 0,
+      }),
+    ];
+    expect(pickColdOffender(ops, CATALOG)).toBeNull();
+  });
+
+  it('respects a custom threshold', () => {
+    const ops = [
+      makeOp({
+        operation: 'decompose_prd',
+        cache_creation_tokens: 500,
+        cache_hit_rate: 0,
+      }),
+    ];
+    // Score = 500. Default threshold (1000) excludes it; custom
+    // threshold of 100 admits it.
+    expect(pickColdOffender(ops, CATALOG)).toBeNull();
+    expect(pickColdOffender(ops, CATALOG, 100)).toBe('decompose_prd');
+  });
+
+  it('ignores hot-cache operations regardless of size', () => {
+    const ops = [
+      makeOp({
+        operation: 'decompose_prd',
+        cache_creation_tokens: 100_000,
+        cache_hit_rate: 1.0,
+      }),
+    ];
+    expect(pickColdOffender(ops, CATALOG)).toBeNull();
+  });
+});
+
+// -----------------------------------------------------------------
+// bucketByCategory
+// -----------------------------------------------------------------
+
+describe('bucketByCategory', () => {
+  it('returns an empty array when there are no operations', () => {
+    expect(bucketByCategory([], CATALOG)).toEqual([]);
+  });
+
+  it('groups registered operations into their declared categories', () => {
+    const ops = [
+      makeOp({ operation: 'decompose_prd', cost_usd: 1.0, tokens: 100 }),
+      makeOp({ operation: 'analyze_blocker', cost_usd: 0.5, tokens: 50 }),
+    ];
+    const groups = bucketByCategory(ops, CATALOG);
+    const map = Object.fromEntries(groups.map((g) => [g.category, g]));
+    expect(Object.keys(map).sort()).toEqual(
+      ['decomposition', 'runtime'].sort(),
+    );
+    expect(map.decomposition.ops).toHaveLength(1);
+    expect(map.runtime.ops).toHaveLength(1);
+  });
+
+  it('drops categories with zero operations', () => {
+    // Only one decomposition op; other three categories must not
+    // appear in the result.
+    const ops = [makeOp({ operation: 'decompose_prd' })];
+    const groups = bucketByCategory(ops, CATALOG);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].category).toBe('decomposition');
+  });
+
+  it("buckets unregistered operations into 'other'", () => {
+    const ops = [makeOp({ operation: 'totally_made_up_op' })];
+    const groups = bucketByCategory(ops, CATALOG);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].category).toBe('other');
+    expect(groups[0].ops[0].operation).toBe('totally_made_up_op');
+  });
+
+  it('aggregates cost / tokens / calls per group', () => {
+    const ops = [
+      makeOp({
+        operation: 'decompose_prd',
+        events: 3,
+        tokens: 1000,
+        cost_usd: 0.5,
+      }),
+      makeOp({
+        operation: 'decompose_prd',
+        events: 2,
+        tokens: 500,
+        cost_usd: 0.25,
+      }),
+    ];
+    const groups = bucketByCategory(ops, CATALOG);
+    expect(groups[0].totalCalls).toBe(5);
+    expect(groups[0].totalTokens).toBe(1500);
+    expect(groups[0].totalCost).toBeCloseTo(0.75, 5);
+  });
+
+  it('preserves the canonical category order for stable rendering', () => {
+    const ops = [
+      makeOp({ operation: 'validate_work' }), // monitoring
+      makeOp({ operation: 'decompose_prd' }), // decomposition
+      makeOp({ operation: 'analyze_blocker' }), // runtime
+    ];
+    const groups = bucketByCategory(ops, CATALOG);
+    // ``ALL_CATEGORIES`` defines decomposition → runtime → monitoring
+    // → other; groups must follow that order regardless of input
+    // order so the UI is deterministic across renders.
+    const observed = groups.map((g) => g.category);
+    const expected = ALL_CATEGORIES.filter((c) => observed.includes(c));
+    expect(observed).toEqual(expected);
+  });
+});

--- a/dashboard/src/components/operationsPanel.logic.ts
+++ b/dashboard/src/components/operationsPanel.logic.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure helpers for OperationsPanel — extracted for unit testability.
+ *
+ * Kaia review on PR #39 called out that the OperationsPanel's
+ * filter/collapse/cold-offender branching has real surface area and
+ * zero coverage. Cato's dashboard has Vitest configured but no
+ * React-Testing-Library setup; rather than introduce that just to
+ * test branching logic, we extract the pure functions (no React,
+ * no DOM) into this file and exercise them directly. The component
+ * keeps rendering responsibilities; this file owns the data
+ * transformations.
+ *
+ * Functions here intentionally take only the data they need — no
+ * Props or React state — so tests can construct inputs by hand
+ * without mocking the component tree.
+ */
+
+import type {
+  OperationCatalogEntry,
+  OperationSlice,
+} from '../services/costService';
+
+export type CategoryKey =
+  | 'decomposition'
+  | 'runtime'
+  | 'monitoring'
+  | 'other';
+
+export const ALL_CATEGORIES: CategoryKey[] = [
+  'decomposition',
+  'runtime',
+  'monitoring',
+  'other',
+];
+
+export const CATEGORY_LABELS: Record<CategoryKey, string> = {
+  decomposition: 'Decomposition',
+  runtime: 'Runtime',
+  monitoring: 'Monitoring',
+  other: 'Other',
+};
+
+export interface CategoryGroup {
+  category: CategoryKey;
+  ops: OperationSlice[];
+  totalCost: number;
+  totalTokens: number;
+  totalCalls: number;
+}
+
+/**
+ * Approximate the tokens we'd save by tightening the prompt of
+ * ``op`` so it hits the cache window on every call.
+ *
+ * The heuristic is ``cache_creation_tokens × (1 - cache_hit_rate)``:
+ * cache_creation_tokens captures how much we paid to set up the
+ * prompt cache, and ``1 - hit_rate`` captures how often that
+ * investment was wasted (i.e., a fresh creation rather than a hit).
+ * Higher score = more headroom for optimization.
+ */
+export function coldCacheScore(op: OperationSlice): number {
+  const creation = op.cache_creation_tokens ?? 0;
+  const rate = op.cache_hit_rate ?? 0;
+  return creation * (1 - rate);
+}
+
+/**
+ * Identify the single biggest cold-cache offender, or ``null``.
+ *
+ * Two gates:
+ * 1. Operations whose key isn't in ``catalog`` are skipped — Kaia
+ *    review on PR #39 called out that landing the 🔥 badge on a
+ *    typo'd operation just amplifies the typo. Marcus's recorder
+ *    already warns about unregistered keys in dev logs.
+ * 2. Score must exceed ``threshold`` (default 1000 tokens). Below
+ *    that, "biggest offender" is noise. The threshold is exposed
+ *    as an argument so tests can drive corner cases without
+ *    constructing absurdly large mock data.
+ *
+ * Returns the operation key of the worst offender, or ``null``
+ * when nothing meets the threshold.
+ */
+export function pickColdOffender(
+  operations: OperationSlice[],
+  catalog: Record<string, OperationCatalogEntry>,
+  threshold = 1000,
+): string | null {
+  let bestKey: string | null = null;
+  let bestScore = 0;
+  for (const op of operations) {
+    if (catalog[op.operation] == null) continue;
+    const score = coldCacheScore(op);
+    if (score > bestScore && score > threshold) {
+      bestScore = score;
+      bestKey = op.operation;
+    }
+  }
+  return bestKey;
+}
+
+/**
+ * Group operations by their catalog category, computing per-group
+ * aggregates and dropping empty buckets.
+ *
+ * Operations whose key is not in the catalog fall into the
+ * ``'other'`` bucket so they remain visible in the dashboard. The
+ * recorder logs a WARNING for those (see Marcus
+ * ``cost_recorder.py``), making the gap discoverable.
+ */
+export function bucketByCategory(
+  operations: OperationSlice[],
+  catalog: Record<string, OperationCatalogEntry>,
+): CategoryGroup[] {
+  const buckets: Record<CategoryKey, OperationSlice[]> = {
+    decomposition: [],
+    runtime: [],
+    monitoring: [],
+    other: [],
+  };
+  for (const op of operations) {
+    const cat =
+      (catalog[op.operation]?.category as CategoryKey | undefined) ?? 'other';
+    buckets[cat].push(op);
+  }
+  return ALL_CATEGORIES.map((cat) => {
+    const ops = buckets[cat];
+    return {
+      category: cat,
+      ops,
+      totalCost: ops.reduce((s, o) => s + o.cost_usd, 0),
+      totalTokens: ops.reduce((s, o) => s + o.tokens, 0),
+      totalCalls: ops.reduce((s, o) => s + o.events, 0),
+    };
+  }).filter((g) => g.ops.length > 0);
+}

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -263,6 +263,39 @@ export async function fetchProjectFullSummary(
 }
 
 // ---------------------------------------------------------------------------
+// Operation taxonomy (per-LLM-call drill-down labels + descriptions)
+// ---------------------------------------------------------------------------
+
+/**
+ * One entry in the operation catalog returned by ``/api/cost/operations``.
+ *
+ * Sourced from Marcus's ``src/cost_tracking/operations.py``. The
+ * dashboard joins ``OperationSlice.operation`` keys against this
+ * mapping to render hover-tooltips that explain what each LLM call
+ * does and why it spent tokens.
+ */
+export interface OperationCatalogEntry {
+  label: string;
+  description: string;
+  category: 'decomposition' | 'runtime' | 'monitoring' | 'other';
+}
+
+export interface OperationCatalog {
+  operations: Record<string, OperationCatalogEntry>;
+}
+
+/**
+ * Fetch the operation taxonomy once on page load.
+ *
+ * Older Marcus checkouts may not ship the operations module — in
+ * that case the endpoint returns ``{operations: {}}`` and the UI
+ * falls back to the raw operation key as the label.
+ */
+export async function fetchOperationCatalog(): Promise<OperationCatalog> {
+  return _get('/api/cost/operations');
+}
+
+// ---------------------------------------------------------------------------
 // Project budget caps
 // ---------------------------------------------------------------------------
 

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -510,6 +510,38 @@ class TestSessionTurns:
 
 
 # ---------------------------------------------------------------------------
+# /api/cost/operations
+# ---------------------------------------------------------------------------
+
+
+@requires_marcus
+class TestOperationsTaxonomy:
+    """``GET /api/cost/operations`` exposes the Marcus operation catalog.
+
+    The dashboard reads this once on load to populate per-event
+    tooltips that explain what each LLM call does.
+    """
+
+    def test_returns_known_operations(self, client: TestClient) -> None:
+        """Catalog includes the well-known keys used by call sites."""
+        resp = client.get("/api/cost/operations")
+        assert resp.status_code == 200
+        ops = resp.json()["operations"]
+        # Spot-check a handful of high-traffic operations
+        for key in ("decompose_prd", "analyze_blocker", "extract_outcomes"):
+            assert key in ops, f"missing {key} from taxonomy"
+            entry = ops[key]
+            assert entry["label"]
+            assert entry["description"]
+            assert entry["category"] in {
+                "decomposition",
+                "runtime",
+                "monitoring",
+                "other",
+            }
+
+
+# ---------------------------------------------------------------------------
 # /api/cost/prices  (GET + POST)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds per-LLM-call drill-down so users see *what* the planner spent tokens on. Paired with Marcus PR https://github.com/lwgray/marcus/pull/517 which tags every planner LLM call with an operation key and exposes a catalog of human descriptions.

Before: the Real-time tab's "Tokens by operation" panel showed raw keys like `analyze` for everything. After: 23 distinct operations grouped by category, with hover-tooltips explaining what each call does, filter pills, collapsible category groups, and a 🔥 badge on the biggest prompt-tightening target.

## What's in here

**Commit 1 — Initial implementation (`efece48`)**
- `GET /api/cost/operations` endpoint exposes the catalog (`label / description / category`) sourced from `src.cost_tracking.operations` in Marcus. Returns `{"operations": {}}` when Marcus is older and lacks the module.
- `fetchOperationCatalog` service helper.
- `RealTimeTab` loads the catalog once on mount and renders each `by_operation` row with the human label, a hover tooltip (catalog description), and a category chip.
- `TestOperationsTaxonomy` spot-checks that well-known keys round-trip from Marcus through the API.

**Commit 2 — Kaia review fixes (`f717763`)**
- **P1 NameError fix.** `_marcus_all_operations` is now initialized at module scope alongside the other CostStore placeholders. Previously it was only bound inside the discovery-success branch, so if Marcus discovery failed entirely, the endpoint would 500 with `NameError` instead of returning the documented empty fallback.
- **Extracted `OperationsPanel` component** from `RealTimeTab` so the drill-down has room to grow.
- **Filter pills** above the table toggle whole categories on/off. Default: all on. Each pill shows the op count and uses category-specific colors.
- **Collapsible category groups** with per-category aggregates (op count, calls, tokens, cost) so the panel stays scannable past 40 operations. Click the header to expand/collapse.
- **🔥 cold-cache offender badge** on the single row with the highest `cache_creation_tokens × (1 - cache_hit_rate)`, gated at 1k tokens so noise doesn't trigger it. Tooltip explains the heuristic. The whole row gets a subtle warning tint.
- CSS for filter pills, group headers, chevrons, and category-colored borders/labels.

## Test plan

- [x] `pytest tests/test_cost_api.py -q` — 24 passed
- [x] `mypy backend/cost_routes.py` — 0 errors
- [x] `tsc --noEmit` on dashboard — exit 0
- [x] Move `src/cost_tracking/operations.py` aside on the Marcus side → endpoint returns `200` + `{"operations": {}}` (no 500, no `NameError`)
- [ ] Visual check post-merge: filter pills toggle correctly, category groups collapse/expand, 🔥 badge appears on the heaviest cold-cache row, hover tooltips render Marcus's description text

🤖 Generated with [Claude Code](https://claude.com/claude-code)