### PR TITLE
refactor(cost): mirror Marcus runs/path rename (Marcus #409)

### DIFF
--- a/backend/cost_ingest.py
+++ b/backend/cost_ingest.py
@@ -111,10 +111,11 @@ def resolve_binding_from_cwd(record: Dict[str, Any]) -> Optional["AgentBinding"]
 
     return AgentBinding(
         agent_id=cwd.name,
-        # experiment_id is an MLflow handle; we don't have it from
-        # project_info.json, so leave it 'unassigned'. The project_id
-        # is what the dashboard joins on.
-        experiment_id="unassigned",
+        # run_id isn't recorded in project_info.json, so leave it
+        # 'unassigned'. The project_id is what the dashboard joins
+        # on. Renamed from experiment_id alongside Marcus's
+        # ``runs`` table rename (Simon ``7ed3074d``).
+        run_id="unassigned",
         project_id=str(project_id),
     )
 

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -9,13 +9,20 @@ in ``backend/api.py``.
 
 Endpoints
 ---------
-- ``GET  /api/cost/experiments`` — list experiments with totals
-- ``GET  /api/cost/experiments/{exp_id}`` — full per-experiment breakdown
-- ``GET  /api/cost/projects/{project_id}`` — project rollup + experiments
+- ``GET  /api/cost/runs`` — list runs with totals
+- ``GET  /api/cost/runs/{run_id}`` — full per-run breakdown
+- ``GET  /api/cost/projects/{project_id}`` — project rollup + runs
 - ``GET  /api/cost/sessions/{session_id}/turns`` — per-turn trajectory
 - ``GET  /api/cost/prices`` — current pricing table (latest per model)
 - ``POST /api/cost/prices`` — insert a new price row (versioned by ``effective_from``)
-- ``GET  /api/cost/export/{exp_id}`` — CSV export of all events
+- ``GET  /api/cost/export/{run_id}`` — CSV export of all events
+
+Terminology note
+----------------
+Endpoints renamed from ``/experiments`` → ``/runs`` in coordination
+with Marcus's ``experiment_id`` → ``run_id`` rename. The MLflow
+experiment concept is unrelated and stays where it lives in
+Marcus's ``start_experiment`` MCP tool.
 """
 
 from __future__ import annotations
@@ -363,13 +370,18 @@ def unassigned_totals(
     return totals
 
 
-@router.get("/experiments")  # type: ignore[misc]
-def list_experiments(
+@router.get("/runs")  # type: ignore[misc]
+def list_runs(
     project_id: Optional[str] = Query(None),
     limit: int = Query(100, ge=1, le=1000),
     aggregator: Any = Depends(get_aggregator),
 ) -> Dict[str, Any]:
-    """List experiments with token + cost totals attached.
+    """List runs with token + cost totals attached.
+
+    Renamed from ``/experiments`` in coordination with the Marcus
+    rename (Simon ``7ed3074d``). The legacy ``experiment`` term
+    clashed with MLflow's separate concept; ``run`` accurately
+    describes a single project traversal.
 
     Parameters
     ----------
@@ -378,28 +390,30 @@ def list_experiments(
     limit : int
         Cap at 1000. Default 100.
     """
-    rows = aggregator.list_experiments(project_id=project_id, limit=limit)
-    return {"experiments": rows, "count": len(rows)}
+    rows = aggregator.list_runs(project_id=project_id, limit=limit)
+    return {"runs": rows, "count": len(rows)}
 
 
-@router.get("/experiments/{experiment_id}")  # type: ignore[misc]
-def experiment_summary(
-    experiment_id: str,
+@router.get("/runs/{run_id}")  # type: ignore[misc]
+def run_summary(
+    run_id: str,
     aggregator: Any = Depends(get_aggregator),
 ) -> Dict[str, Any]:
-    """Full per-experiment breakdown (summary + by_role / agent / task / etc.).
+    """Full per-run breakdown (summary + by_role / agent / task / etc.).
 
     Returns the exact dict shape documented in Marcus #409. Cato's
     frontend renders the result without further transformation.
 
+    Renamed from ``/experiments/{experiment_id}``.
+
     Raises
     ------
     HTTPException
-        404 if the experiment does not exist.
+        404 if the run does not exist.
     """
-    summary: Optional[Dict[str, Any]] = aggregator.experiment_summary(experiment_id)
+    summary: Optional[Dict[str, Any]] = aggregator.run_summary(run_id)
     if summary is None:
-        raise HTTPException(status_code=404, detail="experiment not found")
+        raise HTTPException(status_code=404, detail="run not found")
     return summary
 
 
@@ -409,7 +423,7 @@ def project_summary(
     aggregator: Any = Depends(get_aggregator),
     store: Any = Depends(get_store),
 ) -> Dict[str, Any]:
-    """Project rollup + list of experiment summaries.
+    """Project rollup + list of run summaries.
 
     Legacy thin shape kept for backwards compatibility with the old
     project picker; the project-first dashboard tabs use
@@ -420,7 +434,7 @@ def project_summary(
         "project_id": project_id,
         "project_name": names.get(project_id),
         "totals": aggregator.project_totals(project_id),
-        "experiments": aggregator.list_experiments(project_id=project_id),
+        "runs": aggregator.list_runs(project_id=project_id),
     }
 
 
@@ -639,12 +653,12 @@ def create_price(
 # -- export ------------------------------------------------------------------
 
 
-@router.get("/export/{experiment_id}")  # type: ignore[misc]
-def export_experiment_csv(
-    experiment_id: str,
+@router.get("/export/{run_id}")  # type: ignore[misc]
+def export_run_csv(
+    run_id: str,
     store: Any = Depends(get_store),
 ) -> StreamingResponse:
-    """CSV export of every ``token_events`` row for one experiment."""
+    """CSV export of every ``token_events`` row for one run."""
     cursor = store.conn.execute(
         """
         SELECT event_id, timestamp, agent_id, agent_role, operation,
@@ -652,10 +666,10 @@ def export_experiment_csv(
                input_tokens, cache_creation_tokens, cache_read_tokens,
                output_tokens, total_tokens, cost_usd, request_id, status
         FROM v_event_cost
-        WHERE experiment_id = ?
+        WHERE run_id = ?
         ORDER BY timestamp, event_id
         """,
-        (experiment_id,),
+        (run_id,),
     )
     headers = [d[0] for d in cursor.description]
     buf = io.StringIO()
@@ -667,7 +681,5 @@ def export_experiment_csv(
     return StreamingResponse(
         iter([buf.getvalue()]),
         media_type="text/csv",
-        headers={
-            "Content-Disposition": (f'attachment; filename="cost_{experiment_id}.csv"')
-        },
+        headers={"Content-Disposition": (f'attachment; filename="cost_{run_id}.csv"')},
     )

--- a/dashboard/src/components/CostTimeSeries.tsx
+++ b/dashboard/src/components/CostTimeSeries.tsx
@@ -1,21 +1,22 @@
 /**
- * Per-experiment cost time series.
+ * Per-run cost time series.
  *
- * Renders one bar per experiment along an absolute time axis (started_at).
- * Bars are colored by project so multi-project history is legible at a
- * glance. Used by the Historical tab.
+ * Renders one bar per run along an absolute time axis (started_at).
+ * Bars are colored by project so multi-project history is legible at
+ * a glance. Used by the Historical tab. Renamed from
+ * "per-experiment" in coordination with Marcus's ``runs`` rename.
  */
 
 import { useMemo } from 'react';
 import * as d3 from 'd3';
-import type { ExperimentRow } from '../services/costService';
+import type { RunRow } from '../services/costService';
 import './CostTimeSeries.css';
 
 interface Props {
-  experiments: ExperimentRow[];
+  runs: RunRow[];
   width?: number;
   height?: number;
-  onSelect?: (experimentId: string) => void;
+  onSelect?: (runId: string) => void;
 }
 
 const MARGIN = { top: 16, right: 16, bottom: 40, left: 56 };
@@ -26,7 +27,7 @@ function formatUsd(v: number): string {
 }
 
 const CostTimeSeries = ({
-  experiments,
+  runs,
   width = 800,
   height = 260,
   onSelect,
@@ -36,13 +37,13 @@ const CostTimeSeries = ({
 
   const parsed = useMemo(
     () =>
-      experiments
+      runs
         .map((e) => ({
           ...e,
           ts: new Date(e.started_at).getTime(),
         }))
         .sort((a, b) => a.ts - b.ts),
-    [experiments],
+    [runs],
   );
 
   const xScale = useMemo(() => {
@@ -67,7 +68,7 @@ const CostTimeSeries = ({
   if (parsed.length === 0) {
     return (
       <div className="cost-timeseries-empty">
-        No experiments to chart yet.
+        No runs to chart yet.
       </div>
     );
   }
@@ -106,9 +107,9 @@ const CostTimeSeries = ({
           const barH = innerH - y;
           return (
             <g
-              key={d.experiment_id}
+              key={d.run_id}
               transform={`translate(${x - barW / 2},${y})`}
-              onClick={() => onSelect?.(d.experiment_id)}
+              onClick={() => onSelect?.(d.run_id)}
               style={{ cursor: onSelect ? 'pointer' : 'default' }}
               className="bar-group"
             >
@@ -120,7 +121,7 @@ const CostTimeSeries = ({
                 rx={2}
               >
                 <title>
-                  {d.project_name ?? d.experiment_id}
+                  {d.project_name ?? d.run_id}
                   {'\n'}
                   {new Date(d.ts).toLocaleString()}
                   {'\n'}

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -12,10 +12,18 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:4301';
 // Response types
 // ---------------------------------------------------------------------------
 
-export interface ExperimentRow {
-  experiment_id: string;
+export interface RunRow {
+  run_id: string;
   project_id: string;
   project_name: string | null;
+  /**
+   * Entry point that produced this run. ``'direct'`` for human MCP
+   * users, ``'marcus'`` for ``/marcus`` runs, ``'posidonius'`` for
+   * Posidonius automated trials, ``'unknown'`` for legacy rows.
+   * Renamed from the old ExperimentRow shape in coordination with
+   * Marcus's ``experiments`` → ``runs`` rename.
+   */
+  path: string;
   started_at: string;
   ended_at: string | null;
   num_agents: number | null;
@@ -82,8 +90,8 @@ export interface ModelSlice {
   cost_usd: number;
 }
 
-export interface ExperimentSummary {
-  experiment_id: string;
+export interface RunSummary {
+  run_id: string;
   project_id: string;
   project_name: string | null;
   started_at: string;
@@ -129,25 +137,29 @@ async function _get<T>(path: string): Promise<T> {
 }
 
 /**
- * List experiments with token + cost totals attached.
+ * List runs with token + cost totals attached.
+ *
+ * Renamed from ``fetchExperiments`` in coordination with Marcus's
+ * ``runs`` table rename (Simon ``7ed3074d``); the term "experiment"
+ * was colliding with MLflow's separate concept.
  *
  * @param projectId Optional project filter.
  * @param limit Cap at 1000. Default 100.
  */
-export async function fetchExperiments(
+export async function fetchRuns(
   projectId?: string,
   limit = 100,
-): Promise<{ experiments: ExperimentRow[]; count: number }> {
+): Promise<{ runs: RunRow[]; count: number }> {
   const params = new URLSearchParams({ limit: String(limit) });
   if (projectId) params.set('project_id', projectId);
-  return _get(`/api/cost/experiments?${params}`);
+  return _get(`/api/cost/runs?${params}`);
 }
 
-/** Full per-experiment breakdown (summary + by_role / agent / task / etc.). */
-export async function fetchExperimentSummary(
-  experimentId: string,
-): Promise<ExperimentSummary> {
-  return _get(`/api/cost/experiments/${encodeURIComponent(experimentId)}`);
+/** Full per-run breakdown (summary + by_role / agent / task / etc.). */
+export async function fetchRunSummary(
+  runId: string,
+): Promise<RunSummary> {
+  return _get(`/api/cost/runs/${encodeURIComponent(runId)}`);
 }
 
 /** Per-turn cost trajectory for one Claude Code session. */
@@ -165,17 +177,14 @@ export interface ProjectRow {
   project_id: string;
   /**
    * Human-readable name. Resolved in order of preference:
-   * 1. experiments.project_name (set explicitly via start_experiment)
+   * 1. runs.project_name (the wrapper-recorded primary run)
    * 2. Marcus's project registry (data/marcus_state/projects.json),
    *    which is the same source the regular Cato projects panel uses
    * 3. NULL — picker falls back to a truncated project_id
-   *
-   * Most Marcus runs never open an MLflow experiment, so #2 is the
-   * usual source.
    */
   project_name: string | null;
   events: number;
-  experiments: number;
+  runs: number;
   agents: number;
   total_tokens: number;
   total_cost_usd: number;
@@ -192,12 +201,12 @@ export interface UnassignedTotals {
 export interface ProjectSummary {
   project_id: string;
   totals: {
-    experiments: number;
+    runs: number;
     events: number;
     total_tokens: number;
     total_cost_usd: number;
   };
-  experiments: ExperimentRow[];
+  runs: RunRow[];
 }
 
 /** List projects with cost rollups (primary picker for the dashboard). */
@@ -223,18 +232,17 @@ export async function fetchProjectSummary(
  * Full per-project breakdown — drives the Real-time / Historical /
  * Budget tabs in the project-first dashboard.
  *
- * Same shape as :func:`fetchExperimentSummary` but scoped to project_id,
- * which is the only universal identity in Marcus's coordination model
- * (Marcus #503). Marcus runs that never opened an MLflow experiment
- * still have project_id on every event, so this is the universal
- * surface for cost data.
+ * Same shape as :func:`fetchRunSummary` but scoped to project_id,
+ * which is the only universal identity in Marcus's coordination
+ * model (Marcus #503). Every cost event carries a project_id, so
+ * this is the universal surface for cost data.
  */
 export interface ProjectFullSummary {
   project_id: string;
   project_name: string | null;
   summary: {
     total_events: number;
-    experiments: number;
+    runs: number;
     agents: number;
     sessions: number;
     total_tokens: number;

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -40,8 +40,8 @@ def store(tmp_path: Path) -> Any:
     """Tmp CostStore seeded with one Anthropic price and a few events."""
     from src.cost_tracking.cost_store import (
         CostStore,
-        Experiment,
         ModelPrice,
+        Run,
         TokenEvent,
     )
 
@@ -58,9 +58,9 @@ def store(tmp_path: Path) -> Any:
             source="default",
         )
     )
-    s.record_experiment(
-        Experiment(
-            experiment_id="exp_1",
+    s.record_run(
+        Run(
+            run_id="exp_1",
             project_id="proj_1",
             project_name="hangman",
             started_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
@@ -70,7 +70,7 @@ def store(tmp_path: Path) -> Any:
         )
     )
     base = dict(
-        experiment_id="exp_1",
+        run_id="exp_1",
         project_id="proj_1",
         provider="anthropic",
         model="claude-sonnet-4-6",
@@ -132,7 +132,7 @@ def client(store: Any) -> TestClient:
 
 
 # ---------------------------------------------------------------------------
-# /api/cost/experiments
+# /api/cost/runs
 # ---------------------------------------------------------------------------
 
 
@@ -160,7 +160,7 @@ class TestProjectsList:
 
         store.record_event(
             TokenEvent(
-                experiment_id="unassigned",
+                run_id="unassigned",
                 project_id="unassigned",
                 agent_id="planner",
                 agent_role="planner",
@@ -194,7 +194,7 @@ class TestUnassignedTotals:
 
         store.record_event(
             TokenEvent(
-                experiment_id="unassigned",
+                run_id="unassigned",
                 project_id="unassigned",
                 agent_id="planner",
                 agent_role="planner",
@@ -213,34 +213,33 @@ class TestUnassignedTotals:
 
 
 @requires_marcus
-class TestExperimentsList:
-    def test_lists_experiments(self, client: TestClient) -> None:
-        """Endpoint returns the seeded experiment with totals."""
-        resp = client.get("/api/cost/experiments")
+class TestRunsList:
+    def test_lists_runs(self, client: TestClient) -> None:
+        """Endpoint returns the seeded run with totals."""
+        resp = client.get("/api/cost/runs")
         assert resp.status_code == 200
         body = resp.json()
         assert body["count"] == 1
-        assert body["experiments"][0]["experiment_id"] == "exp_1"
+        assert body["runs"][0]["run_id"] == "exp_1"
         assert (
-            body["experiments"][0]["total_tokens"]
-            == 1000 + 500 + 2000 + 500 + 100 + 300 + 50
+            body["runs"][0]["total_tokens"] == 1000 + 500 + 2000 + 500 + 100 + 300 + 50
         )
 
     def test_filter_by_project(self, client: TestClient) -> None:
         """Unknown project returns empty list, not 404."""
-        resp = client.get("/api/cost/experiments?project_id=nope")
+        resp = client.get("/api/cost/runs?project_id=nope")
         assert resp.status_code == 200
         assert resp.json()["count"] == 0
 
 
 @requires_marcus
-class TestExperimentSummary:
+class TestRunSummary:
     def test_returns_full_breakdown(self, client: TestClient) -> None:
-        """Endpoint returns the same shape as CostAggregator.experiment_summary."""
-        resp = client.get("/api/cost/experiments/exp_1")
+        """Endpoint returns the same shape as CostAggregator.run_summary."""
+        resp = client.get("/api/cost/runs/exp_1")
         assert resp.status_code == 200
         body = resp.json()
-        assert body["experiment_id"] == "exp_1"
+        assert body["run_id"] == "exp_1"
         assert {
             "summary",
             "by_role",
@@ -251,21 +250,21 @@ class TestExperimentSummary:
         } <= set(body.keys())
 
     def test_unknown_returns_404(self, client: TestClient) -> None:
-        """Missing experiment_id yields a 404."""
-        resp = client.get("/api/cost/experiments/nope")
+        """Missing run_id yields a 404."""
+        resp = client.get("/api/cost/runs/nope")
         assert resp.status_code == 404
 
 
 @requires_marcus
 class TestProjectSummary:
     def test_returns_project_totals(self, client: TestClient) -> None:
-        """Project endpoint returns totals + experiments list."""
+        """Project endpoint returns totals + runs list."""
         resp = client.get("/api/cost/projects/proj_1")
         assert resp.status_code == 200
         body = resp.json()
         assert body["project_id"] == "proj_1"
         assert body["totals"]["events"] == 3
-        assert len(body["experiments"]) == 1
+        assert len(body["runs"]) == 1
 
 
 @requires_marcus
@@ -360,7 +359,7 @@ class TestProjectNameEnrichment:
 
         store.record_event(
             TokenEvent(
-                experiment_id="exp_orphan",
+                run_id="exp_orphan",
                 project_id="proj_no_mlflow",
                 agent_id="planner",
                 agent_role="planner",
@@ -418,7 +417,7 @@ class TestProjectNameEnrichment:
         # registry.
         store.record_event(
             TokenEvent(
-                experiment_id="exp_snap",
+                run_id="exp_snap",
                 project_id="snap_proj",
                 agent_id="planner",
                 agent_role="planner",


### PR DESCRIPTION
## Summary
Companion to Marcus PR for renaming `experiments` → `runs` and adding the `path` discriminator. Ships atomically with Marcus — no backward-compat aliases.

## Backend
- `/api/cost/experiments` → `/api/cost/runs`
- `/api/cost/experiments/{id}` → `/api/cost/runs/{id}`
- `/api/cost/export/{id}` (id is now `run_id`)
- `list_experiments` → `list_runs`; `experiment_summary` → `run_summary`; `export_experiment_csv` → `export_run_csv`
- Response key `experiments` → `runs` (project payload)
- `AgentBinding.experiment_id` → `run_id` in `cost_ingest`

## Frontend
- TS types: `ExperimentRow` → `RunRow` (with new `path: string`), `ExperimentSummary` → `RunSummary`
- Services: `fetchExperiments` → `fetchRuns`, `fetchExperimentSummary` → `fetchRunSummary`
- `ProjectRow.experiments` → `.runs`; `ProjectSummary.experiments` → `.runs`; `ProjectFullSummary.summary.experiments` → `.runs`
- `CostTimeSeries` prop `experiments` → `runs`; internal `experimentId` → `runId`; all `experiment_id` references → `run_id`

## Test plan
- [x] `pytest tests/test_cost_api.py` (24 pass)
- [x] `npm run test` in `dashboard/` (17 vitest pass)
- [x] `tsc --noEmit` clean

## Coordination
Marcus PR: lwgray/marcus#522 — must merge together to avoid schema/API skew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)