### PR TITLE
Release v0.3.3

### DIFF
--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   version-check:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,10 @@ minimum compatible Marcus version.
 
 ## [Unreleased]
 
-## [0.3.2] - 2026-05-17
+## [0.3.3] - 2026-05-17
 
 Adds the cost dashboard — a full per-project / per-task / per-tool view of
-Marcus token spend — alongside three regression fixes from the v0.3.1
-project-scoped fast path.
+Marcus token spend.
 
 ### Added
 - **Cost dashboard.** New `/api/cost/*` endpoints backed by Marcus, with a
@@ -32,6 +31,12 @@ project-scoped fast path.
 - Aggregator mirrors Marcus's runs/path rename.
 - Worker JSONL ingestion wired through; pricing UX cleanup.
 - Dashboard dev server moved to port 5847 with auto-bump.
+
+## [0.3.2] - 2026-05-07
+
+Three regressions from the v0.3.1 project-scoped fast path. All showed up as
+DAG/Board nodes being absent at project start and only "appearing" once an
+agent worked on them.
 
 ### Fixed
 - **Hex-Planka projects load all parents from creation time.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,28 @@ minimum compatible Marcus version.
 
 ## [Unreleased]
 
-## [0.3.2] - 2026-05-07
+## [0.3.2] - 2026-05-17
 
-Three regressions from the v0.3.1 project-scoped fast path. All showed up as
-DAG/Board nodes being absent at project start and only "appearing" once an
-agent worked on them.
+Adds the cost dashboard — a full per-project / per-task / per-tool view of
+Marcus token spend — alongside three regression fixes from the v0.3.1
+project-scoped fast path.
+
+### Added
+- **Cost dashboard.** New `/api/cost/*` endpoints backed by Marcus, with a
+  real-time cost tab and Historical / Budget / Pricing tabs.
+- Project-first dashboard layout with project as the primary axis across the
+  API and UI; unified project picker; Historical and Pricing surfaced in
+  Settings.
+- Per-task and per-tool cost audit views; operation-taxonomy drill-down in the
+  Real-time tab.
+- Subtask timing rolls up onto auto-completed parent tasks.
+- Show Subtasks / Parents / All toggle on graph views.
+- Persistent project names and global CSS theme tokens.
+
+### Changed
+- Aggregator mirrors Marcus's runs/path rename.
+- Worker JSONL ingestion wired through; pricing UX cleanup.
+- Dashboard dev server moved to port 5847 with auto-bump.
 
 ### Fixed
 - **Hex-Planka projects load all parents from creation time.**

--- a/backend/api.py
+++ b/backend/api.py
@@ -147,6 +147,13 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Cost-tracking router (Marcus issue #409). Imports Marcus's CostStore /
+# CostAggregator directly via cost_routes; available iff Marcus is on
+# sys.path with src/cost_tracking present.
+from backend.cost_routes import router as cost_router  # noqa: E402
+
+app.include_router(cost_router)
+
 # Initialize aggregator for snapshot API — multi-root if configured
 aggregator = (
     Aggregator(

--- a/backend/cost_ingest.py
+++ b/backend/cost_ingest.py
@@ -111,10 +111,11 @@ def resolve_binding_from_cwd(record: Dict[str, Any]) -> Optional["AgentBinding"]
 
     return AgentBinding(
         agent_id=cwd.name,
-        # experiment_id is an MLflow handle; we don't have it from
-        # project_info.json, so leave it 'unassigned'. The project_id
-        # is what the dashboard joins on.
-        experiment_id="unassigned",
+        # run_id isn't recorded in project_info.json, so leave it
+        # 'unassigned'. The project_id is what the dashboard joins
+        # on. Renamed from experiment_id alongside Marcus's
+        # ``runs`` table rename (Simon ``7ed3074d``).
+        run_id="unassigned",
         project_id=str(project_id),
     )
 

--- a/backend/cost_ingest.py
+++ b/backend/cost_ingest.py
@@ -1,0 +1,191 @@
+"""
+Worker JSONL ingestion driver for the Cato cost dashboard.
+
+The Marcus side (``src/cost_tracking/worker_ingester.py``) provides the
+:class:`WorkerJSONLIngester` library — it knows how to read a Claude
+Code session JSONL file and write ``token_events`` rows. What it doesn't
+know is **how to map a session JSONL record to a ``project_id``** —
+that's experiment-specific glue. This module supplies that glue.
+
+Binding resolution
+------------------
+Each Claude Code session record carries a ``cwd`` field — the working
+directory of the worker subprocess. Marcus's spawn_agents.py creates a
+worktree per agent at::
+
+    <experiment_dir>/worktrees/<agent_id>
+
+…and writes the project's metadata to ``<experiment_dir>/project_info.json``
+before spawning workers. The resolver here walks up two levels from
+``cwd``, reads ``project_info.json``, and emits an
+:class:`AgentBinding`.
+
+Sessions whose cwd doesn't match this layout (project-creator agents,
+monitor agents, ad-hoc Claude Code sessions in unrelated dirs) return
+``None`` from the resolver and are correctly dropped — they aren't part
+of any experiment Cato should attribute cost to.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from src.cost_tracking.worker_ingester import AgentBinding
+
+
+# ---------------------------------------------------------------------------
+# Binding resolution
+# ---------------------------------------------------------------------------
+
+
+def _read_project_info(experiment_dir: str) -> Optional[Dict[str, Any]]:
+    """Read ``project_info.json`` from an experiment directory.
+
+    Reads from disk every call. An earlier ``lru_cache`` here returned
+    stale data when a user re-ran an experiment in the same directory
+    with a different ``project_id``, since the cache had process
+    lifetime. Disk hits are cheap (small JSON, OS page cache) and
+    correctness matters more than the saved syscalls.
+
+    Returns
+    -------
+    dict or None
+        Parsed JSON when the file exists and is valid, else None.
+    """
+    path = Path(experiment_dir) / "project_info.json"
+    if not path.exists():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            return data
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("project_info.json unreadable at %s: %s", path, exc)
+        return None
+
+
+def resolve_binding_from_cwd(record: Dict[str, Any]) -> Optional["AgentBinding"]:
+    """Map a Claude Code JSONL record to an :class:`AgentBinding`.
+
+    Walks the ``cwd`` field two levels up (past ``worktrees/<agent_id>``)
+    to find the experiment directory, reads ``project_info.json`` from
+    there to get the ``project_id``, and uses the cwd's basename as the
+    ``agent_id``.
+
+    Returns
+    -------
+    AgentBinding or None
+        ``None`` when the cwd doesn't match the expected layout (e.g.
+        project-creator agents working in the experiment root, monitor
+        agents, or unrelated Claude Code sessions). The caller drops
+        such records.
+    """
+    from src.cost_tracking.worker_ingester import AgentBinding
+
+    cwd_raw = record.get("cwd")
+    if not isinstance(cwd_raw, str) or not cwd_raw:
+        return None
+
+    cwd = Path(cwd_raw)
+    # Expected layout: <experiment_dir>/worktrees/<agent_id>
+    # So parent should be named 'worktrees' and grandparent is the exp dir.
+    if cwd.parent.name != "worktrees":
+        return None
+
+    experiment_dir = cwd.parent.parent
+    info = _read_project_info(str(experiment_dir))
+    if info is None:
+        return None
+
+    project_id = info.get("project_id")
+    if not project_id:
+        return None
+
+    return AgentBinding(
+        agent_id=cwd.name,
+        # experiment_id is an MLflow handle; we don't have it from
+        # project_info.json, so leave it 'unassigned'. The project_id
+        # is what the dashboard joins on.
+        experiment_id="unassigned",
+        project_id=str(project_id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ingestion driver
+# ---------------------------------------------------------------------------
+
+
+def run_ingest(store: Any) -> Dict[str, Any]:
+    """Sweep ``~/.claude/projects/`` and ingest every session JSONL.
+
+    Idempotent — :class:`WorkerJSONLIngester` dedupes by record UUID
+    within a single process. Re-running the sweep on the same files
+    inserts only records added since the last sweep.
+
+    Parameters
+    ----------
+    store : CostStore
+        Marcus's cost store to write events into.
+
+    Returns
+    -------
+    dict
+        ``{ingested: int, files: int, skipped_unbound: int}`` where
+        ``ingested`` counts new ``token_events`` rows, ``files`` the
+        number of JSONL files scanned, and ``skipped_unbound`` is the
+        number of sessions whose cwd didn't resolve (project-creators,
+        monitors, ad-hoc sessions outside the experiment layout).
+    """
+    from src.cost_tracking.worker_ingester import WorkerJSONLIngester
+
+    base = Path.home() / ".claude" / "projects"
+    if not base.exists():
+        return {"ingested": 0, "files": 0, "skipped_unbound": 0}
+
+    skipped_unbound = 0
+
+    def _wrap_resolver(record: Dict[str, Any]) -> Optional["AgentBinding"]:
+        nonlocal skipped_unbound
+        b = resolve_binding_from_cwd(record)
+        if b is None:
+            skipped_unbound += 1
+        return b
+
+    ingester = WorkerJSONLIngester(store=store, resolve_binding=_wrap_resolver)
+
+    ingested = 0
+    files = 0
+    for jsonl in base.rglob("*.jsonl"):
+        files += 1
+        try:
+            ingested += ingester.ingest_file(jsonl)
+        except Exception:
+            logger.exception("ingest failed for %s", jsonl)
+            continue
+
+    return {
+        "ingested": ingested,
+        "files": files,
+        "skipped_unbound": skipped_unbound,
+    }
+
+
+def clear_project_info_cache() -> None:
+    """No-op kept for API compatibility.
+
+    Earlier versions cached :func:`_read_project_info` via ``lru_cache``;
+    tests called this between cases to drop the cache. The cache has
+    been removed (it caused stale reads on experiment re-runs), but
+    callers may still invoke this helper — keep the symbol so they
+    don't break.
+    """
+    return None

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -9,13 +9,20 @@ in ``backend/api.py``.
 
 Endpoints
 ---------
-- ``GET  /api/cost/experiments`` — list experiments with totals
-- ``GET  /api/cost/experiments/{exp_id}`` — full per-experiment breakdown
-- ``GET  /api/cost/projects/{project_id}`` — project rollup + experiments
+- ``GET  /api/cost/runs`` — list runs with totals
+- ``GET  /api/cost/runs/{run_id}`` — full per-run breakdown
+- ``GET  /api/cost/projects/{project_id}`` — project rollup + runs
 - ``GET  /api/cost/sessions/{session_id}/turns`` — per-turn trajectory
 - ``GET  /api/cost/prices`` — current pricing table (latest per model)
 - ``POST /api/cost/prices`` — insert a new price row (versioned by ``effective_from``)
-- ``GET  /api/cost/export/{exp_id}`` — CSV export of all events
+- ``GET  /api/cost/export/{run_id}`` — CSV export of all events
+
+Terminology note
+----------------
+Endpoints renamed from ``/experiments`` → ``/runs`` in coordination
+with Marcus's ``experiment_id`` → ``run_id`` rename. The MLflow
+experiment concept is unrelated and stays where it lives in
+Marcus's ``start_experiment`` MCP tool.
 """
 
 from __future__ import annotations
@@ -363,13 +370,18 @@ def unassigned_totals(
     return totals
 
 
-@router.get("/experiments")  # type: ignore[misc]
-def list_experiments(
+@router.get("/runs")  # type: ignore[misc]
+def list_runs(
     project_id: Optional[str] = Query(None),
     limit: int = Query(100, ge=1, le=1000),
     aggregator: Any = Depends(get_aggregator),
 ) -> Dict[str, Any]:
-    """List experiments with token + cost totals attached.
+    """List runs with token + cost totals attached.
+
+    Renamed from ``/experiments`` in coordination with the Marcus
+    rename (Simon ``7ed3074d``). The legacy ``experiment`` term
+    clashed with MLflow's separate concept; ``run`` accurately
+    describes a single project traversal.
 
     Parameters
     ----------
@@ -378,28 +390,30 @@ def list_experiments(
     limit : int
         Cap at 1000. Default 100.
     """
-    rows = aggregator.list_experiments(project_id=project_id, limit=limit)
-    return {"experiments": rows, "count": len(rows)}
+    rows = aggregator.list_runs(project_id=project_id, limit=limit)
+    return {"runs": rows, "count": len(rows)}
 
 
-@router.get("/experiments/{experiment_id}")  # type: ignore[misc]
-def experiment_summary(
-    experiment_id: str,
+@router.get("/runs/{run_id}")  # type: ignore[misc]
+def run_summary(
+    run_id: str,
     aggregator: Any = Depends(get_aggregator),
 ) -> Dict[str, Any]:
-    """Full per-experiment breakdown (summary + by_role / agent / task / etc.).
+    """Full per-run breakdown (summary + by_role / agent / task / etc.).
 
     Returns the exact dict shape documented in Marcus #409. Cato's
     frontend renders the result without further transformation.
 
+    Renamed from ``/experiments/{experiment_id}``.
+
     Raises
     ------
     HTTPException
-        404 if the experiment does not exist.
+        404 if the run does not exist.
     """
-    summary: Optional[Dict[str, Any]] = aggregator.experiment_summary(experiment_id)
+    summary: Optional[Dict[str, Any]] = aggregator.run_summary(run_id)
     if summary is None:
-        raise HTTPException(status_code=404, detail="experiment not found")
+        raise HTTPException(status_code=404, detail="run not found")
     return summary
 
 
@@ -409,7 +423,7 @@ def project_summary(
     aggregator: Any = Depends(get_aggregator),
     store: Any = Depends(get_store),
 ) -> Dict[str, Any]:
-    """Project rollup + list of experiment summaries.
+    """Project rollup + list of run summaries.
 
     Legacy thin shape kept for backwards compatibility with the old
     project picker; the project-first dashboard tabs use
@@ -420,7 +434,7 @@ def project_summary(
         "project_id": project_id,
         "project_name": names.get(project_id),
         "totals": aggregator.project_totals(project_id),
-        "experiments": aggregator.list_experiments(project_id=project_id),
+        "runs": aggregator.list_runs(project_id=project_id),
     }
 
 
@@ -639,12 +653,12 @@ def create_price(
 # -- export ------------------------------------------------------------------
 
 
-@router.get("/export/{experiment_id}")  # type: ignore[misc]
-def export_experiment_csv(
-    experiment_id: str,
+@router.get("/export/{run_id}")  # type: ignore[misc]
+def export_run_csv(
+    run_id: str,
     store: Any = Depends(get_store),
 ) -> StreamingResponse:
-    """CSV export of every ``token_events`` row for one experiment."""
+    """CSV export of every ``token_events`` row for one run."""
     cursor = store.conn.execute(
         """
         SELECT event_id, timestamp, agent_id, agent_role, operation,
@@ -652,10 +666,10 @@ def export_experiment_csv(
                input_tokens, cache_creation_tokens, cache_read_tokens,
                output_tokens, total_tokens, cost_usd, request_id, status
         FROM v_event_cost
-        WHERE experiment_id = ?
+        WHERE run_id = ?
         ORDER BY timestamp, event_id
         """,
-        (experiment_id,),
+        (run_id,),
     )
     headers = [d[0] for d in cursor.description]
     buf = io.StringIO()
@@ -667,7 +681,5 @@ def export_experiment_csv(
     return StreamingResponse(
         iter([buf.getvalue()]),
         media_type="text/csv",
-        headers={
-            "Content-Disposition": (f'attachment; filename="cost_{experiment_id}.csv"')
-        },
+        headers={"Content-Disposition": (f'attachment; filename="cost_{run_id}.csv"')},
     )

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -45,6 +45,13 @@ COST_TRACKING_AVAILABLE = False
 CostStore: Any = None
 CostAggregator: Any = None
 ModelPrice: Any = None
+# Bound at module scope (not just inside the success branch) so that
+# ``list_operations()`` can reference it unconditionally. If Marcus
+# discovery fails entirely — outer try raises, or no _marcus_root is
+# found — this stays ``None`` and the endpoint returns an empty
+# mapping instead of crashing with NameError. Kaia review on
+# ``feat/marcus-409-operations-taxonomy``.
+_marcus_all_operations: Any = None
 
 try:
     import sys
@@ -71,6 +78,23 @@ try:
             CostStore,
             ModelPrice,
         )
+
+        # Operation taxonomy: imported defensively so older Marcus
+        # checkouts without this module still load the cost routes.
+        # ``_marcus_all_operations`` stays ``None`` (its module-scope
+        # default) when unavailable; the ``/api/cost/operations``
+        # endpoint returns an empty mapping in that case so the
+        # dashboard degrades gracefully to "no tooltip" instead of
+        # crashing. The two-step import-then-assign pattern (rather
+        # than ``import ... as _marcus_all_operations``) avoids a
+        # mypy ``no-redef`` error against the module-scope
+        # declaration on line 54.
+        try:
+            from src.cost_tracking.operations import all_operations
+
+            _marcus_all_operations = all_operations
+        except ImportError:
+            pass  # leave as None (set at module scope)
 
         COST_TRACKING_AVAILABLE = True
         logger.info("Cato cost-tracking enabled (Marcus at %s)", _marcus_root)
@@ -474,6 +498,33 @@ def session_turns(
 
 
 # -- pricing endpoints -------------------------------------------------------
+
+
+@router.get("/operations")  # type: ignore[misc]
+def list_operations() -> Dict[str, Any]:
+    """Return the canonical operation taxonomy for cost-event drill-down.
+
+    Sourced from ``src.cost_tracking.operations`` in Marcus. Returns an
+    empty mapping when Marcus is older and lacks the module — the
+    dashboard treats unknown operation keys gracefully (synthesized
+    label, generic tooltip).
+
+    The mapping shape is::
+
+        {
+            "operations": {
+                "<key>": {
+                    "label": "Human label",
+                    "description": "What this LLM call does and why.",
+                    "category": "decomposition" | "runtime" | "monitoring" | "other",
+                },
+                ...
+            }
+        }
+    """
+    if _marcus_all_operations is None:
+        return {"operations": {}}
+    return {"operations": _marcus_all_operations()}
 
 
 @router.get("/prices")  # type: ignore[misc]

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -156,6 +156,22 @@ class PriceCreateRequest(BaseModel):
 router = APIRouter(prefix="/api/cost", tags=["cost"])
 
 
+@router.post("/ingest")  # type: ignore[misc]
+def trigger_ingest(
+    store: Any = Depends(get_store),
+) -> Dict[str, Any]:
+    """Sweep ``~/.claude/projects/`` and ingest any new worker session events.
+
+    Marcus's :class:`WorkerJSONLIngester` is idempotent (UUID-dedupes
+    per process) so calling this on every dashboard load is safe.
+    Returns a small summary so the UI can show "X new events ingested
+    from Y files" if it wants.
+    """
+    from backend.cost_ingest import run_ingest
+
+    return run_ingest(store)
+
+
 @router.get("/projects")  # type: ignore[misc]
 def list_projects(
     limit: int = Query(100, ge=1, le=1000),

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -131,90 +131,98 @@ def get_aggregator(store: Any = Depends(get_store)) -> Any:
 # the same source Cato's regular projects panel uses
 # (``aggregator._load_projects()`` in cato_src/core/aggregator.py).
 #
-# Cached with a 30s TTL: the file is small but reading it on every
-# dashboard tick is wasteful, and 30s matches the dashboard's poll
-# interval so the cache effectively no-ops repeat requests within a
-# poll.
+# Cache: 5s TTL keyed by the store identity. Was 30s — dropped after
+# Kaia review on PR #36 flagged that rename / fresh-snapshot lag was
+# user-visible at that TTL. 5s keeps poll loops cheap (one dashboard
+# poll = ~1 file read + 1 SQL scan) while making updates near-instant.
+# Keying by ``id(store)`` prevents test cross-talk: tests use
+# ``app.dependency_overrides[get_store]`` with tmp stores, and a
+# module-level cache without store keying would leak the previous
+# store's names into the next test.
 
-_PROJECT_NAMES_CACHE: Dict[str, str] = {}
-_PROJECT_NAMES_CACHE_AT: float = 0.0
-_PROJECT_NAMES_TTL_SEC = 30.0
+_PROJECT_NAMES_CACHES: Dict[int, Dict[str, str]] = {}
+_PROJECT_NAMES_CACHE_AT: Dict[int, float] = {}
+_PROJECT_NAMES_TTL_SEC = 5.0
 
 
-def _load_project_names() -> Dict[str, str]:
-    """Map ``project_id`` → ``name`` from Marcus's project registry.
+def _load_project_names(store: Optional[Any] = None) -> Dict[str, str]:
+    """Map ``project_id`` → ``name`` for cost-row enrichment.
 
-    Reads ``<marcus_root>/data/marcus_state/projects.json`` (the same
-    file Marcus's :class:`ProjectRegistry` writes). Returns an empty
-    dict on any read failure — the dashboard then falls back to a
-    truncated project_id in the picker, which is the pre-existing
-    behavior.
+    Sources (merged, later wins):
+    1. Marcus's project registry (``data/marcus_state/projects.json``)
+       — names of *currently registered* projects. Same source the
+       regular Cato projects panel uses.
+    2. costs.db ``project_names`` table — snapshotted at every
+       ``PlannerContext`` push by Marcus PR #515. Names persist even
+       after the project is deleted from the registry, so this table
+       is the source of truth for everything else and overrides #1
+       when both have a name (the snapshot reflects the name as it
+       was when work was attributed; the registry may have been
+       renamed since).
 
-    Cached for ``_PROJECT_NAMES_TTL_SEC`` to keep poll loops cheap.
+    Cached for ``_PROJECT_NAMES_TTL_SEC`` per store identity.
     """
-    global _PROJECT_NAMES_CACHE, _PROJECT_NAMES_CACHE_AT
+    cache_key = id(store) if store is not None else 0
 
     now = time.monotonic()
-    if (
-        _PROJECT_NAMES_CACHE
-        and (now - _PROJECT_NAMES_CACHE_AT) < _PROJECT_NAMES_TTL_SEC
-    ):
-        return _PROJECT_NAMES_CACHE
-
-    if _marcus_root is None:
-        return {}
-
-    projects_file = _marcus_root / "data" / "marcus_state" / "projects.json"
-    if not projects_file.exists():
-        return {}
-
-    try:
-        with projects_file.open("r", encoding="utf-8") as fh:
-            raw = json.load(fh)
-    except (OSError, json.JSONDecodeError) as exc:
-        logger.debug("projects.json unreadable: %s", exc)
-        return {}
+    cached = _PROJECT_NAMES_CACHES.get(cache_key)
+    cached_at = _PROJECT_NAMES_CACHE_AT.get(cache_key, 0.0)
+    if cached and (now - cached_at) < _PROJECT_NAMES_TTL_SEC:
+        return cached
 
     out: Dict[str, str] = {}
-    for key, value in raw.items():
-        # projects.json is a dict keyed by project_id with a sentinel
-        # 'active_project' entry. Skip non-dict values and unkeyed rows.
-        if key == "active_project" or not isinstance(value, dict):
-            continue
-        pid = value.get("id")
-        name = value.get("name")
-        if pid and name:
-            # Marcus normalizes project_id to dashless hex at the write
-            # path now (see canonical_project_id in cost_recorder.py), so
-            # all new token_events rows match the second key below. We
-            # index both variants anyway:
-            #   - dashless covers new writes + legacy .hex auto-discovery
-            #   - dashed covers the projects.json key itself (some Cato
-            #     code paths look it up by registry id directly)
-            # Cheap defense-in-depth against drift.
-            out[pid] = name
-            out[pid.replace("-", "")] = name
 
-    _PROJECT_NAMES_CACHE = out
-    _PROJECT_NAMES_CACHE_AT = now
+    # Source 1: projects.json (live registry).
+    if _marcus_root is not None:
+        projects_file = _marcus_root / "data" / "marcus_state" / "projects.json"
+        if projects_file.exists():
+            try:
+                with projects_file.open("r", encoding="utf-8") as fh:
+                    raw = json.load(fh)
+                for key, value in raw.items():
+                    if key == "active_project" or not isinstance(value, dict):
+                        continue
+                    pid = value.get("id")
+                    name = value.get("name")
+                    if pid and name:
+                        # Index both dashed + dashless variants because
+                        # legacy data has both forms (see canonical_project_id).
+                        out[pid] = name
+                        out[pid.replace("-", "")] = name
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.debug("projects.json unreadable: %s", exc)
+
+    # Source 2: costs.db project_names table (snapshot — overrides
+    # registry for projects that were deleted but still have cost data).
+    if store is not None:
+        try:
+            for pid, name in store.conn.execute(
+                "SELECT project_id, name FROM project_names"
+            ):
+                out[pid] = name
+        except Exception as exc:  # pragma: no cover - sqlite errors logged
+            logger.debug("project_names table unreadable: %s", exc)
+
+    _PROJECT_NAMES_CACHES[cache_key] = out
+    _PROJECT_NAMES_CACHE_AT[cache_key] = now
     return out
 
 
 def clear_project_names_cache() -> None:
-    """Drop the project-name cache. Used by tests."""
-    global _PROJECT_NAMES_CACHE, _PROJECT_NAMES_CACHE_AT
-    _PROJECT_NAMES_CACHE = {}
-    _PROJECT_NAMES_CACHE_AT = 0.0
+    """Drop every project-name cache entry. Used by tests."""
+    _PROJECT_NAMES_CACHES.clear()
+    _PROJECT_NAMES_CACHE_AT.clear()
 
 
-def _enrich_project_names(rows: list) -> list:
-    """Overlay registry names on cost rows when no MLflow name exists.
+def _enrich_project_names(rows: list, store: Optional[Any] = None) -> list:
+    """Overlay snapshotted/registry names on cost rows.
 
     Mutates each row in-place: if ``project_name`` is None / missing,
-    fill it from the registry. Otherwise leave it (an MLflow run with
-    an explicit project_name wins because it was set by the user).
+    fill it from the merged name sources (project_names table first,
+    then projects.json). MLflow-explicit names from the aggregator
+    still win because we only fill missing rows.
     """
-    names = _load_project_names()
+    names = _load_project_names(store=store)
     for row in rows:
         if not row.get("project_name") and row.get("project_id") in names:
             row["project_name"] = names[row["project_id"]]
@@ -296,6 +304,7 @@ def trigger_ingest(
 def list_projects(
     limit: int = Query(100, ge=1, le=1000),
     aggregator: Any = Depends(get_aggregator),
+    store: Any = Depends(get_store),
 ) -> Dict[str, Any]:
     """List every project that has cost activity, sorted by spend desc.
 
@@ -311,7 +320,7 @@ def list_projects(
         Cap at 1000. Default 100.
     """
     rows = aggregator.list_projects(limit=limit)
-    _enrich_project_names(rows)
+    _enrich_project_names(rows, store=store)
     return {"projects": rows, "count": len(rows)}
 
 
@@ -374,6 +383,7 @@ def experiment_summary(
 def project_summary(
     project_id: str,
     aggregator: Any = Depends(get_aggregator),
+    store: Any = Depends(get_store),
 ) -> Dict[str, Any]:
     """Project rollup + list of experiment summaries.
 
@@ -381,7 +391,7 @@ def project_summary(
     project picker; the project-first dashboard tabs use
     ``/projects/{id}/summary`` for the full per-project breakdown.
     """
-    names = _load_project_names()
+    names = _load_project_names(store=store)
     return {
         "project_id": project_id,
         "project_name": names.get(project_id),
@@ -430,14 +440,15 @@ def put_project_budget(
 def project_full_summary(
     project_id: str,
     aggregator: Any = Depends(get_aggregator),
+    store: Any = Depends(get_store),
 ) -> Dict[str, Any]:
     """Full per-project breakdown — drives Real-time/Historical/Budget tabs.
 
     Same shape as ``/experiments/{id}`` (summary + by_role / by_agent /
     by_task / by_operation / by_model) but scoped to project_id, the
     only universal identity in Marcus's coordination model (#503).
-    Project-name is overlaid from Marcus's project registry (same
-    source the regular projects panel uses).
+    Project-name is overlaid from Marcus's project_names snapshot
+    (PR #515) with fallback to projects.json.
 
     Raises
     ------
@@ -447,7 +458,7 @@ def project_full_summary(
     summary: Optional[Dict[str, Any]] = aggregator.project_summary(project_id)
     if summary is None:
         raise HTTPException(status_code=404, detail="project not found")
-    names = _load_project_names()
+    names = _load_project_names(store=store)
     summary["project_name"] = names.get(project_id)
     return summary
 

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -1,0 +1,368 @@
+"""
+Cato cost-tracking API routes.
+
+Exposes ``/api/cost/*`` endpoints backed by Marcus's :class:`CostStore`
+and :class:`CostAggregator` (see Marcus issue #409). Cato runs as a
+sidecar to Marcus and imports the cost-tracking modules directly,
+following the same pattern used by the historical analysis endpoints
+in ``backend/api.py``.
+
+Endpoints
+---------
+- ``GET  /api/cost/experiments`` — list experiments with totals
+- ``GET  /api/cost/experiments/{exp_id}`` — full per-experiment breakdown
+- ``GET  /api/cost/projects/{project_id}`` — project rollup + experiments
+- ``GET  /api/cost/sessions/{session_id}/turns`` — per-turn trajectory
+- ``GET  /api/cost/prices`` — current pricing table (latest per model)
+- ``POST /api/cost/prices`` — insert a new price row (versioned by ``effective_from``)
+- ``GET  /api/cost/export/{exp_id}`` — CSV export of all events
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Marcus module discovery
+# ---------------------------------------------------------------------------
+
+COST_TRACKING_AVAILABLE = False
+CostStore: Any = None
+CostAggregator: Any = None
+ModelPrice: Any = None
+
+try:
+    import sys
+
+    # Mirror the historical-mode discovery in backend/api.py: search a few
+    # well-known Marcus locations and add its root to sys.path.
+    _possible_roots = [
+        Path(__file__).parent.parent.parent / "marcus",  # sibling
+        Path.home() / "dev" / "marcus",
+        Path("/Users/lwgray/dev/marcus"),
+    ]
+    _marcus_root: Optional[Path] = None
+    for _root in _possible_roots:
+        if (_root / "src" / "cost_tracking").exists():
+            _marcus_root = _root
+            break
+    if _marcus_root is not None:
+        if str(_marcus_root) not in sys.path:
+            sys.path.insert(0, str(_marcus_root))
+        from src.cost_tracking.cost_aggregator import (  # type: ignore[no-redef]
+            CostAggregator,
+        )
+        from src.cost_tracking.cost_store import (  # type: ignore[no-redef]
+            CostStore,
+            ModelPrice,
+        )
+
+        COST_TRACKING_AVAILABLE = True
+        logger.info("Cato cost-tracking enabled (Marcus at %s)", _marcus_root)
+    else:
+        logger.warning("Marcus cost_tracking modules not found; /api/cost/* disabled")
+except Exception as exc:  # pragma: no cover - logged, fallback to disabled
+    logger.error("Could not import Marcus cost_tracking: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Store provider (FastAPI dependency, overridable in tests)
+# ---------------------------------------------------------------------------
+
+
+def _default_db_path() -> Path:
+    """Return the default cost DB path Marcus uses (``~/.marcus/costs.db``).
+
+    Override with the ``MARCUS_COST_DB`` env var in tests / non-default
+    deployments.
+    """
+    return Path(
+        os.environ.get("MARCUS_COST_DB", str(Path.home() / ".marcus" / "costs.db"))
+    )
+
+
+def get_store() -> Any:
+    """Yield a :class:`CostStore` instance (FastAPI dependency).
+
+    Tests override this via ``app.dependency_overrides`` to point at a
+    tmp database.
+
+    Raises
+    ------
+    HTTPException
+        503 if Marcus's cost_tracking modules are not importable.
+    """
+    if not COST_TRACKING_AVAILABLE or CostStore is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Marcus cost_tracking modules are not available",
+        )
+    return CostStore(db_path=_default_db_path())
+
+
+def get_aggregator(store: Any = Depends(get_store)) -> Any:
+    """Yield a :class:`CostAggregator` (FastAPI dependency)."""
+    return CostAggregator(store=store)
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class PriceCreateRequest(BaseModel):
+    """Payload for POST /api/cost/prices.
+
+    Mirrors :class:`src.cost_tracking.cost_store.ModelPrice`. Pricing is
+    versioned: send a new ``effective_from`` to update a model's rate
+    without rewriting historical events.
+    """
+
+    model: str = Field(..., description="Model identifier (e.g. 'claude-sonnet-4-6')")
+    provider: str = Field(..., description="Provider tag ('anthropic', 'openai', etc.)")
+    effective_from: Optional[datetime] = Field(
+        None,
+        description="UTC datetime this price became active. Defaults to now.",
+    )
+    input_per_million: float = Field(..., ge=0)
+    output_per_million: float = Field(..., ge=0)
+    cache_creation_per_million: Optional[float] = Field(None, ge=0)
+    cache_read_per_million: Optional[float] = Field(None, ge=0)
+    source: str = Field(
+        "cato_user",
+        description="Origin tag — 'cato_user' for UI edits, 'contract' for "
+        "negotiated rates, 'default' is reserved for seed data.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+router = APIRouter(prefix="/api/cost", tags=["cost"])
+
+
+@router.get("/experiments")  # type: ignore[misc]
+def list_experiments(
+    project_id: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=1000),
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """List experiments with token + cost totals attached.
+
+    Parameters
+    ----------
+    project_id : str, optional
+        Restrict to one project.
+    limit : int
+        Cap at 1000. Default 100.
+    """
+    rows = aggregator.list_experiments(project_id=project_id, limit=limit)
+    return {"experiments": rows, "count": len(rows)}
+
+
+@router.get("/experiments/{experiment_id}")  # type: ignore[misc]
+def experiment_summary(
+    experiment_id: str,
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """Full per-experiment breakdown (summary + by_role / agent / task / etc.).
+
+    Returns the exact dict shape documented in Marcus #409. Cato's
+    frontend renders the result without further transformation.
+
+    Raises
+    ------
+    HTTPException
+        404 if the experiment does not exist.
+    """
+    summary: Optional[Dict[str, Any]] = aggregator.experiment_summary(experiment_id)
+    if summary is None:
+        raise HTTPException(status_code=404, detail="experiment not found")
+    return summary
+
+
+@router.get("/projects/{project_id}")  # type: ignore[misc]
+def project_summary(
+    project_id: str,
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """Project rollup + list of experiment summaries."""
+    return {
+        "project_id": project_id,
+        "totals": aggregator.project_totals(project_id),
+        "experiments": aggregator.list_experiments(project_id=project_id),
+    }
+
+
+@router.get("/sessions/{session_id}/turns")  # type: ignore[misc]
+def session_turns(
+    session_id: str,
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """Per-turn cost trajectory for one Claude Code session."""
+    turns = aggregator.session_turns(session_id)
+    return {"session_id": session_id, "turns": turns}
+
+
+# -- pricing endpoints -------------------------------------------------------
+
+
+@router.get("/prices")  # type: ignore[misc]
+def list_current_prices(
+    store: Any = Depends(get_store),
+) -> Dict[str, Any]:
+    """Return the latest price per (model, provider) — what's currently in effect."""
+    rows = list(store.conn.execute("""
+            SELECT model, provider, effective_from,
+                   input_per_million, output_per_million,
+                   cache_creation_per_million, cache_read_per_million, source
+            FROM model_prices p1
+            WHERE effective_from = (
+                SELECT MAX(effective_from) FROM model_prices p2
+                WHERE p2.model = p1.model AND p2.provider = p1.provider
+            )
+            ORDER BY model, provider
+            """))
+    cols = [
+        "model",
+        "provider",
+        "effective_from",
+        "input_per_million",
+        "output_per_million",
+        "cache_creation_per_million",
+        "cache_read_per_million",
+        "source",
+    ]
+    return {"prices": [dict(zip(cols, r)) for r in rows]}
+
+
+@router.get("/prices/history")  # type: ignore[misc]
+def list_price_history(
+    model: Optional[str] = Query(None),
+    store: Any = Depends(get_store),
+) -> Dict[str, Any]:
+    """Full price history, optionally filtered to a single ``model``."""
+    if model:
+        rows = list(
+            store.conn.execute(
+                "SELECT model, provider, effective_from, input_per_million, "
+                "output_per_million, cache_creation_per_million, "
+                "cache_read_per_million, source FROM model_prices "
+                "WHERE model = ? ORDER BY effective_from DESC",
+                (model,),
+            )
+        )
+    else:
+        rows = list(
+            store.conn.execute(
+                "SELECT model, provider, effective_from, input_per_million, "
+                "output_per_million, cache_creation_per_million, "
+                "cache_read_per_million, source FROM model_prices "
+                "ORDER BY model, effective_from DESC"
+            )
+        )
+    cols = [
+        "model",
+        "provider",
+        "effective_from",
+        "input_per_million",
+        "output_per_million",
+        "cache_creation_per_million",
+        "cache_read_per_million",
+        "source",
+    ]
+    return {"prices": [dict(zip(cols, r)) for r in rows]}
+
+
+@router.post("/prices")  # type: ignore[misc]
+def create_price(
+    payload: PriceCreateRequest,
+    store: Any = Depends(get_store),
+) -> Dict[str, Any]:
+    """Insert a new ``model_prices`` row, versioned by ``effective_from``.
+
+    A duplicate ``(model, provider, effective_from)`` returns 409.
+    """
+    if ModelPrice is None:  # pragma: no cover - guarded by get_store
+        raise HTTPException(status_code=503, detail="cost_tracking unavailable")
+    effective = payload.effective_from or datetime.now(timezone.utc)
+    price = ModelPrice(
+        model=payload.model,
+        provider=payload.provider,
+        effective_from=effective,
+        input_per_million=payload.input_per_million,
+        output_per_million=payload.output_per_million,
+        cache_creation_per_million=payload.cache_creation_per_million,
+        cache_read_per_million=payload.cache_read_per_million,
+        source=payload.source,
+    )
+    try:
+        store.record_price(price)
+    except Exception as exc:
+        # IntegrityError raised by sqlite3 on duplicate PK.
+        if (
+            "UNIQUE" in str(exc)
+            or "PRIMARY KEY" in str(exc)
+            or "constraint" in str(exc).lower()
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "price with that (model, provider, effective_from) "
+                    "already exists"
+                ),
+            )
+        raise
+    return {"status": "ok", "effective_from": effective.isoformat()}
+
+
+# -- export ------------------------------------------------------------------
+
+
+@router.get("/export/{experiment_id}")  # type: ignore[misc]
+def export_experiment_csv(
+    experiment_id: str,
+    store: Any = Depends(get_store),
+) -> StreamingResponse:
+    """CSV export of every ``token_events`` row for one experiment."""
+    cursor = store.conn.execute(
+        """
+        SELECT event_id, timestamp, agent_id, agent_role, operation,
+               task_id, session_id, turn_index, provider, model,
+               input_tokens, cache_creation_tokens, cache_read_tokens,
+               output_tokens, total_tokens, cost_usd, request_id, status
+        FROM v_event_cost
+        WHERE experiment_id = ?
+        ORDER BY timestamp, event_id
+        """,
+        (experiment_id,),
+    )
+    headers = [d[0] for d in cursor.description]
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(headers)
+    for row in cursor:
+        writer.writerow(row)
+    buf.seek(0)
+    return StreamingResponse(
+        iter([buf.getvalue()]),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": (f'attachment; filename="cost_{experiment_id}.csv"')
+        },
+    )

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -156,6 +156,43 @@ class PriceCreateRequest(BaseModel):
 router = APIRouter(prefix="/api/cost", tags=["cost"])
 
 
+@router.get("/projects")  # type: ignore[misc]
+def list_projects(
+    limit: int = Query(100, ge=1, le=1000),
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """List every project that has cost activity, sorted by spend desc.
+
+    Project is Marcus's primary identity (GH-388 + spawn_agents.py), so
+    this is the dashboard's main entry point. Each row carries event
+    count, experiment count, agent count, tokens, cost, and first/last
+    activity timestamps. Excludes the ``'unassigned'`` bucket — surfaced
+    separately via ``/api/cost/projects/unassigned``.
+
+    Parameters
+    ----------
+    limit : int
+        Cap at 1000. Default 100.
+    """
+    rows = aggregator.list_projects(limit=limit)
+    return {"projects": rows, "count": len(rows)}
+
+
+@router.get("/projects/unassigned")  # type: ignore[misc]
+def unassigned_totals(
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """Cost of LLM calls Marcus made without an active PlannerContext.
+
+    Surfaces the "no project resolved" bucket as a first-class panel so
+    the gap is observable rather than silent. A high number here means
+    a code path is making LLM calls outside the MCP request lifecycle
+    (or a project-creation tool ran without a target project_id).
+    """
+    totals: Dict[str, Any] = aggregator.unassigned_totals()
+    return totals
+
+
 @router.get("/experiments")  # type: ignore[misc]
 def list_experiments(
     project_id: Optional[str] = Query(None),

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -22,8 +22,10 @@ from __future__ import annotations
 
 import csv
 import io
+import json
 import logging
 import os
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -119,8 +121,126 @@ def get_aggregator(store: Any = Depends(get_store)) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Project-name resolution
+# ---------------------------------------------------------------------------
+#
+# Marcus's main code path never calls ``start_experiment``, so the
+# ``experiments`` table is usually empty and we can't get a human-
+# readable project_name from there. Instead we read Marcus's project
+# registry directly — ``data/marcus_state/projects.json`` — which is
+# the same source Cato's regular projects panel uses
+# (``aggregator._load_projects()`` in cato_src/core/aggregator.py).
+#
+# Cached with a 30s TTL: the file is small but reading it on every
+# dashboard tick is wasteful, and 30s matches the dashboard's poll
+# interval so the cache effectively no-ops repeat requests within a
+# poll.
+
+_PROJECT_NAMES_CACHE: Dict[str, str] = {}
+_PROJECT_NAMES_CACHE_AT: float = 0.0
+_PROJECT_NAMES_TTL_SEC = 30.0
+
+
+def _load_project_names() -> Dict[str, str]:
+    """Map ``project_id`` → ``name`` from Marcus's project registry.
+
+    Reads ``<marcus_root>/data/marcus_state/projects.json`` (the same
+    file Marcus's :class:`ProjectRegistry` writes). Returns an empty
+    dict on any read failure — the dashboard then falls back to a
+    truncated project_id in the picker, which is the pre-existing
+    behavior.
+
+    Cached for ``_PROJECT_NAMES_TTL_SEC`` to keep poll loops cheap.
+    """
+    global _PROJECT_NAMES_CACHE, _PROJECT_NAMES_CACHE_AT
+
+    now = time.monotonic()
+    if (
+        _PROJECT_NAMES_CACHE
+        and (now - _PROJECT_NAMES_CACHE_AT) < _PROJECT_NAMES_TTL_SEC
+    ):
+        return _PROJECT_NAMES_CACHE
+
+    if _marcus_root is None:
+        return {}
+
+    projects_file = _marcus_root / "data" / "marcus_state" / "projects.json"
+    if not projects_file.exists():
+        return {}
+
+    try:
+        with projects_file.open("r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("projects.json unreadable: %s", exc)
+        return {}
+
+    out: Dict[str, str] = {}
+    for key, value in raw.items():
+        # projects.json is a dict keyed by project_id with a sentinel
+        # 'active_project' entry. Skip non-dict values and unkeyed rows.
+        if key == "active_project" or not isinstance(value, dict):
+            continue
+        pid = value.get("id")
+        name = value.get("name")
+        if pid and name:
+            # Marcus normalizes project_id to dashless hex at the write
+            # path now (see canonical_project_id in cost_recorder.py), so
+            # all new token_events rows match the second key below. We
+            # index both variants anyway:
+            #   - dashless covers new writes + legacy .hex auto-discovery
+            #   - dashed covers the projects.json key itself (some Cato
+            #     code paths look it up by registry id directly)
+            # Cheap defense-in-depth against drift.
+            out[pid] = name
+            out[pid.replace("-", "")] = name
+
+    _PROJECT_NAMES_CACHE = out
+    _PROJECT_NAMES_CACHE_AT = now
+    return out
+
+
+def clear_project_names_cache() -> None:
+    """Drop the project-name cache. Used by tests."""
+    global _PROJECT_NAMES_CACHE, _PROJECT_NAMES_CACHE_AT
+    _PROJECT_NAMES_CACHE = {}
+    _PROJECT_NAMES_CACHE_AT = 0.0
+
+
+def _enrich_project_names(rows: list) -> list:
+    """Overlay registry names on cost rows when no MLflow name exists.
+
+    Mutates each row in-place: if ``project_name`` is None / missing,
+    fill it from the registry. Otherwise leave it (an MLflow run with
+    an explicit project_name wins because it was set by the user).
+    """
+    names = _load_project_names()
+    for row in rows:
+        if not row.get("project_name") and row.get("project_id") in names:
+            row["project_name"] = names[row["project_id"]]
+    return rows
+
+
+# ---------------------------------------------------------------------------
 # Request models
 # ---------------------------------------------------------------------------
+
+
+class ProjectBudgetRequest(BaseModel):
+    """Payload for ``PUT /api/cost/projects/{id}/budget``.
+
+    Sending ``budget_usd <= 0`` removes the cap (Marcus side deletes
+    the row); the dashboard then reverts to the "no budget set" hint.
+    """
+
+    budget_usd: float = Field(
+        ...,
+        description="USD ceiling. <= 0 clears the cap.",
+    )
+    note: Optional[str] = Field(
+        None,
+        description="Free-text annotation (e.g., 'PoC cap', 'Q2 budget').",
+    )
 
 
 class PriceCreateRequest(BaseModel):
@@ -191,6 +311,7 @@ def list_projects(
         Cap at 1000. Default 100.
     """
     rows = aggregator.list_projects(limit=limit)
+    _enrich_project_names(rows)
     return {"projects": rows, "count": len(rows)}
 
 
@@ -254,12 +375,81 @@ def project_summary(
     project_id: str,
     aggregator: Any = Depends(get_aggregator),
 ) -> Dict[str, Any]:
-    """Project rollup + list of experiment summaries."""
+    """Project rollup + list of experiment summaries.
+
+    Legacy thin shape kept for backwards compatibility with the old
+    project picker; the project-first dashboard tabs use
+    ``/projects/{id}/summary`` for the full per-project breakdown.
+    """
+    names = _load_project_names()
     return {
         "project_id": project_id,
+        "project_name": names.get(project_id),
         "totals": aggregator.project_totals(project_id),
         "experiments": aggregator.list_experiments(project_id=project_id),
     }
+
+
+@router.get("/projects/{project_id}/budget")  # type: ignore[misc]
+def get_project_budget(
+    project_id: str,
+    store: Any = Depends(get_store),
+) -> Dict[str, Any]:
+    """Return the budget cap set for a project, or null if none.
+
+    Surfaced to the dashboard's Budget tab so it can render
+    spend-vs-cap when a ceiling is set, falling back to spend-only
+    when not.
+    """
+    row = store.get_project_budget(project_id)
+    return {"project_id": project_id, "budget": row}
+
+
+@router.put("/projects/{project_id}/budget")  # type: ignore[misc]
+def put_project_budget(
+    project_id: str,
+    payload: ProjectBudgetRequest,
+    store: Any = Depends(get_store),
+) -> Dict[str, Any]:
+    """Set or clear a project's budget cap.
+
+    Idempotent upsert on Marcus's side; the cap survives Cato
+    restarts because it's persisted to costs.db. Passing
+    ``budget_usd <= 0`` clears the cap (deletes the row).
+    """
+    store.set_project_budget(
+        project_id=project_id,
+        budget_usd=payload.budget_usd,
+        note=payload.note,
+    )
+    row = store.get_project_budget(project_id)
+    return {"project_id": project_id, "budget": row}
+
+
+@router.get("/projects/{project_id}/summary")  # type: ignore[misc]
+def project_full_summary(
+    project_id: str,
+    aggregator: Any = Depends(get_aggregator),
+) -> Dict[str, Any]:
+    """Full per-project breakdown — drives Real-time/Historical/Budget tabs.
+
+    Same shape as ``/experiments/{id}`` (summary + by_role / by_agent /
+    by_task / by_operation / by_model) but scoped to project_id, the
+    only universal identity in Marcus's coordination model (#503).
+    Project-name is overlaid from Marcus's project registry (same
+    source the regular projects panel uses).
+
+    Raises
+    ------
+    HTTPException
+        404 if the project has no token events.
+    """
+    summary: Optional[Dict[str, Any]] = aggregator.project_summary(project_id)
+    if summary is None:
+        raise HTTPException(status_code=404, detail="project not found")
+    names = _load_project_names()
+    summary["project_name"] = names.get(project_id)
+    return summary
 
 
 @router.get("/sessions/{session_id}/turns")  # type: ignore[misc]

--- a/cato_src/core/aggregator.py
+++ b/cato_src/core/aggregator.py
@@ -1467,8 +1467,31 @@ class Aggregator:
                 )
                 return None
 
-            # Step 2: Fetch parent task rows for the candidate IDs
+            # Step 2: Fetch parent task rows for the candidate IDs, then
+            # follow ``dependencies`` edges to pull in any referenced parents
+            # that didn't surface via conversations / Planka prefix. Without
+            # this expansion, an unstarted task whose dependent appears first
+            # in the logs would be a dangling edge target → orphan-filtered
+            # out of the DAG. The slow path does the same walk inline
+            # (aggregator.py:1771-1789).
             parent_tasks = self._load_parent_tasks_by_ids(candidates, root)
+            seen_ids = set(candidates)
+            for _ in range(8):  # bounded BFS over dep chain depth
+                new_dep_ids: Set[str] = set()
+                for task in parent_tasks:
+                    deps = task.get("dependencies") or task.get("dependency_ids") or []
+                    for dep in deps:
+                        dep_str = str(dep)
+                        if dep_str and dep_str not in seen_ids:
+                            new_dep_ids.add(dep_str)
+                if not new_dep_ids:
+                    break
+                seen_ids |= new_dep_ids
+                extra = self._load_parent_tasks_by_ids(new_dep_ids, root)
+                if not extra:
+                    break
+                parent_tasks.extend(extra)
+            candidates = seen_ids
 
             # Step 3: Read subtasks.json (mtime-cached) and filter by parent
             all_subtasks = self._load_subtasks_json_cached(root)

--- a/cato_src/core/aggregator.py
+++ b/cato_src/core/aggregator.py
@@ -784,6 +784,12 @@ class Aggregator:
         # (must happen before parent tasks are filtered out)
         raw_tasks = self._inherit_parent_dependencies_to_first_subtask(raw_tasks)
 
+        # Step 2.5: Stash a parent→subtask-rollup snapshot BEFORE the filter
+        # removes subtasks. Applied AFTER message-enrichment below so the
+        # rollup wins over message-derived started_at (which is the late
+        # auto_complete event timestamp, not the real work span).
+        subtask_rollup = self._build_subtask_rollup(raw_tasks)
+
         # Step 3: Filter tasks by view mode
         filtered_tasks = self._filter_tasks_by_view(raw_tasks, view_mode)
 
@@ -791,10 +797,29 @@ class Aggregator:
         # Create task_ids set early for message filtering
         task_ids_set = {t["id"] for t in filtered_tasks}
 
+        # In parents view, agents do work on subtasks — their status_update
+        # messages reference subtask IDs. Rewrite those to the parent ID so
+        # they surface in the parent's conversation pane.
+        subtask_to_parent: Dict[str, str] = {}
+        if view_mode == "parents":
+            for t in raw_tasks:
+                tid = t.get("id")
+                pid = t.get("parent_task_id")
+                if tid and pid and str(pid) in task_ids_set:
+                    subtask_to_parent[str(tid)] = str(pid)
+
+        def _resolve_task_id(msg: Dict[str, Any]) -> Optional[str]:
+            tid = msg.get("task_id") or msg.get("metadata", {}).get("task_id")
+            if tid and tid in subtask_to_parent:
+                rewritten = subtask_to_parent[tid]
+                msg["task_id"] = rewritten
+                return rewritten
+            return str(tid) if tid else None
+
         # PASS 1: Filter messages directly related to project tasks
         task_related_messages = []
         for msg in raw_messages:
-            task_id = msg.get("task_id") or msg.get("metadata", {}).get("task_id")
+            task_id = _resolve_task_id(msg)
             if task_id and task_id in task_ids_set:
                 task_related_messages.append(msg)
 
@@ -852,7 +877,7 @@ class Aggregator:
         # PASS 2: Include all messages involving project agents
         filtered_messages = []
         for msg in raw_messages:
-            task_id = msg.get("task_id") or msg.get("metadata", {}).get("task_id")
+            task_id = _resolve_task_id(msg)
             from_agent = msg.get("from_agent_id")
             to_agent = msg.get("to_agent_id")
 
@@ -899,6 +924,14 @@ class Aggregator:
         # Step 5.5: Calculate synthetic start times based on dependencies
         # (for tasks without started_at but with dependencies)
         self._calculate_synthetic_start_times(filtered_tasks)
+
+        # Step 5.6: Apply parent timing rollup LAST. Overrides both message-
+        # derived started_at (auto_complete event timestamp) and the
+        # dep-completion clamp from synthesize_start_times — the rollup
+        # spans the real work window (first subtask start → last subtask
+        # end), and a parent's subtasks legitimately start before sibling
+        # parents finish.
+        self._apply_subtask_rollup(filtered_tasks, subtask_rollup)
 
         # Step 6: Calculate timeline boundaries
         timeline_start, timeline_end, duration_minutes = self._calculate_timeline(
@@ -1539,6 +1572,9 @@ class Aggregator:
             )
 
             # Step 5: Apply enrichment in-place (subset of enrich_tasks_with_timing)
+            # Populate started_at/completed_at AND created_at/updated_at — the
+            # former so getTaskStateAtTime + synth see the real per-task start
+            # (without it, every same-dep sibling collapses onto latest_dep_end).
             for task in project_tasks:
                 task_id = str(task.get("id") or task.get("task_id") or "")
                 outcome = outcomes_by_task.get(task_id)
@@ -1546,14 +1582,18 @@ class Aggregator:
                     task["actual_hours"] = outcome["actual_hours"]
                     if outcome.get("started_at"):
                         task["created_at"] = outcome["started_at"]
+                        task["started_at"] = outcome["started_at"]
                     if outcome.get("completed_at"):
                         task["updated_at"] = outcome["completed_at"]
+                        task["completed_at"] = outcome["completed_at"]
                 timing = timings_by_task.get(task_id)
                 if timing:
                     if "start_time" in timing:
                         task["created_at"] = timing["start_time"]
+                        task["started_at"] = timing["start_time"]
                     if "end_time" in timing:
                         task["updated_at"] = timing["end_time"]
+                        task["completed_at"] = timing["end_time"]
                     if "duration_hours" in timing:
                         task["actual_hours"] = timing["duration_hours"]
 
@@ -2378,6 +2418,116 @@ class Aggregator:
 
         return "work"
 
+    def _build_subtask_rollup(
+        self, tasks: List[Dict[str, Any]]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Aggregate subtask timing per parent.
+
+        Run before parents-view filtering removes subtasks. The returned
+        map is applied by ``_apply_subtask_rollup`` after enrichment.
+        """
+        subtasks_by_parent: Dict[str, List[Dict[str, Any]]] = {}
+        for t in tasks:
+            pid = t.get("parent_task_id")
+            if pid:
+                subtasks_by_parent.setdefault(str(pid), []).append(t)
+
+        # Fast path stores outcome timestamps in created_at/updated_at, not
+        # started_at/completed_at — so accept either source per subtask.
+        def _start(c: Dict[str, Any]) -> Optional[str]:
+            return c.get("started_at") or c.get("created_at")
+
+        def _is_done(c: Dict[str, Any]) -> bool:
+            if c.get("completed_at"):
+                return True
+            return (c.get("status") or "").lower() in ("done", "completed")
+
+        def _end(c: Dict[str, Any]) -> Optional[str]:
+            # updated_at is a placeholder on incomplete subtasks — only treat
+            # it as an end time once the child has actually completed,
+            # otherwise an active parent gets marked completed.
+            if not _is_done(c):
+                return None
+            return c.get("completed_at") or c.get("updated_at")
+
+        rollup: Dict[str, Dict[str, Any]] = {}
+        for pid, children in subtasks_by_parent.items():
+            starts = [s for c in children if (s := _start(c))]
+            # completed_at only rolls up when every child is done — a partial
+            # rollup would mark a still-active parent completed.
+            all_done = all(_is_done(c) for c in children)
+            ends = [e for c in children if (e := _end(c))] if all_done else []
+            hours = [
+                c["actual_hours"]
+                for c in children
+                if isinstance(c.get("actual_hours"), (int, float))
+            ]
+            agent_counts: Dict[str, int] = {}
+            for c in children:
+                aid = c.get("assigned_agent_id")
+                if aid:
+                    agent_counts[aid] = agent_counts.get(aid, 0) + 1
+
+            rollup[pid] = {
+                "started_at": min(starts) if starts else None,
+                "completed_at": max(ends) if ends else None,
+                "actual_hours": sum(hours) if hours else None,
+                "assigned_agent_id": (
+                    max(agent_counts, key=lambda k: agent_counts[k])
+                    if agent_counts
+                    else None
+                ),
+            }
+        return rollup
+
+    def _apply_subtask_rollup(
+        self,
+        tasks: List[Dict[str, Any]],
+        rollup: Dict[str, Dict[str, Any]],
+    ) -> None:
+        """Apply pre-computed subtask rollup to parents.
+
+        Marcus intentionally writes NO ``task_outcomes`` row for parents that
+        auto-complete via ``check_and_complete_parent_task`` — the work data
+        lives on the subtask outcomes, attributed to the real worker who did
+        each subtask. Writing a synthetic parent outcome upstream would
+        corrupt agent learning (double-counted hours, inflated total_tasks,
+        skewed skill_success_rates EMA). See the contract comment in
+        ``marcus/src/marcus_mcp/coordinator/subtask_assignment.py``.
+
+        Cato is a denormalized read-side view, so aggregation happens here:
+        we synthesize parent display fields by rolling up subtask data, and
+        flag the parent with ``work_via_subtasks=True`` so per-view rendering
+        decisions stay honest. Overrides message-derived started_at because
+        the auto_complete event timestamp is roughly the last-subtask end,
+        not the real work span.
+        """
+        applied = 0
+        for parent in tasks:
+            pid = str(parent.get("id") or parent.get("task_id") or "")
+            r = rollup.get(pid)
+            if not r:
+                continue
+            applied += 1
+            if r["started_at"]:
+                parent["started_at"] = r["started_at"]
+            if r["completed_at"]:
+                parent["completed_at"] = r["completed_at"]
+                if (
+                    not parent.get("updated_at")
+                    or parent["updated_at"] < r["completed_at"]
+                ):
+                    parent["updated_at"] = r["completed_at"]
+            if r["actual_hours"] is not None and not parent.get("actual_hours"):
+                parent["actual_hours"] = r["actual_hours"]
+            if r["assigned_agent_id"] and not parent.get("assigned_agent_id"):
+                parent["assigned_agent_id"] = r["assigned_agent_id"]
+            # Flag so SwimLane can skip this parent — the rolled-up
+            # min→max span isn't a contiguous work bar (subtasks interleave).
+            parent["work_via_subtasks"] = True
+        if applied:
+            logger.info(f"Applied subtask rollup to {applied} parents")
+
     def _filter_tasks_by_view(
         self, tasks: List[Dict[str, Any]], view_mode: str
     ) -> List[Dict[str, Any]]:
@@ -3090,9 +3240,12 @@ class Aggregator:
         logger.info(f"Calculating timeline from {len(tasks)} tasks")
 
         for task in tasks:
-            # Only use created_at and updated_at for timeline calculation
-            # (started_at/completed_at from messages may have timezone issues)
-            for field in ["created_at", "updated_at"]:
+            # Include started_at/completed_at so message-derived timestamps
+            # (set by _enrich_tasks_with_message_timestamps) extend the
+            # timeline. Without this, tasks whose assignment messages
+            # arrive after the last completed task's updated_at render
+            # as todo 0% because currentAbsTime never reaches their start.
+            for field in ["created_at", "updated_at", "started_at", "completed_at"]:
                 if task.get(field):
                     try:
                         ts_str = task[field]
@@ -3189,6 +3342,17 @@ class Aggregator:
                 # Use earliest assignment
                 earliest = min(assignment_msgs, key=lambda m: m.get("timestamp", ""))
                 task["started_at"] = earliest.get("timestamp")
+                # Backfill assigned_agent_id from the assignment recipient
+                # when neither outcome nor kanban supplied one. Without this
+                # the SwimLane drops the task (its filter requires the agent
+                # match), so e.g. auto_complete assignments to unicorn_N
+                # never surface.
+                if not task.get("assigned_agent_id"):
+                    to_agent = earliest.get("to_agent_id") or earliest.get(
+                        "to_agent_name"
+                    )
+                    if to_agent:
+                        task["assigned_agent_id"] = to_agent
 
             # Find completed_at from worker progress messages
             progress_msgs = [
@@ -3392,6 +3556,7 @@ class Aggregator:
                 metadata=task_data.get("metadata", {}),
                 display_role=self._classify_display_role(task_data),
                 blocker_ai_suggestions=task_data.get("blocker_ai_suggestions"),
+                work_via_subtasks=bool(task_data.get("work_via_subtasks")),
             )
             tasks.append(task)
 

--- a/cato_src/core/aggregator.py
+++ b/cato_src/core/aggregator.py
@@ -1429,11 +1429,35 @@ class Aggregator:
             except Exception as e:
                 logger.debug(f"Conversation parent-id lookup failed: {e}")
 
-            # Source B: Planka prefix fuzzy match (numeric IDs only)
-            if planka_board_id or planka_project_id:
+            # Determine whether the slow path would take the Planka prefix
+            # match or its no-prefix project_id fallback. This gate matches
+            # aggregator.py:1656 — non-numeric Planka IDs fall back.
+            has_numeric_planka = False
+            for pid in (planka_board_id, planka_project_id):
+                if pid and len(pid) >= 8:
+                    try:
+                        int(pid[:8])
+                        has_numeric_planka = True
+                        break
+                    except ValueError:
+                        pass
+
+            if has_numeric_planka:
+                # Source B: Planka prefix fuzzy match (numeric IDs only)
                 candidates |= self._query_parent_ids_by_planka_prefix(
                     planka_board_id, planka_project_id, root
                 )
+            else:
+                # Source B': project_id field match — slow-path fallback for
+                # hex-Planka projects (board_id like "f3ae1ca0..."). Without
+                # this every parent except the few in conversations is missing.
+                candidates |= self._query_parent_ids_by_project_metadata(
+                    project_id, root
+                )
+                if planka_project_id and planka_project_id != project_id:
+                    candidates |= self._query_parent_ids_by_project_metadata(
+                        planka_project_id, root
+                    )
 
             # Source C: parent IDs of subtasks that match Planka prefix.
             # Replicates the slow path's "matched subtask reveals parent"

--- a/cato_src/core/store.py
+++ b/cato_src/core/store.py
@@ -182,6 +182,14 @@ class Task:
     # Latest blocker AI suggestions (only populated for blocked tasks)
     blocker_ai_suggestions: Optional[Dict[str, Any]] = None
 
+    # True when the parent task was auto-completed via its subtasks (Marcus's
+    # check_and_complete_parent_task path). The aggregator rolls up subtask
+    # timing/agent/hours so DAG/Board render correctly, but SwimLane should
+    # skip these — subtasks interleave on the same agent, so a single bar
+    # would falsely imply contiguous work. Use Subtasks view for real
+    # timing on these parents.
+    work_via_subtasks: bool = False
+
     def __post_init__(self) -> None:
         """Validate timezone-aware timestamps."""
         if self.created_at.tzinfo is None:

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -6,6 +6,7 @@ import ConversationView from './components/ConversationView';
 import HealthCheckDashboard from './components/HealthCheckDashboard';
 import QualityDashboard from './components/QualityDashboard';
 import BoardView from './components/BoardView';
+import CostDashboard from './components/CostDashboard';
 import TimelineControls from './components/TimelineControls';
 import MetricsPanel from './components/MetricsPanel';
 import ProjectInfoDrawer from './components/ProjectInfoDrawer';
@@ -80,6 +81,12 @@ function App() {
               Quality
             </button>
           )}
+          <button
+            className={currentLayer === 'cost' ? 'active' : ''}
+            onClick={() => setCurrentLayer('cost')}
+          >
+            💰 Cost
+          </button>
           {contextTasks.length > 0 && (
             <button
               className={`project-info-trigger ${isProjectInfoOpen ? 'active' : ''}`}
@@ -93,7 +100,7 @@ function App() {
       </header>
 
       <div className="app-content">
-        <div className={`visualization-container ${currentLayer === 'quality' || currentLayer === 'board' ? 'full-width' : ''}`}>
+        <div className={`visualization-container ${currentLayer === 'quality' || currentLayer === 'board' || currentLayer === 'cost' ? 'full-width' : ''}`}>
           {/* Live mode views */}
           {currentLayer === 'network' && <NetworkGraphView />}
           {currentLayer === 'swimlanes' && <AgentSwimLanesView />}
@@ -101,6 +108,7 @@ function App() {
           {currentLayer === 'board' && <BoardView />}
           {currentLayer === 'health' && <HealthCheckDashboard />}
           {currentLayer === 'quality' && <QualityDashboard />}
+          {currentLayer === 'cost' && <CostDashboard />}
         </div>
 
         {/* Task Lifecycle Panel — inline sidebar, pushes content left */}

--- a/dashboard/src/components/AgentSpendBars.css
+++ b/dashboard/src/components/AgentSpendBars.css
@@ -1,0 +1,25 @@
+.agent-spend-bars {
+  font-family: var(--font-mono, ui-monospace, 'SF Mono', monospace);
+}
+
+.agent-spend-bars .agent-label {
+  font-size: 12px;
+  fill: var(--text-color, #1e293b);
+}
+
+.agent-spend-bars .agent-cost {
+  font-size: 11px;
+  fill: var(--text-muted, #475569);
+}
+
+.agent-spend-bars .agent-spend-row:hover rect {
+  opacity: 1;
+}
+
+.agent-spend-empty {
+  padding: 24px;
+  color: var(--text-muted, #64748b);
+  font-size: 13px;
+  font-style: italic;
+  text-align: center;
+}

--- a/dashboard/src/components/AgentSpendBars.tsx
+++ b/dashboard/src/components/AgentSpendBars.tsx
@@ -1,0 +1,122 @@
+/**
+ * Horizontal bar chart of per-agent spend in the active experiment.
+ *
+ * Renders one row per ``AgentSlice`` from the experiment summary, sorted
+ * by ``cost_usd`` descending. Uses D3 to compute the scale and React to
+ * render the SVG primitives — same hybrid the rest of Cato uses
+ * (NetworkGraphView, AgentSwimLanesView).
+ */
+
+import { useMemo } from 'react';
+import * as d3 from 'd3';
+import type { AgentSlice } from '../services/costService';
+import './AgentSpendBars.css';
+
+interface Props {
+  agents: AgentSlice[];
+  /** Total height in px. Defaults to 32 × number of rows + margins. */
+  height?: number;
+  /** Click handler — frontend wires this to an agent drill-in panel. */
+  onAgentClick?: (agentId: string) => void;
+}
+
+const MARGIN = { top: 8, right: 64, bottom: 8, left: 140 };
+const ROW_HEIGHT = 28;
+
+const ROLE_COLORS: Record<string, string> = {
+  planner: '#7c3aed',     // purple
+  worker: '#0ea5e9',      // sky
+  creator: '#10b981',     // emerald
+  monitor: '#f59e0b',     // amber
+  subagent: '#8b5cf6',    // violet
+};
+
+function formatUsd(v: number): string {
+  if (v >= 1) return `$${v.toFixed(2)}`;
+  return `$${v.toFixed(4)}`;
+}
+
+const AgentSpendBars = ({ agents, height, onAgentClick }: Props) => {
+  // Sort defensively — backend already orders by cost_usd DESC but the
+  // parent may have remapped.
+  const sorted = useMemo(
+    () => [...agents].sort((a, b) => b.cost_usd - a.cost_usd),
+    [agents],
+  );
+
+  const totalHeight =
+    height ?? sorted.length * ROW_HEIGHT + MARGIN.top + MARGIN.bottom;
+  const width = 640;
+  const innerWidth = width - MARGIN.left - MARGIN.right;
+
+  const xScale = useMemo(() => {
+    const maxCost = d3.max(sorted, (d) => d.cost_usd) ?? 0.0001;
+    return d3.scaleLinear().domain([0, maxCost]).range([0, innerWidth]);
+  }, [sorted, innerWidth]);
+
+  if (sorted.length === 0) {
+    return (
+      <div className="agent-spend-empty">
+        No agent activity yet — events will appear when the next worker turn lands.
+      </div>
+    );
+  }
+
+  return (
+    <svg
+      className="agent-spend-bars"
+      width="100%"
+      height={totalHeight}
+      viewBox={`0 0 ${width} ${totalHeight}`}
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      aria-label="Per-agent spend"
+    >
+      <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+        {sorted.map((a, i) => {
+          const y = i * ROW_HEIGHT;
+          const barWidth = xScale(a.cost_usd);
+          const color = ROLE_COLORS[a.role] ?? '#64748b';
+          return (
+            <g
+              key={a.agent_id}
+              className="agent-spend-row"
+              transform={`translate(0,${y})`}
+              onClick={() => onAgentClick?.(a.agent_id)}
+              style={{ cursor: onAgentClick ? 'pointer' : 'default' }}
+            >
+              <text
+                className="agent-label"
+                x={-8}
+                y={ROW_HEIGHT / 2}
+                textAnchor="end"
+                dominantBaseline="middle"
+              >
+                {a.agent_id}
+              </text>
+              <rect
+                x={0}
+                y={4}
+                width={barWidth}
+                height={ROW_HEIGHT - 8}
+                fill={color}
+                opacity={0.85}
+                rx={3}
+              />
+              <text
+                className="agent-cost"
+                x={barWidth + 8}
+                y={ROW_HEIGHT / 2}
+                dominantBaseline="middle"
+              >
+                {formatUsd(a.cost_usd)}
+              </text>
+            </g>
+          );
+        })}
+      </g>
+    </svg>
+  );
+};
+
+export default AgentSpendBars;

--- a/dashboard/src/components/AgentSwimLanesView.css
+++ b/dashboard/src/components/AgentSwimLanesView.css
@@ -13,6 +13,21 @@
   position: relative;
 }
 
+.swimlane-hint {
+  margin: 0.75rem 1rem 1.25rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  color: #94a3b8;
+  background-color: rgba(30, 41, 59, 0.5);
+  border-left: 3px solid #64748b;
+  border-radius: 0 0.25rem 0.25rem 0;
+}
+
+.swimlane-hint strong {
+  color: #cbd5e1;
+  font-weight: 600;
+}
+
 .swimlanes-content {
   position: relative;
   min-height: 100%;

--- a/dashboard/src/components/AgentSwimLanesView.tsx
+++ b/dashboard/src/components/AgentSwimLanesView.tsx
@@ -1,6 +1,7 @@
 import { useVisualizationStore } from '../store/visualizationStore';
 import { Task as SnapshotTask } from '../services/dataService';
 import { getTaskStateAtTime, timeToLogScale } from '../utils/timelineUtils';
+import ViewModeToggle from './ViewModeToggle';
 import './AgentSwimLanesView.css';
 
 type TaskStatus = 'todo' | 'in_progress' | 'done' | 'blocked';
@@ -16,6 +17,7 @@ const AgentSwimLanesView = () => {
   if (!snapshot || !snapshot.start_time || !snapshot.end_time) {
     return (
       <div className="swimlanes-view">
+        <ViewModeToggle />
         <div className="swimlanes-container">
           <div className="no-data">No snapshot data available</div>
         </div>
@@ -142,6 +144,7 @@ const AgentSwimLanesView = () => {
 
   return (
     <div className="swimlanes-view">
+      <ViewModeToggle />
       <div className="swimlanes-container">
         <div className="swimlanes-content">
           {/* Time axis */}

--- a/dashboard/src/components/AgentSwimLanesView.tsx
+++ b/dashboard/src/components/AgentSwimLanesView.tsx
@@ -34,10 +34,18 @@ const AgentSwimLanesView = () => {
     (t) => t.display_role === 'structural'
   );
 
+  // Skip parents whose work happened on interleaved subtasks — their
+  // rolled-up min→max span would overlap with sibling parents on the
+  // same agent. Subtasks view shows real timing for those.
+  const hiddenViaSubtaskRollup = snapshot.tasks.filter((t) => t.work_via_subtasks).length;
+
   const agentTasks = snapshot.agents
     .map((agent) => {
       const tasks = snapshot.tasks.filter(
-        (t) => t.assigned_agent_id === agent.id && (t.display_role || 'work') === 'work'
+        (t) =>
+          t.assigned_agent_id === agent.id &&
+          (t.display_role || 'work') === 'work' &&
+          !t.work_via_subtasks
       );
       return { agent, tasks };
     })
@@ -330,6 +338,13 @@ const AgentSwimLanesView = () => {
             </div>
           ))}
         </div>
+        {hiddenViaSubtaskRollup > 0 && (
+          <div className="swimlane-hint">
+            {hiddenViaSubtaskRollup} auto-completed parent
+            {hiddenViaSubtaskRollup === 1 ? '' : 's'} hidden — switch to
+            <strong> Subtasks</strong> view for real timing.
+          </div>
+        )}
       </div>
 
     </div>

--- a/dashboard/src/components/BoardView.tsx
+++ b/dashboard/src/components/BoardView.tsx
@@ -3,6 +3,7 @@ import { useVisualizationStore } from '../store/visualizationStore';
 import { Task } from '../services/dataService';
 import { getTaskStateAtTime } from '../utils/timelineUtils';
 import ArtifactPreviewModal from './ArtifactPreviewModal';
+import ViewModeToggle from './ViewModeToggle';
 import './BoardView.css';
 
 const COLUMNS: { key: Task['status']; label: string; color: string; icon: string }[] = [
@@ -137,6 +138,7 @@ const BoardView = () => {
   if (!snapshot) {
     return (
       <div className="board-view">
+        <ViewModeToggle />
         <div className="board-empty">No data available</div>
       </div>
     );
@@ -232,6 +234,7 @@ const BoardView = () => {
 
   return (
     <div className={`board-view ${selectedTask ? 'with-detail' : ''}`}>
+      <ViewModeToggle />
       {/* Board columns */}
       <div className="board-columns">
         {COLUMNS.map((col) => {

--- a/dashboard/src/components/BudgetTab.css
+++ b/dashboard/src/components/BudgetTab.css
@@ -1,0 +1,125 @@
+.cost-budget {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 24px;
+}
+
+.budget-banner {
+  padding: 12px 16px;
+  border-radius: 6px;
+  font-weight: 500;
+}
+
+.budget-banner.banner-warning {
+  background: rgba(245, 158, 11, 0.12);
+  color: #b45309;
+  border: 1px solid rgba(245, 158, 11, 0.4);
+}
+
+.budget-banner.banner-over {
+  background: rgba(220, 38, 38, 0.12);
+  color: #b91c1c;
+  border: 1px solid rgba(220, 38, 38, 0.4);
+}
+
+.budget-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.budget-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 8px;
+  background: var(--bg-elevated, #ffffff);
+}
+
+.budget-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted, #64748b);
+}
+
+.budget-value {
+  font-size: 22px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.budget-value.negative {
+  color: #dc2626;
+}
+
+.budget-bar-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.budget-bar {
+  height: 10px;
+  background: var(--border-color, #e2e8f0);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.budget-bar-fill {
+  height: 100%;
+  background: #0ea5e9;
+  transition: width 0.3s ease-out;
+}
+
+.budget-bar-fill.fill-warning {
+  background: #f59e0b;
+}
+
+.budget-bar-fill.fill-over {
+  background: #dc2626;
+}
+
+.budget-bar-caption {
+  font-size: 12px;
+  color: var(--text-muted, #64748b);
+  font-variant-numeric: tabular-nums;
+}
+
+.budget-meta {
+  display: flex;
+  gap: 24px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-color, #e2e8f0);
+  font-size: 13px;
+}
+
+.budget-meta .meta-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #64748b);
+  margin-right: 6px;
+}
+
+.budget-meta .meta-value {
+  font-weight: 500;
+}
+
+.budget-hint {
+  padding: 12px 16px;
+  background: var(--bg-canvas, #f8fafc);
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--text-muted, #475569);
+}
+
+.budget-hint code {
+  background: var(--bg-elevated, #ffffff);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}

--- a/dashboard/src/components/BudgetTab.css
+++ b/dashboard/src/components/BudgetTab.css
@@ -123,3 +123,122 @@
   border-radius: 4px;
   font-size: 12px;
 }
+
+/* Budget cap form */
+.budget-set-form {
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  background: var(--bg-elevated, #ffffff);
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+}
+
+.budget-current-cap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.budget-cap-label {
+  font-size: 13px;
+  color: var(--text-muted, #475569);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.budget-cap-value {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--text-primary, #0f172a);
+}
+
+.budget-cap-note {
+  font-size: 13px;
+  color: var(--text-muted, #475569);
+  font-style: italic;
+}
+
+.budget-cap-empty {
+  font-size: 13px;
+  color: var(--text-muted, #94a3b8);
+}
+
+.budget-edit-btn {
+  margin-left: auto;
+  padding: 4px 12px;
+  font-size: 13px;
+  background: var(--bg-canvas, #f8fafc);
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.budget-edit-btn:hover {
+  background: var(--bg-hover, #e2e8f0);
+}
+
+.budget-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.budget-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted, #475569);
+}
+
+.budget-form input {
+  padding: 6px 10px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 4px;
+  font-size: 14px;
+  min-width: 160px;
+}
+
+.budget-form-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.budget-form-actions button {
+  padding: 6px 14px;
+  font-size: 13px;
+  border-radius: 4px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  cursor: pointer;
+}
+
+.budget-form-actions button[type="submit"] {
+  background: var(--primary, #3b82f6);
+  color: white;
+  border-color: var(--primary, #3b82f6);
+}
+
+.budget-form-actions button[type="submit"]:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.budget-form-hint {
+  margin-left: 8px;
+  color: var(--text-muted, #64748b);
+  font-size: 12px;
+}
+
+.budget-form-msg {
+  width: 100%;
+  margin: 4px 0 0 0;
+  font-size: 13px;
+  color: var(--text-muted, #475569);
+}
+
+.budget-form-msg.success {
+  color: var(--success, #16a34a);
+}

--- a/dashboard/src/components/BudgetTab.tsx
+++ b/dashboard/src/components/BudgetTab.tsx
@@ -1,137 +1,296 @@
 /**
- * Tab 3 — Budget projection.
+ * Tab 3 — Budget view (project-scoped).
  *
- * Reads the active experiment's running totals plus its declared
- * ``budget_usd`` (set at experiment creation) and shows:
- * 1. Current spend / budget cap / remaining headroom
- * 2. Projected total based on elapsed-vs-completed ratio
- * 3. A threshold-crossing banner once spend exceeds 80% of budget
+ * Project-first (Marcus #503): renders cumulative spend, spend rate,
+ * and projection for one project. When a project-level budget cap is
+ * set (via the form in this tab), compares spend against cap and
+ * surfaces threshold-crossing warnings — the same UX the old
+ * experiment-level Budget tab had, lifted to the project axis.
  *
- * No backend changes — derives everything from the experiment summary
- * already exposed by ``/api/cost/experiments/{id}``.
+ * Budget caps persist in Marcus's cost DB via the ``project_budgets``
+ * table and survive Cato restarts.
  */
 
 import { useEffect, useState } from 'react';
 import {
-  fetchExperimentSummary,
-  type ExperimentSummary,
+  fetchProjectBudget,
+  fetchProjectFullSummary,
+  setProjectBudget,
+  type ProjectBudget,
+  type ProjectFullSummary,
 } from '../services/costService';
 import './BudgetTab.css';
 
 interface Props {
-  experimentId: string;
+  projectId: string;
 }
 
 function formatUsd(v: number, decimals = 2): string {
   return `$${v.toFixed(decimals)}`;
 }
 
-function elapsedMinutes(startedAt: string, endedAt: string | null): number {
-  const start = new Date(startedAt).getTime();
-  const end = endedAt ? new Date(endedAt).getTime() : Date.now();
+function elapsedMinutes(firstAt: string, lastAt: string): number {
+  const start = new Date(firstAt).getTime();
+  const end = new Date(lastAt).getTime();
   return Math.max(0, (end - start) / 60000);
 }
 
-const BudgetTab = ({ experimentId }: Props) => {
-  const [summary, setSummary] = useState<ExperimentSummary | null>(null);
+const BudgetTab = ({ projectId }: Props) => {
+  const [summary, setSummary] = useState<ProjectFullSummary | null>(null);
+  const [budget, setBudget] = useState<ProjectBudget | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [noActivity, setNoActivity] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  // Budget edit form state.
+  const [editing, setEditing] = useState(false);
+  const [draftCap, setDraftCap] = useState('');
+  const [draftNote, setDraftNote] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [formMsg, setFormMsg] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    setLoaded(false);
+    setNoActivity(false);
+    setSummary(null);
+    setBudget(null);
+
     const tick = async () => {
       try {
-        const s = await fetchExperimentSummary(experimentId);
+        const s = await fetchProjectFullSummary(projectId);
         if (!cancelled) {
           setSummary(s);
+          setNoActivity(false);
           setError(null);
         }
       } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('HTTP 404')) {
+          setNoActivity(true);
+          setError(null);
+        } else {
+          setError(msg);
         }
       }
+
+      // Budget fetch runs even when summary 404s — user might be
+      // setting a cap before the first LLM call.
+      try {
+        const b = await fetchProjectBudget(projectId);
+        if (!cancelled) setBudget(b.budget);
+      } catch {
+        // non-fatal
+      }
+
+      if (!cancelled) setLoaded(true);
     };
-    tick();
+    void tick();
     const id = window.setInterval(tick, 10_000);
     return () => {
       cancelled = true;
       window.clearInterval(id);
     };
-  }, [experimentId]);
+  }, [projectId]);
+
+  const submitBudget = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setFormMsg(null);
+    try {
+      const cap = Number(draftCap);
+      if (Number.isNaN(cap)) {
+        setFormMsg('Enter a number.');
+        return;
+      }
+      const result = await setProjectBudget(
+        projectId,
+        cap,
+        draftNote || undefined,
+      );
+      setBudget(result.budget);
+      setEditing(false);
+      setDraftCap('');
+      setDraftNote('');
+      setFormMsg(
+        result.budget == null
+          ? 'Cap cleared.'
+          : `Cap set to ${formatUsd(result.budget.budget_usd)}.`,
+      );
+    } catch (err) {
+      setFormMsg(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
 
   if (error) return <div className="cost-error">⚠ {error}</div>;
-  if (!summary) return <div className="cost-loading">Loading budget…</div>;
 
-  // budget_usd is on the experiment metadata returned by the summary;
-  // it is set at creation time (Marcus's Experiment dataclass field).
-  const budget = (summary as unknown as { budget_usd: number | null }).budget_usd;
-  const spent = summary.summary.total_cost_usd;
-  const isRunning = summary.ended_at === null;
+  // Show the budget form even when noActivity so users can set caps before
+  // any LLM call lands. The trajectory section is hidden in that case.
+  const headerSection = (
+    <section className="budget-set-form">
+      {!editing && (
+        <div className="budget-current-cap">
+          {budget != null ? (
+            <>
+              <span className="budget-cap-label">Cap:</span>
+              <span className="budget-cap-value">
+                {formatUsd(budget.budget_usd)}
+              </span>
+              {budget.note && (
+                <span className="budget-cap-note">— {budget.note}</span>
+              )}
+            </>
+          ) : (
+            <span className="budget-cap-empty">No cap set for this project.</span>
+          )}
+          <button
+            type="button"
+            className="budget-edit-btn"
+            onClick={() => {
+              setEditing(true);
+              setDraftCap(budget ? String(budget.budget_usd) : '');
+              setDraftNote(budget?.note ?? '');
+              setFormMsg(null);
+            }}
+          >
+            {budget != null ? 'Edit' : 'Set cap'}
+          </button>
+        </div>
+      )}
+      {editing && (
+        <form className="budget-form" onSubmit={submitBudget}>
+          <label>
+            <span>Cap ($)</span>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              required
+              value={draftCap}
+              onChange={(e) => setDraftCap(e.target.value)}
+              placeholder="e.g. 50"
+            />
+          </label>
+          <label>
+            <span>Note (optional)</span>
+            <input
+              type="text"
+              value={draftNote}
+              onChange={(e) => setDraftNote(e.target.value)}
+              placeholder="e.g. PoC budget"
+            />
+          </label>
+          <div className="budget-form-actions">
+            <button type="submit" disabled={saving}>
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setEditing(false);
+                setFormMsg(null);
+              }}
+            >
+              Cancel
+            </button>
+            <small className="budget-form-hint">
+              Set to 0 to clear the cap.
+            </small>
+          </div>
+          {formMsg && <p className="budget-form-msg">{formMsg}</p>}
+        </form>
+      )}
+      {!editing && formMsg && (
+        <p className="budget-form-msg success">{formMsg}</p>
+      )}
+    </section>
+  );
 
-  // Projection: linear extrapolation from completed_tasks / total_tasks.
-  // Falls back to "n/a" if neither is known.
-  let projected: number | null = null;
-  if (
-    summary.completed_tasks != null &&
-    summary.total_tasks != null &&
-    summary.completed_tasks > 0
-  ) {
-    projected = spent * (summary.total_tasks / summary.completed_tasks);
+  if (noActivity) {
+    return (
+      <div className="cost-budget">
+        {headerSection}
+        <div className="cost-empty">
+          <p>No spend recorded for this project yet.</p>
+          <p className="hint">
+            Spend trajectory appears here once at least one LLM call has
+            been attributed to this project. The cap above will apply as
+            soon as costs start accruing.
+          </p>
+        </div>
+      </div>
+    );
   }
 
-  const pct = budget && budget > 0 ? spent / budget : null;
-  const remaining = budget != null ? budget - spent : null;
-  const alertThreshold = pct != null && pct >= 0.8;
-  const overBudget = pct != null && pct >= 1.0;
+  if (!summary && !loaded) return <div className="cost-loading">Loading budget…</div>;
+  if (!summary) return <div className="cost-empty">No data.</div>;
 
-  const elapsed = elapsedMinutes(summary.started_at, summary.ended_at);
+  const s = summary.summary;
+  const spent = s.total_cost_usd;
+  const elapsed = elapsedMinutes(s.first_event_at, s.last_event_at);
+  const rate = elapsed > 0 ? spent / elapsed : 0;
+  const oneHourProjection = spent + rate * 60;
+
+  // Cap-comparison metrics.
+  const cap = budget?.budget_usd ?? null;
+  const pct = cap != null && cap > 0 ? spent / cap : null;
+  const remaining = cap != null ? cap - spent : null;
+  const overBudget = pct != null && pct >= 1.0;
+  const alertThreshold = pct != null && pct >= 0.8;
 
   return (
     <div className="cost-budget">
-      {alertThreshold && (
+      {headerSection}
+
+      {alertThreshold && cap != null && (
         <div
           className={`budget-banner ${
             overBudget ? 'banner-over' : 'banner-warning'
           }`}
         >
           {overBudget
-            ? `⚠ Over budget — spent ${formatUsd(spent)} of ${formatUsd(
-                budget!,
-              )} cap`
-            : `⚠ At ${(pct! * 100).toFixed(0)}% of budget`}
+            ? `⚠ Over budget — spent ${formatUsd(spent)} of ${formatUsd(cap)} cap`
+            : `⚠ At ${(pct! * 100).toFixed(0)}% of ${formatUsd(cap)} cap`}
         </div>
       )}
 
       <section className="budget-grid">
         <div className="budget-card">
-          <span className="budget-label">Spent</span>
+          <span className="budget-label">Total spent</span>
           <span className="budget-value">{formatUsd(spent)}</span>
         </div>
+        {cap != null && (
+          <div className="budget-card">
+            <span className="budget-label">Remaining</span>
+            <span
+              className={`budget-value ${
+                remaining != null && remaining < 0 ? 'negative' : ''
+              }`}
+            >
+              {remaining != null ? formatUsd(remaining) : '—'}
+            </span>
+          </div>
+        )}
         <div className="budget-card">
-          <span className="budget-label">Budget</span>
-          <span className="budget-value">
-            {budget != null ? formatUsd(budget) : '—'}
-          </span>
+          <span className="budget-label">Spend rate</span>
+          <span className="budget-value">{formatUsd(rate, 4)}/min</span>
         </div>
         <div className="budget-card">
-          <span className="budget-label">Remaining</span>
-          <span
-            className={`budget-value ${
-              remaining != null && remaining < 0 ? 'negative' : ''
-            }`}
-          >
-            {remaining != null ? formatUsd(remaining) : '—'}
-          </span>
+          <span className="budget-label">+1h projection</span>
+          <span className="budget-value">{formatUsd(oneHourProjection)}</span>
         </div>
         <div className="budget-card">
-          <span className="budget-label">Projected total</span>
+          <span className="budget-label">Cache savings</span>
           <span className="budget-value">
-            {projected != null ? formatUsd(projected) : '—'}
+            {(s.cache_hit_rate * 100).toFixed(1)}%
           </span>
         </div>
       </section>
 
-      {budget != null && budget > 0 && (
+      {cap != null && cap > 0 && (
         <section className="budget-bar-row">
           <div className="budget-bar">
             <div
@@ -142,33 +301,58 @@ const BudgetTab = ({ experimentId }: Props) => {
             />
           </div>
           <div className="budget-bar-caption">
-            {(pct! * 100).toFixed(1)}% of {formatUsd(budget)}
+            {(pct! * 100).toFixed(1)}% of {formatUsd(cap)}
           </div>
         </section>
       )}
 
       <section className="budget-meta">
         <div>
-          <span className="meta-label">Status</span>
-          <span className="meta-value">{isRunning ? 'running' : 'done'}</span>
+          <span className="meta-label">Events</span>
+          <span className="meta-value">{s.total_events}</span>
+        </div>
+        <div>
+          <span className="meta-label">Agents</span>
+          <span className="meta-value">{s.agents}</span>
+        </div>
+        <div>
+          <span className="meta-label">Sessions</span>
+          <span className="meta-value">{s.sessions}</span>
         </div>
         <div>
           <span className="meta-label">Elapsed</span>
           <span className="meta-value">{elapsed.toFixed(1)} min</span>
         </div>
-        <div>
-          <span className="meta-label">Tasks</span>
-          <span className="meta-value">
-            {summary.completed_tasks ?? '?'} / {summary.total_tasks ?? '?'}
-          </span>
-        </div>
       </section>
 
-      {budget == null && (
-        <p className="budget-hint">
-          No budget set on this experiment. Add a <code>budget_usd</code> when
-          you create the experiment to see projections and alerts.
-        </p>
+      {summary.by_model.length > 0 && (
+        <section className="cost-panel">
+          <h3>Spend by model</h3>
+          <table className="cost-table">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>Provider</th>
+                <th>Events</th>
+                <th>Cost</th>
+                <th>% of total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.by_model.map((m) => (
+                <tr key={`${m.model}-${m.provider}`}>
+                  <td>{m.model}</td>
+                  <td>{m.provider}</td>
+                  <td>{m.events}</td>
+                  <td>{formatUsd(m.cost_usd, 4)}</td>
+                  <td>
+                    {spent > 0 ? ((m.cost_usd / spent) * 100).toFixed(1) : '0'}%
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
       )}
     </div>
   );

--- a/dashboard/src/components/BudgetTab.tsx
+++ b/dashboard/src/components/BudgetTab.tsx
@@ -1,0 +1,177 @@
+/**
+ * Tab 3 — Budget projection.
+ *
+ * Reads the active experiment's running totals plus its declared
+ * ``budget_usd`` (set at experiment creation) and shows:
+ * 1. Current spend / budget cap / remaining headroom
+ * 2. Projected total based on elapsed-vs-completed ratio
+ * 3. A threshold-crossing banner once spend exceeds 80% of budget
+ *
+ * No backend changes — derives everything from the experiment summary
+ * already exposed by ``/api/cost/experiments/{id}``.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  fetchExperimentSummary,
+  type ExperimentSummary,
+} from '../services/costService';
+import './BudgetTab.css';
+
+interface Props {
+  experimentId: string;
+}
+
+function formatUsd(v: number, decimals = 2): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function elapsedMinutes(startedAt: string, endedAt: string | null): number {
+  const start = new Date(startedAt).getTime();
+  const end = endedAt ? new Date(endedAt).getTime() : Date.now();
+  return Math.max(0, (end - start) / 60000);
+}
+
+const BudgetTab = ({ experimentId }: Props) => {
+  const [summary, setSummary] = useState<ExperimentSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const s = await fetchExperimentSummary(experimentId);
+        if (!cancelled) {
+          setSummary(s);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    };
+    tick();
+    const id = window.setInterval(tick, 10_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [experimentId]);
+
+  if (error) return <div className="cost-error">⚠ {error}</div>;
+  if (!summary) return <div className="cost-loading">Loading budget…</div>;
+
+  // budget_usd is on the experiment metadata returned by the summary;
+  // it is set at creation time (Marcus's Experiment dataclass field).
+  const budget = (summary as unknown as { budget_usd: number | null }).budget_usd;
+  const spent = summary.summary.total_cost_usd;
+  const isRunning = summary.ended_at === null;
+
+  // Projection: linear extrapolation from completed_tasks / total_tasks.
+  // Falls back to "n/a" if neither is known.
+  let projected: number | null = null;
+  if (
+    summary.completed_tasks != null &&
+    summary.total_tasks != null &&
+    summary.completed_tasks > 0
+  ) {
+    projected = spent * (summary.total_tasks / summary.completed_tasks);
+  }
+
+  const pct = budget && budget > 0 ? spent / budget : null;
+  const remaining = budget != null ? budget - spent : null;
+  const alertThreshold = pct != null && pct >= 0.8;
+  const overBudget = pct != null && pct >= 1.0;
+
+  const elapsed = elapsedMinutes(summary.started_at, summary.ended_at);
+
+  return (
+    <div className="cost-budget">
+      {alertThreshold && (
+        <div
+          className={`budget-banner ${
+            overBudget ? 'banner-over' : 'banner-warning'
+          }`}
+        >
+          {overBudget
+            ? `⚠ Over budget — spent ${formatUsd(spent)} of ${formatUsd(
+                budget!,
+              )} cap`
+            : `⚠ At ${(pct! * 100).toFixed(0)}% of budget`}
+        </div>
+      )}
+
+      <section className="budget-grid">
+        <div className="budget-card">
+          <span className="budget-label">Spent</span>
+          <span className="budget-value">{formatUsd(spent)}</span>
+        </div>
+        <div className="budget-card">
+          <span className="budget-label">Budget</span>
+          <span className="budget-value">
+            {budget != null ? formatUsd(budget) : '—'}
+          </span>
+        </div>
+        <div className="budget-card">
+          <span className="budget-label">Remaining</span>
+          <span
+            className={`budget-value ${
+              remaining != null && remaining < 0 ? 'negative' : ''
+            }`}
+          >
+            {remaining != null ? formatUsd(remaining) : '—'}
+          </span>
+        </div>
+        <div className="budget-card">
+          <span className="budget-label">Projected total</span>
+          <span className="budget-value">
+            {projected != null ? formatUsd(projected) : '—'}
+          </span>
+        </div>
+      </section>
+
+      {budget != null && budget > 0 && (
+        <section className="budget-bar-row">
+          <div className="budget-bar">
+            <div
+              className={`budget-bar-fill ${
+                overBudget ? 'fill-over' : alertThreshold ? 'fill-warning' : ''
+              }`}
+              style={{ width: `${Math.min(pct! * 100, 100)}%` }}
+            />
+          </div>
+          <div className="budget-bar-caption">
+            {(pct! * 100).toFixed(1)}% of {formatUsd(budget)}
+          </div>
+        </section>
+      )}
+
+      <section className="budget-meta">
+        <div>
+          <span className="meta-label">Status</span>
+          <span className="meta-value">{isRunning ? 'running' : 'done'}</span>
+        </div>
+        <div>
+          <span className="meta-label">Elapsed</span>
+          <span className="meta-value">{elapsed.toFixed(1)} min</span>
+        </div>
+        <div>
+          <span className="meta-label">Tasks</span>
+          <span className="meta-value">
+            {summary.completed_tasks ?? '?'} / {summary.total_tasks ?? '?'}
+          </span>
+        </div>
+      </section>
+
+      {budget == null && (
+        <p className="budget-hint">
+          No budget set on this experiment. Add a <code>budget_usd</code> when
+          you create the experiment to see projections and alerts.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default BudgetTab;

--- a/dashboard/src/components/CostDashboard.css
+++ b/dashboard/src/components/CostDashboard.css
@@ -123,30 +123,109 @@
 }
 
 .cost-picker label {
-  color: var(--text-muted, #64748b);
+  /* On dark backgrounds the prior #64748b was almost invisible. Lift
+     to a brighter slate so the picker label reads cleanly. */
+  color: var(--text-primary, #e2e8f0);
+  font-weight: 500;
 }
 
 .cost-picker select {
-  padding: 6px 10px;
-  font-size: 13px;
-  border: 1px solid var(--border-color, #cbd5e1);
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid var(--border-color, #475569);
   border-radius: 6px;
-  background: var(--bg-elevated, #ffffff);
-  min-width: 220px;
+  background: var(--bg-elevated, #1e293b);
+  color: var(--text-primary, #f1f5f9);
+  min-width: 320px;
+  max-width: 520px;
   font-variant-numeric: tabular-nums;
 }
 
-.cost-unassigned-banner {
-  /* Take a full row on narrow viewports so the banner can't be pushed
-     off-screen by a long picker chain. (Kaia PR #33 review.) */
-  flex-basis: 100%;
-  margin-left: auto;
-  padding: 6px 10px;
-  background: rgba(245, 158, 11, 0.12);
+.cost-picker select option {
+  /* Some browsers don't inherit colors well on <option>s when the
+     parent <select> is dark — force the pairing explicitly. */
+  background: #1e293b;
+  color: #f1f5f9;
+}
+
+/* Compact caution icon — replaces the wide inline 'Unassigned: …'
+   banner that previously pushed the picker off-screen. Click to
+   toggle the popover with details. */
+.cost-unassigned-icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: 50%;
+  background: rgba(245, 158, 11, 0.18);
+  border: 1px solid rgba(245, 158, 11, 0.55);
+  color: #fbbf24;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.cost-unassigned-icon:hover {
+  background: rgba(245, 158, 11, 0.32);
+}
+
+.cost-unassigned-popover {
+  margin-top: 10px;
+  padding: 12px 16px;
+  background: var(--bg-elevated, #1e293b);
   border: 1px solid rgba(245, 158, 11, 0.4);
-  color: #b45309;
-  border-radius: 6px;
+  border-radius: 8px;
+  color: var(--text-primary, #f1f5f9);
+  max-width: 520px;
+}
+
+.cost-unassigned-popover h4 {
+  margin: 0 0 6px;
+  font-size: 14px;
+  color: #fbbf24;
+}
+
+.cost-unassigned-popover .hint {
+  margin: 0 0 10px;
   font-size: 12px;
+  color: var(--text-muted, #cbd5e1);
+}
+
+.cost-unassigned-stats {
+  display: flex;
+  gap: 18px;
+  margin: 0 0 8px;
+}
+
+.cost-unassigned-stats > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.cost-unassigned-stats dt {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted, #94a3b8);
+}
+
+.cost-unassigned-stats dd {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
-  cursor: help;
+}
+
+.cost-unassigned-close {
+  font-size: 12px;
+  padding: 4px 10px;
+  background: transparent;
+  color: var(--text-muted, #cbd5e1);
+  border: 1px solid var(--border-color, #475569);
+  border-radius: 4px;
+  cursor: pointer;
 }

--- a/dashboard/src/components/CostDashboard.css
+++ b/dashboard/src/components/CostDashboard.css
@@ -105,3 +105,48 @@
   color: var(--text-muted, #64748b);
   font-size: 14px;
 }
+
+/* Phase-9 project-axis additions */
+
+.cost-pickers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  align-items: center;
+}
+
+.cost-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.cost-picker label {
+  color: var(--text-muted, #64748b);
+}
+
+.cost-picker select {
+  padding: 6px 10px;
+  font-size: 13px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 6px;
+  background: var(--bg-elevated, #ffffff);
+  min-width: 220px;
+  font-variant-numeric: tabular-nums;
+}
+
+.cost-unassigned-banner {
+  /* Take a full row on narrow viewports so the banner can't be pushed
+     off-screen by a long picker chain. (Kaia PR #33 review.) */
+  flex-basis: 100%;
+  margin-left: auto;
+  padding: 6px 10px;
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.4);
+  color: #b45309;
+  border-radius: 6px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  cursor: help;
+}

--- a/dashboard/src/components/CostDashboard.css
+++ b/dashboard/src/components/CostDashboard.css
@@ -1,0 +1,107 @@
+.cost-dashboard {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: auto;
+  background: var(--bg-canvas, #f8fafc);
+}
+
+.cost-dashboard-error {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted, #64748b);
+}
+
+.cost-dashboard-error h2 {
+  font-size: 18px;
+  margin: 0 0 8px;
+  color: var(--text-color, #1e293b);
+}
+
+.cost-dashboard-error .hint {
+  font-size: 12px;
+  margin-top: 12px;
+  font-style: italic;
+}
+
+.cost-dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-dashboard-header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.cost-experiment-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.cost-experiment-picker label {
+  color: var(--text-muted, #64748b);
+}
+
+.cost-experiment-picker select {
+  padding: 6px 10px;
+  font-size: 13px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 6px;
+  background: var(--bg-elevated, #ffffff);
+  min-width: 240px;
+}
+
+.cost-tab-strip {
+  display: flex;
+  gap: 4px;
+  padding: 8px 24px 0;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-tab-strip button {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  border: none;
+  background: transparent;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  color: var(--text-muted, #64748b);
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.cost-tab-strip button:hover:not(:disabled) {
+  color: var(--text-color, #1e293b);
+}
+
+.cost-tab-strip button.active {
+  color: var(--accent-color, #0ea5e9);
+  border-bottom-color: var(--accent-color, #0ea5e9);
+}
+
+.cost-tab-strip button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cost-tab-content {
+  flex: 1;
+  overflow: auto;
+}
+
+.cost-empty {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted, #64748b);
+  font-size: 14px;
+}

--- a/dashboard/src/components/CostDashboard.tsx
+++ b/dashboard/src/components/CostDashboard.tsx
@@ -1,34 +1,30 @@
 /**
  * Top-level cost dashboard page (Marcus issue #409).
  *
- * Project-first: project_id is the only universal identity in Marcus's
- * coordination model (Marcus CLAUDE.md GH-388, spawn_agents.py, and
- * the #503 project-axis refactor). Marcus's main code path doesn't
- * open MLflow experiments, so the experiment dimension is no longer
- * surfaced in the UI — every tab renders from project-level data.
+ * Project-first (Marcus #503): project_id is the only universal
+ * identity. The picker is unified with Cato's main header dropdown —
+ * pick a project once at the top of the page and the Cost view
+ * reflects that choice. There is no local picker.
  *
- * Sub-tabs (all keyed off the selected project):
- *   - Real-time  → live spend, agents working, per-role breakdown
- *   - Historical → cross-project totals + per-project time series
- *   - Budget     → cost so far vs. spend rate / projection
- *   - Pricing    → current rate table + insert form
+ * The view now contains only two tabs: Real-time (live spend +
+ * per-call breakdown) and Budget (cap + projection). Historical and
+ * Pricing are accessed from the settings gear in the header (full-
+ * screen modals) since they're cross-project / global views, not
+ * tied to the active project.
  */
 
 import { useEffect, useRef, useState } from 'react';
+import { useVisualizationStore } from '../store/visualizationStore';
 import {
-  fetchProjects,
   fetchUnassignedTotals,
   triggerIngest,
-  type ProjectRow,
   type UnassignedTotals,
 } from '../services/costService';
 import BudgetTab from './BudgetTab';
-import HistoricalTab from './HistoricalTab';
-import PricingTab from './PricingTab';
 import RealTimeTab from './RealTimeTab';
 import './CostDashboard.css';
 
-type CostTab = 'realtime' | 'historical' | 'budget' | 'pricing';
+type CostTab = 'realtime' | 'budget';
 
 function formatUsd(v: number, decimals = 2): string {
   return `$${v.toFixed(decimals)}`;
@@ -40,45 +36,33 @@ function formatTokens(v: number): string {
   return String(v);
 }
 
-function formatProjectDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return '';
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-}
-
 /**
- * Render a project label for the picker. Order of preference:
- * 1. explicit project_name (MLflow / registry overlay)
- * 2. "Unnamed · <first-event date>" — gives temporal context for
- *    projects deleted from the registry but still in token_events
- * Tokens are appended to either so users can identify by spend.
+ * Normalize a project_id to the canonical (dashless hex) form the
+ * cost DB uses. Cato's main picker emits Marcus's project_id in
+ * whichever form the registry stored it (often dashed UUID); the
+ * cost data is dashless. See Marcus canonical_project_id.
  */
-function projectLabel(p: ProjectRow): string {
-  const tokens = formatTokens(p.total_tokens);
-  const cost = formatUsd(p.total_cost_usd);
-  if (p.project_name) {
-    return `${p.project_name} — ${cost} (${tokens} tokens)`;
-  }
-  const date = formatProjectDate(p.first_event_at);
-  const prefix = date ? `Unnamed · ${date}` : 'Unnamed';
-  return `${prefix} — ${cost} (${tokens} tokens)`;
+function canonicalProjectId(pid: string | null): string | null {
+  if (!pid) return null;
+  return pid.replace(/-/g, '');
 }
 
 const CostDashboard = () => {
   const [activeTab, setActiveTab] = useState<CostTab>('realtime');
-  const [projects, setProjects] = useState<ProjectRow[]>([]);
   const [unassigned, setUnassigned] = useState<UnassignedTotals | null>(null);
   const [unassignedOpen, setUnassignedOpen] = useState(false);
-  const [selectedProject, setSelectedProject] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [initialLoading, setInitialLoading] = useState(true);
+
+  // Unified picker: read the active project from the global store.
+  // No local selectedProject state, no local <select>. Switching the
+  // main header picker propagates here automatically.
+  const globalProjectId = useVisualizationStore(
+    (state) => state.selectedProjectId,
+  );
+  const projectId = canonicalProjectId(globalProjectId);
 
   // First-paint perf: triggerIngest sweeps ~/.claude/projects/<sess>.jsonl
-  // and was previously awaited *before* fetchProjects, which made the
-  // initial load take 10+ seconds on accounts with many session files.
-  // Now we fire ingest in the background and let the picker render
-  // immediately from whatever is already in costs.db. The next poll
-  // tick picks up any rows ingest added.
+  // and was previously awaited before initial render. Now we fire in
+  // the background; the next 30s poll picks up any new rows.
   const ingestInFlight = useRef(false);
   useEffect(() => {
     let cancelled = false;
@@ -96,30 +80,7 @@ const CostDashboard = () => {
     };
 
     const load = async () => {
-      // Kick off ingest in parallel — do not await.
       fireIngestInBackground();
-
-      try {
-        const { projects: ps } = await fetchProjects();
-        if (cancelled) return;
-        setProjects(ps);
-        setError(null);
-        // Auto-select the most expensive project the first time we see
-        // any. Functional setState avoids depending on selectedProject
-        // in the effect's deps array.
-        setSelectedProject((current) =>
-          current === null && ps.length > 0 ? ps[0].project_id : current,
-        );
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
-        }
-      } finally {
-        if (!cancelled) setInitialLoading(false);
-      }
-
-      // Fetch unassigned totals independently; failure here is not
-      // fatal — we just skip the banner this tick.
       try {
         const una = await fetchUnassignedTotals();
         if (!cancelled) setUnassigned(una);
@@ -136,66 +97,25 @@ const CostDashboard = () => {
     };
   }, []);
 
-  if (error && projects.length === 0) {
-    return (
-      <div className="cost-dashboard cost-dashboard-error">
-        <h2>Cost dashboard unavailable</h2>
-        <p>{error}</p>
-        <p className="hint">
-          The cost backend may be disabled — check that Marcus is running and
-          ~/.marcus/costs.db exists.
-        </p>
-      </div>
-    );
-  }
-
   return (
     <div className="cost-dashboard">
       <div className="cost-dashboard-header">
         <h2>Cost</h2>
 
-        <div className="cost-pickers">
-          <div className="cost-picker">
-            <label htmlFor="cost-project-select">Project:</label>
-            <select
-              id="cost-project-select"
-              value={selectedProject ?? ''}
-              onChange={(e) => setSelectedProject(e.target.value || null)}
-            >
-              {projects.length === 0 && (
-                <option value="">
-                  {initialLoading ? '— loading… —' : '— none yet —'}
-                </option>
-              )}
-              {projects.map((p) => (
-                <option key={p.project_id} value={p.project_id}>
-                  {/*
-                    Name resolution: experiments.project_name (MLflow) →
-                    Marcus project registry → "Unnamed · <date>" fallback
-                    for projects deleted from the registry but still in
-                    token_events. See cost_routes._load_project_names.
-                  */}
-                  {projectLabel(p)}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {unassigned && unassigned.events > 0 && (
-            <button
-              type="button"
-              className="cost-unassigned-icon"
-              onClick={() => setUnassignedOpen((v) => !v)}
-              title={
-                'Unassigned cost — LLM calls Marcus made without an ' +
-                'active project context. Click for details.'
-              }
-              aria-label="Unassigned cost details"
-            >
-              ⚠
-            </button>
-          )}
-        </div>
+        {unassigned && unassigned.events > 0 && (
+          <button
+            type="button"
+            className="cost-unassigned-icon"
+            onClick={() => setUnassignedOpen((v) => !v)}
+            title={
+              'Unassigned cost — LLM calls Marcus made without an ' +
+              'active project context. Click for details.'
+            }
+            aria-label="Unassigned cost details"
+          >
+            ⚠
+          </button>
+        )}
 
         {unassignedOpen && unassigned && (
           <div className="cost-unassigned-popover" role="dialog">
@@ -203,7 +123,8 @@ const CostDashboard = () => {
             <p className="hint">
               Calls Marcus made without an active project context — usually
               a code path running outside the MCP request lifecycle, or a
-              project-creation tool.
+              project-creation tool. Historical view in Settings shows
+              project-by-project breakdown including deleted projects.
             </p>
             <dl className="cost-unassigned-stats">
               <div>
@@ -238,44 +159,40 @@ const CostDashboard = () => {
           Real-time
         </button>
         <button
-          className={activeTab === 'historical' ? 'active' : ''}
-          onClick={() => setActiveTab('historical')}
-        >
-          Historical
-        </button>
-        <button
           className={activeTab === 'budget' ? 'active' : ''}
           onClick={() => setActiveTab('budget')}
         >
           Budget
         </button>
-        <button
-          className={activeTab === 'pricing' ? 'active' : ''}
-          onClick={() => setActiveTab('pricing')}
-        >
-          Pricing
-        </button>
       </div>
 
       <div className="cost-tab-content">
-        {activeTab === 'realtime' && selectedProject && (
-          <RealTimeTab projectId={selectedProject} />
+        {activeTab === 'realtime' && projectId && (
+          <RealTimeTab projectId={projectId} />
         )}
-        {activeTab === 'realtime' && !selectedProject && (
+        {activeTab === 'realtime' && !projectId && (
           <div className="cost-empty">
-            No projects yet. Run one with the marcus skill and it'll appear here.
+            <p>No project selected.</p>
+            <p className="hint">
+              Pick a project from the dropdown at the top of the page to
+              see its live cost data. Historical totals (including deleted
+              projects) are available in <strong>Settings → Historical
+              Cost</strong>.
+            </p>
           </div>
         )}
-        {activeTab === 'historical' && <HistoricalTab />}
-        {activeTab === 'budget' && selectedProject && (
-          <BudgetTab projectId={selectedProject} />
+        {activeTab === 'budget' && projectId && (
+          <BudgetTab projectId={projectId} />
         )}
-        {activeTab === 'budget' && !selectedProject && (
+        {activeTab === 'budget' && !projectId && (
           <div className="cost-empty">
-            Select a project to see budget projection.
+            <p>No project selected.</p>
+            <p className="hint">
+              Pick a project at the top to see its budget cap and spend
+              projection.
+            </p>
           </div>
         )}
-        {activeTab === 'pricing' && <PricingTab />}
       </div>
     </div>
   );

--- a/dashboard/src/components/CostDashboard.tsx
+++ b/dashboard/src/components/CostDashboard.tsx
@@ -1,13 +1,29 @@
 /**
  * Top-level cost dashboard page (Marcus issue #409).
  *
- * Four sub-tabs: Real-time (current experiment), Historical (all
- * experiments), Budget (per-experiment projection vs. cap), and
- * Pricing (current rate table + CRUD form).
+ * Project is the primary axis (per Marcus CLAUDE.md GH-388 and
+ * spawn_agents.py) — experiment is a secondary tracking handle that
+ * may or may not be set depending on whether the run opted into
+ * MLflow tracking. The picker leads with project; once a project is
+ * selected, the user can optionally drill into a specific experiment
+ * (MLflow run) within it.
+ *
+ * Sub-tabs:
+ *   - Real-time  → live view of the active MLflow run (when one exists)
+ *   - Historical → cross-project totals + per-experiment time series
+ *   - Budget     → projection vs. cap for the active run
+ *   - Pricing    → current rate table + insert form
  */
 
 import { useEffect, useState } from 'react';
-import { fetchExperiments, type ExperimentRow } from '../services/costService';
+import {
+  fetchProjectSummary,
+  fetchProjects,
+  fetchUnassignedTotals,
+  type ProjectRow,
+  type ProjectSummary,
+  type UnassignedTotals,
+} from '../services/costService';
 import BudgetTab from './BudgetTab';
 import HistoricalTab from './HistoricalTab';
 import PricingTab from './PricingTab';
@@ -16,42 +32,106 @@ import './CostDashboard.css';
 
 type CostTab = 'realtime' | 'historical' | 'budget' | 'pricing';
 
+function formatUsd(v: number, decimals = 2): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function formatTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}
+
 const CostDashboard = () => {
   const [activeTab, setActiveTab] = useState<CostTab>('realtime');
-  const [experiments, setExperiments] = useState<ExperimentRow[]>([]);
+  const [projects, setProjects] = useState<ProjectRow[]>([]);
+  const [unassigned, setUnassigned] = useState<UnassignedTotals | null>(null);
+  const [selectedProject, setSelectedProject] = useState<string | null>(null);
+  const [projectSummary, setProjectSummary] = useState<ProjectSummary | null>(null);
   const [selectedExp, setSelectedExp] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Fetch experiment list on mount and refresh every 30s so a new run
-  // appears in the picker without the user reloading the page.
+  // Poll project list + unassigned totals every 30s so new runs appear
+  // without a page reload and the unassigned indicator stays current.
+  //
+  // Kaia PR #33 review:
+  // - Effect no longer depends on selectedProject (the previous version
+  //   re-subscribed on every selection change for no useful reason; the
+  //   auto-select happens via the functional setState below).
+  // - fetchUnassignedTotals is wrapped in a defensive catch so a 503
+  //   from that endpoint doesn't blank the project picker. Worst case:
+  //   the unassigned banner doesn't appear even though there's a gap.
   useEffect(() => {
     let cancelled = false;
 
     const load = async () => {
       try {
-        const { experiments: exps } = await fetchExperiments();
+        const { projects: ps } = await fetchProjects();
         if (cancelled) return;
-        setExperiments(exps);
+        setProjects(ps);
         setError(null);
-        if (selectedExp === null && exps.length > 0) {
-          setSelectedExp(exps[0].experiment_id);
-        }
+        // Auto-select the most expensive project the first time we see
+        // any. Functional setState avoids depending on selectedProject
+        // in the effect's deps array.
+        setSelectedProject((current) =>
+          current === null && ps.length > 0 ? ps[0].project_id : current,
+        );
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : String(err));
         }
+        return;
+      }
+
+      // Fetch unassigned totals independently; failure here is not
+      // fatal — we just skip the banner this tick.
+      try {
+        const una = await fetchUnassignedTotals();
+        if (!cancelled) setUnassigned(una);
+      } catch {
+        // intentionally swallowed
       }
     };
 
-    load();
+    void load();
     const id = window.setInterval(load, 30_000);
     return () => {
       cancelled = true;
       window.clearInterval(id);
     };
-  }, [selectedExp]);
+  }, []);
 
-  if (error && experiments.length === 0) {
+  // When the selected project changes, fetch its summary (totals +
+  // experiment list) and auto-select the most recent experiment for
+  // the Real-time tab.
+  useEffect(() => {
+    if (!selectedProject) {
+      setProjectSummary(null);
+      setSelectedExp(null);
+      return;
+    }
+    let cancelled = false;
+    fetchProjectSummary(selectedProject)
+      .then((s) => {
+        if (cancelled) return;
+        setProjectSummary(s);
+        if (s.experiments.length > 0) {
+          setSelectedExp(s.experiments[0].experiment_id);
+        } else {
+          setSelectedExp(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedProject]);
+
+  if (error && projects.length === 0) {
     return (
       <div className="cost-dashboard cost-dashboard-error">
         <h2>Cost dashboard unavailable</h2>
@@ -68,22 +148,72 @@ const CostDashboard = () => {
     <div className="cost-dashboard">
       <div className="cost-dashboard-header">
         <h2>Cost</h2>
-        <div className="cost-experiment-picker">
-          <label htmlFor="cost-exp-select">Experiment:</label>
-          <select
-            id="cost-exp-select"
-            value={selectedExp ?? ''}
-            onChange={(e) => setSelectedExp(e.target.value || null)}
-          >
-            {experiments.length === 0 && <option value="">— none yet —</option>}
-            {experiments.map((exp) => (
-              <option key={exp.experiment_id} value={exp.experiment_id}>
-                {exp.project_name ?? exp.experiment_id} — $
-                {exp.total_cost_usd.toFixed(2)}
-              </option>
-            ))}
-          </select>
+
+        <div className="cost-pickers">
+          <div className="cost-picker">
+            <label htmlFor="cost-project-select">Project:</label>
+            <select
+              id="cost-project-select"
+              value={selectedProject ?? ''}
+              onChange={(e) => setSelectedProject(e.target.value || null)}
+            >
+              {projects.length === 0 && (
+                <option value="">— none yet —</option>
+              )}
+              {projects.map((p) => (
+                <option key={p.project_id} value={p.project_id}>
+                  {/*
+                    Prefer the human-readable project_name from the
+                    experiments table; fall back to a truncated id only
+                    when no MLflow run ever registered one. (Kaia review
+                    of #33: 12-char IDs of 19-digit numbers were
+                    indistinguishable in the picker.)
+                  */}
+                  {p.project_name ?? `${p.project_id.slice(0, 12)}…`}
+                  {' '}— {formatUsd(p.total_cost_usd)}
+                  {' '}({p.experiments} {p.experiments === 1 ? 'run' : 'runs'})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {projectSummary && projectSummary.experiments.length > 0 && (
+            <div className="cost-picker">
+              <label
+                htmlFor="cost-exp-select"
+                title={
+                  'MLflow run within the selected project. Most recent ' +
+                  "first. Empty when the project's runs never called " +
+                  'start_experiment — see Historical for project totals.'
+                }
+              >
+                Run:
+              </label>
+              <select
+                id="cost-exp-select"
+                value={selectedExp ?? ''}
+                onChange={(e) => setSelectedExp(e.target.value || null)}
+              >
+                {projectSummary.experiments.map((exp) => (
+                  <option key={exp.experiment_id} value={exp.experiment_id}>
+                    {exp.experiment_id.slice(0, 16)} — {formatUsd(exp.total_cost_usd)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
+
+        {unassigned && unassigned.events > 0 && (
+          <div
+            className="cost-unassigned-banner"
+            title="LLM calls Marcus made without an active project context. Usually a code path running outside the MCP request lifecycle, or a project-creation tool. Investigate the gap."
+          >
+            ⚠ Unassigned: {unassigned.events} events,{' '}
+            {formatTokens(unassigned.total_tokens)} tokens,{' '}
+            {formatUsd(unassigned.total_cost_usd, 4)}
+          </div>
+        )}
       </div>
 
       <div className="cost-tab-strip">
@@ -117,23 +247,32 @@ const CostDashboard = () => {
         {activeTab === 'realtime' && selectedExp && (
           <RealTimeTab experimentId={selectedExp} />
         )}
-        {activeTab === 'realtime' && !selectedExp && (
+        {activeTab === 'realtime' && !selectedExp && selectedProject && (
           <div className="cost-empty">
-            No experiments yet. Run one with the marcus skill and they'll appear here.
+            This project has events but no MLflow run was registered.
+            See the project totals on the Historical tab.
+          </div>
+        )}
+        {activeTab === 'realtime' && !selectedProject && (
+          <div className="cost-empty">
+            No projects yet. Run one with the marcus skill and it'll appear here.
           </div>
         )}
         {activeTab === 'historical' && (
-          <HistoricalTab onSelectExperiment={(id) => {
-            setSelectedExp(id);
-            setActiveTab('realtime');
-          }} />
+          <HistoricalTab
+            onSelectExperiment={(id) => {
+              setSelectedExp(id);
+              setActiveTab('realtime');
+            }}
+          />
         )}
         {activeTab === 'budget' && selectedExp && (
           <BudgetTab experimentId={selectedExp} />
         )}
         {activeTab === 'budget' && !selectedExp && (
           <div className="cost-empty">
-            Select an experiment to see its budget projection.
+            Select a project (and an MLflow run inside it) to see budget
+            projection.
           </div>
         )}
         {activeTab === 'pricing' && <PricingTab />}

--- a/dashboard/src/components/CostDashboard.tsx
+++ b/dashboard/src/components/CostDashboard.tsx
@@ -20,6 +20,7 @@ import {
   fetchProjectSummary,
   fetchProjects,
   fetchUnassignedTotals,
+  triggerIngest,
   type ProjectRow,
   type ProjectSummary,
   type UnassignedTotals,
@@ -65,6 +66,17 @@ const CostDashboard = () => {
     let cancelled = false;
 
     const load = async () => {
+      // Sweep worker JSONL logs before pulling the project list so the
+      // dashboard reflects the current state of all running experiments.
+      // Idempotent on the backend (UUID dedup), so calling on every
+      // tick is safe. Failure here is non-fatal — fall through to the
+      // project fetch and surface whatever we already have.
+      try {
+        await triggerIngest();
+      } catch {
+        // intentionally swallowed
+      }
+
       try {
         const { projects: ps } = await fetchProjects();
         if (cancelled) return;

--- a/dashboard/src/components/CostDashboard.tsx
+++ b/dashboard/src/components/CostDashboard.tsx
@@ -1,0 +1,133 @@
+/**
+ * Top-level cost dashboard page (Marcus issue #409).
+ *
+ * Phase 7 ships only Tab 1 — Real-time. Tabs 2-4 (Historical, Budget,
+ * Pricing) land in the next PR. The tab strip is rendered now so the
+ * picker is in place when those land.
+ */
+
+import { useEffect, useState } from 'react';
+import { fetchExperiments, type ExperimentRow } from '../services/costService';
+import RealTimeTab from './RealTimeTab';
+import './CostDashboard.css';
+
+type CostTab = 'realtime' | 'historical' | 'budget' | 'pricing';
+
+const CostDashboard = () => {
+  const [activeTab, setActiveTab] = useState<CostTab>('realtime');
+  const [experiments, setExperiments] = useState<ExperimentRow[]>([]);
+  const [selectedExp, setSelectedExp] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch experiment list on mount and refresh every 30s so a new run
+  // appears in the picker without the user reloading the page.
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const { experiments: exps } = await fetchExperiments();
+        if (cancelled) return;
+        setExperiments(exps);
+        setError(null);
+        if (selectedExp === null && exps.length > 0) {
+          setSelectedExp(exps[0].experiment_id);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    };
+
+    load();
+    const id = window.setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [selectedExp]);
+
+  if (error && experiments.length === 0) {
+    return (
+      <div className="cost-dashboard cost-dashboard-error">
+        <h2>Cost dashboard unavailable</h2>
+        <p>{error}</p>
+        <p className="hint">
+          The cost backend may be disabled — check that Marcus is running and
+          ~/.marcus/costs.db exists.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="cost-dashboard">
+      <div className="cost-dashboard-header">
+        <h2>Cost</h2>
+        <div className="cost-experiment-picker">
+          <label htmlFor="cost-exp-select">Experiment:</label>
+          <select
+            id="cost-exp-select"
+            value={selectedExp ?? ''}
+            onChange={(e) => setSelectedExp(e.target.value || null)}
+          >
+            {experiments.length === 0 && <option value="">— none yet —</option>}
+            {experiments.map((exp) => (
+              <option key={exp.experiment_id} value={exp.experiment_id}>
+                {exp.project_name ?? exp.experiment_id} — $
+                {exp.total_cost_usd.toFixed(2)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="cost-tab-strip">
+        <button
+          className={activeTab === 'realtime' ? 'active' : ''}
+          onClick={() => setActiveTab('realtime')}
+        >
+          Real-time
+        </button>
+        <button
+          className={activeTab === 'historical' ? 'active' : ''}
+          onClick={() => setActiveTab('historical')}
+          disabled
+          title="Coming in Phase 8"
+        >
+          Historical
+        </button>
+        <button
+          className={activeTab === 'budget' ? 'active' : ''}
+          onClick={() => setActiveTab('budget')}
+          disabled
+          title="Coming in Phase 8"
+        >
+          Budget
+        </button>
+        <button
+          className={activeTab === 'pricing' ? 'active' : ''}
+          onClick={() => setActiveTab('pricing')}
+          disabled
+          title="Coming in Phase 8"
+        >
+          Pricing
+        </button>
+      </div>
+
+      <div className="cost-tab-content">
+        {activeTab === 'realtime' && selectedExp && (
+          <RealTimeTab experimentId={selectedExp} />
+        )}
+        {activeTab === 'realtime' && !selectedExp && (
+          <div className="cost-empty">
+            No experiments yet. Run one with the marcus skill and they'll appear here.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CostDashboard;

--- a/dashboard/src/components/CostDashboard.tsx
+++ b/dashboard/src/components/CostDashboard.tsx
@@ -1,13 +1,16 @@
 /**
  * Top-level cost dashboard page (Marcus issue #409).
  *
- * Phase 7 ships only Tab 1 — Real-time. Tabs 2-4 (Historical, Budget,
- * Pricing) land in the next PR. The tab strip is rendered now so the
- * picker is in place when those land.
+ * Four sub-tabs: Real-time (current experiment), Historical (all
+ * experiments), Budget (per-experiment projection vs. cap), and
+ * Pricing (current rate table + CRUD form).
  */
 
 import { useEffect, useState } from 'react';
 import { fetchExperiments, type ExperimentRow } from '../services/costService';
+import BudgetTab from './BudgetTab';
+import HistoricalTab from './HistoricalTab';
+import PricingTab from './PricingTab';
 import RealTimeTab from './RealTimeTab';
 import './CostDashboard.css';
 
@@ -93,24 +96,18 @@ const CostDashboard = () => {
         <button
           className={activeTab === 'historical' ? 'active' : ''}
           onClick={() => setActiveTab('historical')}
-          disabled
-          title="Coming in Phase 8"
         >
           Historical
         </button>
         <button
           className={activeTab === 'budget' ? 'active' : ''}
           onClick={() => setActiveTab('budget')}
-          disabled
-          title="Coming in Phase 8"
         >
           Budget
         </button>
         <button
           className={activeTab === 'pricing' ? 'active' : ''}
           onClick={() => setActiveTab('pricing')}
-          disabled
-          title="Coming in Phase 8"
         >
           Pricing
         </button>
@@ -125,6 +122,21 @@ const CostDashboard = () => {
             No experiments yet. Run one with the marcus skill and they'll appear here.
           </div>
         )}
+        {activeTab === 'historical' && (
+          <HistoricalTab onSelectExperiment={(id) => {
+            setSelectedExp(id);
+            setActiveTab('realtime');
+          }} />
+        )}
+        {activeTab === 'budget' && selectedExp && (
+          <BudgetTab experimentId={selectedExp} />
+        )}
+        {activeTab === 'budget' && !selectedExp && (
+          <div className="cost-empty">
+            Select an experiment to see its budget projection.
+          </div>
+        )}
+        {activeTab === 'pricing' && <PricingTab />}
       </div>
     </div>
   );

--- a/dashboard/src/components/CostDashboard.tsx
+++ b/dashboard/src/components/CostDashboard.tsx
@@ -1,28 +1,25 @@
 /**
  * Top-level cost dashboard page (Marcus issue #409).
  *
- * Project is the primary axis (per Marcus CLAUDE.md GH-388 and
- * spawn_agents.py) — experiment is a secondary tracking handle that
- * may or may not be set depending on whether the run opted into
- * MLflow tracking. The picker leads with project; once a project is
- * selected, the user can optionally drill into a specific experiment
- * (MLflow run) within it.
+ * Project-first: project_id is the only universal identity in Marcus's
+ * coordination model (Marcus CLAUDE.md GH-388, spawn_agents.py, and
+ * the #503 project-axis refactor). Marcus's main code path doesn't
+ * open MLflow experiments, so the experiment dimension is no longer
+ * surfaced in the UI — every tab renders from project-level data.
  *
- * Sub-tabs:
- *   - Real-time  → live view of the active MLflow run (when one exists)
- *   - Historical → cross-project totals + per-experiment time series
- *   - Budget     → projection vs. cap for the active run
+ * Sub-tabs (all keyed off the selected project):
+ *   - Real-time  → live spend, agents working, per-role breakdown
+ *   - Historical → cross-project totals + per-project time series
+ *   - Budget     → cost so far vs. spend rate / projection
  *   - Pricing    → current rate table + insert form
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
-  fetchProjectSummary,
   fetchProjects,
   fetchUnassignedTotals,
   triggerIngest,
   type ProjectRow,
-  type ProjectSummary,
   type UnassignedTotals,
 } from '../services/costService';
 import BudgetTab from './BudgetTab';
@@ -43,39 +40,64 @@ function formatTokens(v: number): string {
   return String(v);
 }
 
+function formatProjectDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+/**
+ * Render a project label for the picker. Order of preference:
+ * 1. explicit project_name (MLflow / registry overlay)
+ * 2. "Unnamed · <first-event date>" — gives temporal context for
+ *    projects deleted from the registry but still in token_events
+ * Tokens are appended to either so users can identify by spend.
+ */
+function projectLabel(p: ProjectRow): string {
+  const tokens = formatTokens(p.total_tokens);
+  const cost = formatUsd(p.total_cost_usd);
+  if (p.project_name) {
+    return `${p.project_name} — ${cost} (${tokens} tokens)`;
+  }
+  const date = formatProjectDate(p.first_event_at);
+  const prefix = date ? `Unnamed · ${date}` : 'Unnamed';
+  return `${prefix} — ${cost} (${tokens} tokens)`;
+}
+
 const CostDashboard = () => {
   const [activeTab, setActiveTab] = useState<CostTab>('realtime');
   const [projects, setProjects] = useState<ProjectRow[]>([]);
   const [unassigned, setUnassigned] = useState<UnassignedTotals | null>(null);
+  const [unassignedOpen, setUnassignedOpen] = useState(false);
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
-  const [projectSummary, setProjectSummary] = useState<ProjectSummary | null>(null);
-  const [selectedExp, setSelectedExp] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [initialLoading, setInitialLoading] = useState(true);
 
-  // Poll project list + unassigned totals every 30s so new runs appear
-  // without a page reload and the unassigned indicator stays current.
-  //
-  // Kaia PR #33 review:
-  // - Effect no longer depends on selectedProject (the previous version
-  //   re-subscribed on every selection change for no useful reason; the
-  //   auto-select happens via the functional setState below).
-  // - fetchUnassignedTotals is wrapped in a defensive catch so a 503
-  //   from that endpoint doesn't blank the project picker. Worst case:
-  //   the unassigned banner doesn't appear even though there's a gap.
+  // First-paint perf: triggerIngest sweeps ~/.claude/projects/<sess>.jsonl
+  // and was previously awaited *before* fetchProjects, which made the
+  // initial load take 10+ seconds on accounts with many session files.
+  // Now we fire ingest in the background and let the picker render
+  // immediately from whatever is already in costs.db. The next poll
+  // tick picks up any rows ingest added.
+  const ingestInFlight = useRef(false);
   useEffect(() => {
     let cancelled = false;
 
+    const fireIngestInBackground = () => {
+      if (ingestInFlight.current) return;
+      ingestInFlight.current = true;
+      triggerIngest()
+        .catch(() => {
+          // non-fatal — picker still shows whatever was already in the DB
+        })
+        .finally(() => {
+          ingestInFlight.current = false;
+        });
+    };
+
     const load = async () => {
-      // Sweep worker JSONL logs before pulling the project list so the
-      // dashboard reflects the current state of all running experiments.
-      // Idempotent on the backend (UUID dedup), so calling on every
-      // tick is safe. Failure here is non-fatal — fall through to the
-      // project fetch and surface whatever we already have.
-      try {
-        await triggerIngest();
-      } catch {
-        // intentionally swallowed
-      }
+      // Kick off ingest in parallel — do not await.
+      fireIngestInBackground();
 
       try {
         const { projects: ps } = await fetchProjects();
@@ -92,7 +114,8 @@ const CostDashboard = () => {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : String(err));
         }
-        return;
+      } finally {
+        if (!cancelled) setInitialLoading(false);
       }
 
       // Fetch unassigned totals independently; failure here is not
@@ -112,36 +135,6 @@ const CostDashboard = () => {
       window.clearInterval(id);
     };
   }, []);
-
-  // When the selected project changes, fetch its summary (totals +
-  // experiment list) and auto-select the most recent experiment for
-  // the Real-time tab.
-  useEffect(() => {
-    if (!selectedProject) {
-      setProjectSummary(null);
-      setSelectedExp(null);
-      return;
-    }
-    let cancelled = false;
-    fetchProjectSummary(selectedProject)
-      .then((s) => {
-        if (cancelled) return;
-        setProjectSummary(s);
-        if (s.experiments.length > 0) {
-          setSelectedExp(s.experiments[0].experiment_id);
-        } else {
-          setSelectedExp(null);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedProject]);
 
   if (error && projects.length === 0) {
     return (
@@ -170,60 +163,69 @@ const CostDashboard = () => {
               onChange={(e) => setSelectedProject(e.target.value || null)}
             >
               {projects.length === 0 && (
-                <option value="">— none yet —</option>
+                <option value="">
+                  {initialLoading ? '— loading… —' : '— none yet —'}
+                </option>
               )}
               {projects.map((p) => (
                 <option key={p.project_id} value={p.project_id}>
                   {/*
-                    Prefer the human-readable project_name from the
-                    experiments table; fall back to a truncated id only
-                    when no MLflow run ever registered one. (Kaia review
-                    of #33: 12-char IDs of 19-digit numbers were
-                    indistinguishable in the picker.)
+                    Name resolution: experiments.project_name (MLflow) →
+                    Marcus project registry → "Unnamed · <date>" fallback
+                    for projects deleted from the registry but still in
+                    token_events. See cost_routes._load_project_names.
                   */}
-                  {p.project_name ?? `${p.project_id.slice(0, 12)}…`}
-                  {' '}— {formatUsd(p.total_cost_usd)}
-                  {' '}({p.experiments} {p.experiments === 1 ? 'run' : 'runs'})
+                  {projectLabel(p)}
                 </option>
               ))}
             </select>
           </div>
 
-          {projectSummary && projectSummary.experiments.length > 0 && (
-            <div className="cost-picker">
-              <label
-                htmlFor="cost-exp-select"
-                title={
-                  'MLflow run within the selected project. Most recent ' +
-                  "first. Empty when the project's runs never called " +
-                  'start_experiment — see Historical for project totals.'
-                }
-              >
-                Run:
-              </label>
-              <select
-                id="cost-exp-select"
-                value={selectedExp ?? ''}
-                onChange={(e) => setSelectedExp(e.target.value || null)}
-              >
-                {projectSummary.experiments.map((exp) => (
-                  <option key={exp.experiment_id} value={exp.experiment_id}>
-                    {exp.experiment_id.slice(0, 16)} — {formatUsd(exp.total_cost_usd)}
-                  </option>
-                ))}
-              </select>
-            </div>
+          {unassigned && unassigned.events > 0 && (
+            <button
+              type="button"
+              className="cost-unassigned-icon"
+              onClick={() => setUnassignedOpen((v) => !v)}
+              title={
+                'Unassigned cost — LLM calls Marcus made without an ' +
+                'active project context. Click for details.'
+              }
+              aria-label="Unassigned cost details"
+            >
+              ⚠
+            </button>
           )}
         </div>
 
-        {unassigned && unassigned.events > 0 && (
-          <div
-            className="cost-unassigned-banner"
-            title="LLM calls Marcus made without an active project context. Usually a code path running outside the MCP request lifecycle, or a project-creation tool. Investigate the gap."
-          >
-            ⚠ Unassigned: {unassigned.events} events,{' '}
-            {formatTokens(unassigned.total_tokens)} tokens,{' '}
-            {formatUsd(unassigned.total_cost_usd, 4)}
+        {unassignedOpen && unassigned && (
+          <div className="cost-unassigned-popover" role="dialog">
+            <h4>Unassigned LLM activity</h4>
+            <p className="hint">
+              Calls Marcus made without an active project context — usually
+              a code path running outside the MCP request lifecycle, or a
+              project-creation tool.
+            </p>
+            <dl className="cost-unassigned-stats">
+              <div>
+                <dt>Events</dt>
+                <dd>{unassigned.events}</dd>
+              </div>
+              <div>
+                <dt>Tokens</dt>
+                <dd>{formatTokens(unassigned.total_tokens)}</dd>
+              </div>
+              <div>
+                <dt>Cost</dt>
+                <dd>{formatUsd(unassigned.total_cost_usd, 4)}</dd>
+              </div>
+            </dl>
+            <button
+              type="button"
+              className="cost-unassigned-close"
+              onClick={() => setUnassignedOpen(false)}
+            >
+              Close
+            </button>
           </div>
         )}
       </div>
@@ -256,35 +258,21 @@ const CostDashboard = () => {
       </div>
 
       <div className="cost-tab-content">
-        {activeTab === 'realtime' && selectedExp && (
-          <RealTimeTab experimentId={selectedExp} />
-        )}
-        {activeTab === 'realtime' && !selectedExp && selectedProject && (
-          <div className="cost-empty">
-            This project has events but no MLflow run was registered.
-            See the project totals on the Historical tab.
-          </div>
+        {activeTab === 'realtime' && selectedProject && (
+          <RealTimeTab projectId={selectedProject} />
         )}
         {activeTab === 'realtime' && !selectedProject && (
           <div className="cost-empty">
             No projects yet. Run one with the marcus skill and it'll appear here.
           </div>
         )}
-        {activeTab === 'historical' && (
-          <HistoricalTab
-            onSelectExperiment={(id) => {
-              setSelectedExp(id);
-              setActiveTab('realtime');
-            }}
-          />
+        {activeTab === 'historical' && <HistoricalTab />}
+        {activeTab === 'budget' && selectedProject && (
+          <BudgetTab projectId={selectedProject} />
         )}
-        {activeTab === 'budget' && selectedExp && (
-          <BudgetTab experimentId={selectedExp} />
-        )}
-        {activeTab === 'budget' && !selectedExp && (
+        {activeTab === 'budget' && !selectedProject && (
           <div className="cost-empty">
-            Select a project (and an MLflow run inside it) to see budget
-            projection.
+            Select a project to see budget projection.
           </div>
         )}
         {activeTab === 'pricing' && <PricingTab />}

--- a/dashboard/src/components/CostTimeSeries.css
+++ b/dashboard/src/components/CostTimeSeries.css
@@ -1,0 +1,25 @@
+.cost-timeseries {
+  font-family: var(--font-mono, ui-monospace, 'SF Mono', monospace);
+}
+
+.cost-timeseries .grid {
+  stroke: var(--border-color, #e2e8f0);
+  stroke-dasharray: 2 4;
+}
+
+.cost-timeseries .axis-label {
+  font-size: 11px;
+  fill: var(--text-muted, #64748b);
+}
+
+.cost-timeseries .bar-group:hover rect {
+  opacity: 1;
+}
+
+.cost-timeseries-empty {
+  padding: 32px;
+  color: var(--text-muted, #64748b);
+  font-size: 13px;
+  font-style: italic;
+  text-align: center;
+}

--- a/dashboard/src/components/CostTimeSeries.tsx
+++ b/dashboard/src/components/CostTimeSeries.tsx
@@ -1,21 +1,22 @@
 /**
- * Per-experiment cost time series.
+ * Per-run cost time series.
  *
- * Renders one bar per experiment along an absolute time axis (started_at).
- * Bars are colored by project so multi-project history is legible at a
- * glance. Used by the Historical tab.
+ * Renders one bar per run along an absolute time axis (started_at).
+ * Bars are colored by project so multi-project history is legible at
+ * a glance. Used by the Historical tab. Renamed from
+ * "per-experiment" in coordination with Marcus's ``runs`` rename.
  */
 
 import { useMemo } from 'react';
 import * as d3 from 'd3';
-import type { ExperimentRow } from '../services/costService';
+import type { RunRow } from '../services/costService';
 import './CostTimeSeries.css';
 
 interface Props {
-  experiments: ExperimentRow[];
+  runs: RunRow[];
   width?: number;
   height?: number;
-  onSelect?: (experimentId: string) => void;
+  onSelect?: (runId: string) => void;
 }
 
 const MARGIN = { top: 16, right: 16, bottom: 40, left: 56 };
@@ -26,7 +27,7 @@ function formatUsd(v: number): string {
 }
 
 const CostTimeSeries = ({
-  experiments,
+  runs,
   width = 800,
   height = 260,
   onSelect,
@@ -36,13 +37,13 @@ const CostTimeSeries = ({
 
   const parsed = useMemo(
     () =>
-      experiments
+      runs
         .map((e) => ({
           ...e,
           ts: new Date(e.started_at).getTime(),
         }))
         .sort((a, b) => a.ts - b.ts),
-    [experiments],
+    [runs],
   );
 
   const xScale = useMemo(() => {
@@ -67,7 +68,7 @@ const CostTimeSeries = ({
   if (parsed.length === 0) {
     return (
       <div className="cost-timeseries-empty">
-        No experiments to chart yet.
+        No runs to chart yet.
       </div>
     );
   }
@@ -106,9 +107,9 @@ const CostTimeSeries = ({
           const barH = innerH - y;
           return (
             <g
-              key={d.experiment_id}
+              key={d.run_id}
               transform={`translate(${x - barW / 2},${y})`}
-              onClick={() => onSelect?.(d.experiment_id)}
+              onClick={() => onSelect?.(d.run_id)}
               style={{ cursor: onSelect ? 'pointer' : 'default' }}
               className="bar-group"
             >
@@ -120,7 +121,7 @@ const CostTimeSeries = ({
                 rx={2}
               >
                 <title>
-                  {d.project_name ?? d.experiment_id}
+                  {d.project_name ?? d.run_id}
                   {'\n'}
                   {new Date(d.ts).toLocaleString()}
                   {'\n'}

--- a/dashboard/src/components/CostTimeSeries.tsx
+++ b/dashboard/src/components/CostTimeSeries.tsx
@@ -1,0 +1,165 @@
+/**
+ * Per-experiment cost time series.
+ *
+ * Renders one bar per experiment along an absolute time axis (started_at).
+ * Bars are colored by project so multi-project history is legible at a
+ * glance. Used by the Historical tab.
+ */
+
+import { useMemo } from 'react';
+import * as d3 from 'd3';
+import type { ExperimentRow } from '../services/costService';
+import './CostTimeSeries.css';
+
+interface Props {
+  experiments: ExperimentRow[];
+  width?: number;
+  height?: number;
+  onSelect?: (experimentId: string) => void;
+}
+
+const MARGIN = { top: 16, right: 16, bottom: 40, left: 56 };
+
+function formatUsd(v: number): string {
+  if (v >= 1) return `$${v.toFixed(2)}`;
+  return `$${v.toFixed(4)}`;
+}
+
+const CostTimeSeries = ({
+  experiments,
+  width = 800,
+  height = 260,
+  onSelect,
+}: Props) => {
+  const innerW = width - MARGIN.left - MARGIN.right;
+  const innerH = height - MARGIN.top - MARGIN.bottom;
+
+  const parsed = useMemo(
+    () =>
+      experiments
+        .map((e) => ({
+          ...e,
+          ts: new Date(e.started_at).getTime(),
+        }))
+        .sort((a, b) => a.ts - b.ts),
+    [experiments],
+  );
+
+  const xScale = useMemo(() => {
+    const min = d3.min(parsed, (d) => d.ts) ?? Date.now();
+    const max = d3.max(parsed, (d) => d.ts) ?? Date.now();
+    return d3.scaleTime().domain([new Date(min), new Date(max)]).range([0, innerW]);
+  }, [parsed, innerW]);
+
+  const yScale = useMemo(() => {
+    const max = d3.max(parsed, (d) => d.total_cost_usd) ?? 0.01;
+    return d3.scaleLinear().domain([0, max * 1.1]).range([innerH, 0]);
+  }, [parsed, innerH]);
+
+  const projectColor = useMemo(() => {
+    const projects = Array.from(new Set(parsed.map((d) => d.project_id)));
+    const palette = d3.schemeTableau10;
+    const map = new Map<string, string>();
+    projects.forEach((p, i) => map.set(p, palette[i % palette.length]));
+    return map;
+  }, [parsed]);
+
+  if (parsed.length === 0) {
+    return (
+      <div className="cost-timeseries-empty">
+        No experiments to chart yet.
+      </div>
+    );
+  }
+
+  const yTicks = yScale.ticks(5);
+  const xTicks = xScale.ticks(Math.min(parsed.length, 8));
+
+  return (
+    <svg
+      className="cost-timeseries"
+      width="100%"
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      aria-label="Cost over time, by experiment"
+    >
+      <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+        {/* Horizontal grid */}
+        {yTicks.map((t) => (
+          <line
+            key={`yg-${t}`}
+            x1={0}
+            x2={innerW}
+            y1={yScale(t)}
+            y2={yScale(t)}
+            className="grid"
+          />
+        ))}
+
+        {/* Bars */}
+        {parsed.map((d) => {
+          const x = xScale(d.ts);
+          const y = yScale(d.total_cost_usd);
+          const barW = Math.max(6, innerW / Math.max(parsed.length, 8) * 0.6);
+          const barH = innerH - y;
+          return (
+            <g
+              key={d.experiment_id}
+              transform={`translate(${x - barW / 2},${y})`}
+              onClick={() => onSelect?.(d.experiment_id)}
+              style={{ cursor: onSelect ? 'pointer' : 'default' }}
+              className="bar-group"
+            >
+              <rect
+                width={barW}
+                height={barH}
+                fill={projectColor.get(d.project_id) ?? '#64748b'}
+                opacity={0.85}
+                rx={2}
+              >
+                <title>
+                  {d.project_name ?? d.experiment_id}
+                  {'\n'}
+                  {new Date(d.ts).toLocaleString()}
+                  {'\n'}
+                  {formatUsd(d.total_cost_usd)} — {d.total_tokens.toLocaleString()} tok
+                </title>
+              </rect>
+            </g>
+          );
+        })}
+
+        {/* Y-axis labels */}
+        {yTicks.map((t) => (
+          <text
+            key={`yl-${t}`}
+            x={-8}
+            y={yScale(t)}
+            dominantBaseline="middle"
+            textAnchor="end"
+            className="axis-label"
+          >
+            {formatUsd(t)}
+          </text>
+        ))}
+
+        {/* X-axis labels */}
+        {xTicks.map((t) => (
+          <text
+            key={`xl-${t.getTime()}`}
+            x={xScale(t)}
+            y={innerH + 16}
+            textAnchor="middle"
+            className="axis-label"
+          >
+            {d3.timeFormat('%b %d')(t)}
+          </text>
+        ))}
+      </g>
+    </svg>
+  );
+};
+
+export default CostTimeSeries;

--- a/dashboard/src/components/HeaderControls.tsx
+++ b/dashboard/src/components/HeaderControls.tsx
@@ -2,6 +2,98 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useVisualizationStore } from '../store/visualizationStore';
 import { fetchSettings, updateSettings } from '../services/dataService';
 import ExportButton from './ExportButton';
+import HistoricalTab from './HistoricalTab';
+import PricingTab from './PricingTab';
+
+/** Full-screen overlay modal for cross-project / global cost views.
+ *
+ * Historical (lifetime cost rollup) and Pricing (rate table) used to
+ * live inside the Cost dashboard tab strip. They were moved here so
+ * the Cost view stays focused on the *active project*: Real-time +
+ * Budget only. These two are global tools and belong with other
+ * settings-level controls.
+ */
+const CostOverlay = ({
+  kind,
+  onClose,
+}: {
+  kind: 'historical' | 'pricing';
+  onClose: () => void;
+}) => {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.65)',
+        zIndex: 200,
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        paddingTop: '4vh',
+        paddingBottom: '4vh',
+        overflowY: 'auto',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: '#0f172a',
+          border: '1px solid #334155',
+          borderRadius: '0.5rem',
+          width: 'min(1100px, 95vw)',
+          maxHeight: '92vh',
+          overflowY: 'auto',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '0.75rem 1.25rem',
+            borderBottom: '1px solid #334155',
+            position: 'sticky',
+            top: 0,
+            background: '#0f172a',
+          }}
+        >
+          <h2 style={{ margin: 0, color: '#e2e8f0', fontSize: '1.1rem' }}>
+            {kind === 'historical' ? '📊 Historical Cost' : '💲 Pricing Rates'}
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              background: 'transparent',
+              border: '1px solid #475569',
+              color: '#e2e8f0',
+              borderRadius: '0.25rem',
+              padding: '0.25rem 0.65rem',
+              cursor: 'pointer',
+              fontSize: '0.9rem',
+            }}
+          >
+            ✕ Close
+          </button>
+        </div>
+        <div style={{ padding: '1rem 1.25rem' }}>
+          {kind === 'historical' ? <HistoricalTab /> : <PricingTab />}
+        </div>
+      </div>
+    </div>
+  );
+};
 
 /**
  * Header controls component to prevent flickering during data refreshes.
@@ -41,6 +133,14 @@ const HeaderControls = () => {
   const [cutoffDate, setCutoffDate] = useState<string>('');
   const [settingsSaving, setSettingsSaving] = useState(false);
   const settingsRef = useRef<HTMLDivElement>(null);
+
+  // Cost overlays launched from the settings panel. ``costOverlay``
+  // is the only piece of state introduced for Change 2 — when set,
+  // a full-screen modal renders Historical or Pricing on top of
+  // everything else.
+  const [costOverlay, setCostOverlay] = useState<
+    'historical' | 'pricing' | null
+  >(null);
 
   useEffect(() => {
     fetchSettings().then(s => setCutoffDate(s.history_cutoff_date ?? '')).catch(() => {});
@@ -194,6 +294,50 @@ const HeaderControls = () => {
                 >
                   {settingsSaving ? 'Saving…' : 'Save'}
                 </button>
+
+                {/* Cross-project / global cost views. These used to live
+                    in the Cost tab strip but were moved here so the
+                    Cost view can stay focused on the active project
+                    (Real-time + Budget only). */}
+                <div style={{
+                  marginTop: '0.75rem',
+                  paddingTop: '0.75rem',
+                  borderTop: '1px solid #334155',
+                }}>
+                  <div style={{ color: '#94a3b8', fontSize: '0.75rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '0.5rem' }}>
+                    Cost tools
+                  </div>
+                  <button
+                    onClick={() => {
+                      setCostOverlay('historical');
+                      setSettingsOpen(false);
+                    }}
+                    style={{
+                      width: '100%', padding: '0.5rem 0.75rem',
+                      borderRadius: '0.25rem', marginBottom: '0.4rem',
+                      background: '#334155', border: '1px solid #475569',
+                      color: '#e2e8f0', cursor: 'pointer', fontSize: '0.9rem',
+                      textAlign: 'left',
+                    }}
+                  >
+                    📊 Historical Cost
+                  </button>
+                  <button
+                    onClick={() => {
+                      setCostOverlay('pricing');
+                      setSettingsOpen(false);
+                    }}
+                    style={{
+                      width: '100%', padding: '0.5rem 0.75rem',
+                      borderRadius: '0.25rem',
+                      background: '#334155', border: '1px solid #475569',
+                      color: '#e2e8f0', cursor: 'pointer', fontSize: '0.9rem',
+                      textAlign: 'left',
+                    }}
+                  >
+                    💲 Pricing Rates
+                  </button>
+                </div>
               </div>
             )}
           </div>
@@ -203,6 +347,12 @@ const HeaderControls = () => {
         <div className="error-banner">
           ⚠️ Error loading data: {loadError}
         </div>
+      )}
+      {costOverlay && (
+        <CostOverlay
+          kind={costOverlay}
+          onClose={() => setCostOverlay(null)}
+        />
       )}
       {loadingStatus && (
         <div

--- a/dashboard/src/components/HistoricalTab.css
+++ b/dashboard/src/components/HistoricalTab.css
@@ -1,0 +1,53 @@
+.cost-historical {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 24px;
+}
+
+.historical-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 8px;
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.cost-table th,
+.cost-table td {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+}
+
+.cost-table th {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #64748b);
+  font-weight: 600;
+}
+
+.cost-table td.cost-cell {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  text-align: right;
+}
+
+.cost-table tr:hover td {
+  background: var(--bg-canvas, #f8fafc);
+}
+
+.cost-historical .empty {
+  padding: 16px;
+  color: var(--text-muted, #64748b);
+  font-style: italic;
+}

--- a/dashboard/src/components/HistoricalTab.tsx
+++ b/dashboard/src/components/HistoricalTab.tsx
@@ -1,23 +1,16 @@
 /**
- * Tab 2 — Historical view.
+ * Tab 2 — Historical view (project-first).
  *
- * Aggregates every experiment in the cost store and renders:
- * 1. Headline totals (lifetime cost, total tokens, experiment count).
- * 2. A time-series bar chart of cost per experiment.
- * 3. Per-project rollup table.
- *
- * No new backend endpoint needed — derives everything from
- * ``/api/cost/experiments`` (no project filter, capped at 1000).
+ * Lifetime totals + per-project rollup pulled from
+ * ``/api/cost/projects`` (the project picker's data source). Replaces
+ * the old experiment-based aggregation because Marcus's main code
+ * path doesn't open MLflow experiments — project_id is the universal
+ * identity.
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { fetchExperiments, type ExperimentRow } from '../services/costService';
-import CostTimeSeries from './CostTimeSeries';
+import { fetchProjects, type ProjectRow } from '../services/costService';
 import './HistoricalTab.css';
-
-interface Props {
-  onSelectExperiment?: (id: string) => void;
-}
 
 function formatUsd(v: number, decimals = 2): string {
   return `$${v.toFixed(decimals)}`;
@@ -29,16 +22,26 @@ function formatTokens(v: number): string {
   return String(v);
 }
 
-const HistoricalTab = ({ onSelectExperiment }: Props) => {
-  const [experiments, setExperiments] = useState<ExperimentRow[]>([]);
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+const HistoricalTab = () => {
+  const [projects, setProjects] = useState<ProjectRow[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    fetchExperiments(undefined, 1000)
-      .then(({ experiments: exps }) => {
+    fetchProjects(1000)
+      .then(({ projects: ps }) => {
         if (!cancelled) {
-          setExperiments(exps);
+          setProjects(ps);
           setError(null);
         }
       })
@@ -52,33 +55,30 @@ const HistoricalTab = ({ onSelectExperiment }: Props) => {
     };
   }, []);
 
-  // Totals + per-project rollup, computed in-memory.
-  const { totalCost, totalTokens, byProject } = useMemo(() => {
+  const { totalCost, totalTokens, totalEvents, totalAgents } = useMemo(() => {
     let totalCost = 0;
     let totalTokens = 0;
-    const byProject = new Map<
-      string,
-      { project_name: string | null; cost: number; tokens: number; count: number }
-    >();
-    for (const e of experiments) {
-      totalCost += e.total_cost_usd;
-      totalTokens += e.total_tokens;
-      const cur = byProject.get(e.project_id) ?? {
-        project_name: e.project_name,
-        cost: 0,
-        tokens: 0,
-        count: 0,
-      };
-      cur.cost += e.total_cost_usd;
-      cur.tokens += e.total_tokens;
-      cur.count += 1;
-      byProject.set(e.project_id, cur);
+    let totalEvents = 0;
+    const allAgents = new Set<string>();
+    for (const p of projects) {
+      totalCost += p.total_cost_usd;
+      totalTokens += p.total_tokens;
+      totalEvents += p.events;
+      // p.agents is a count, not a list — sum is a fine approximation
+      // here since agent IDs are scoped per-project anyway.
+      allAgents.add(`${p.project_id}:agents:${p.agents}`);
     }
-    const rows = Array.from(byProject.entries())
-      .map(([project_id, v]) => ({ project_id, ...v }))
-      .sort((a, b) => b.cost - a.cost);
-    return { totalCost, totalTokens, byProject: rows };
-  }, [experiments]);
+    // Use the sum of distinct agent counts as the metric — distinct
+    // agent_ids aren't returned on the rollup, but per-project agent
+    // counts summed is a useful "total work performed" metric.
+    const agentSum = projects.reduce((acc, p) => acc + p.agents, 0);
+    return {
+      totalCost,
+      totalTokens,
+      totalEvents,
+      totalAgents: agentSum,
+    };
+  }, [projects]);
 
   if (error) {
     return <div className="cost-error">⚠ {error}</div>;
@@ -96,40 +96,52 @@ const HistoricalTab = ({ onSelectExperiment }: Props) => {
           <span className="cost-stat-value">{formatTokens(totalTokens)}</span>
         </div>
         <div className="cost-stat">
-          <span className="cost-stat-label">Experiments</span>
-          <span className="cost-stat-value">{experiments.length}</span>
+          <span className="cost-stat-label">Events</span>
+          <span className="cost-stat-value">{totalEvents}</span>
+        </div>
+        <div className="cost-stat">
+          <span className="cost-stat-label">Projects</span>
+          <span className="cost-stat-value">{projects.length}</span>
+        </div>
+        <div className="cost-stat">
+          <span className="cost-stat-label">Agent runs</span>
+          <span className="cost-stat-value">{totalAgents}</span>
         </div>
       </header>
 
       <section className="cost-panel">
-        <h3>Cost per experiment</h3>
-        <CostTimeSeries
-          experiments={experiments}
-          onSelect={onSelectExperiment}
-        />
-      </section>
-
-      <section className="cost-panel">
         <h3>By project</h3>
-        {byProject.length === 0 ? (
-          <p className="empty">No experiments yet.</p>
+        {projects.length === 0 ? (
+          <p className="empty">No projects yet.</p>
         ) : (
           <table className="cost-table">
             <thead>
               <tr>
                 <th>Project</th>
-                <th>Runs</th>
+                <th>Events</th>
+                <th>Agents</th>
                 <th>Tokens</th>
                 <th>Cost</th>
+                <th>First seen</th>
+                <th>Last seen</th>
               </tr>
             </thead>
             <tbody>
-              {byProject.map((p) => (
+              {projects.map((p) => (
                 <tr key={p.project_id}>
-                  <td>{p.project_name ?? p.project_id}</td>
-                  <td>{p.count}</td>
-                  <td>{formatTokens(p.tokens)}</td>
-                  <td className="cost-cell">{formatUsd(p.cost)}</td>
+                  <td>
+                    {p.project_name ?? (
+                      <code className="project-id-code">
+                        {p.project_id.slice(0, 12)}…
+                      </code>
+                    )}
+                  </td>
+                  <td>{p.events}</td>
+                  <td>{p.agents}</td>
+                  <td>{formatTokens(p.total_tokens)}</td>
+                  <td className="cost-cell">{formatUsd(p.total_cost_usd)}</td>
+                  <td>{formatDate(p.first_event_at)}</td>
+                  <td>{formatDate(p.last_event_at)}</td>
                 </tr>
               ))}
             </tbody>

--- a/dashboard/src/components/HistoricalTab.tsx
+++ b/dashboard/src/components/HistoricalTab.tsx
@@ -1,0 +1,143 @@
+/**
+ * Tab 2 — Historical view.
+ *
+ * Aggregates every experiment in the cost store and renders:
+ * 1. Headline totals (lifetime cost, total tokens, experiment count).
+ * 2. A time-series bar chart of cost per experiment.
+ * 3. Per-project rollup table.
+ *
+ * No new backend endpoint needed — derives everything from
+ * ``/api/cost/experiments`` (no project filter, capped at 1000).
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { fetchExperiments, type ExperimentRow } from '../services/costService';
+import CostTimeSeries from './CostTimeSeries';
+import './HistoricalTab.css';
+
+interface Props {
+  onSelectExperiment?: (id: string) => void;
+}
+
+function formatUsd(v: number, decimals = 2): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function formatTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}
+
+const HistoricalTab = ({ onSelectExperiment }: Props) => {
+  const [experiments, setExperiments] = useState<ExperimentRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchExperiments(undefined, 1000)
+      .then(({ experiments: exps }) => {
+        if (!cancelled) {
+          setExperiments(exps);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Totals + per-project rollup, computed in-memory.
+  const { totalCost, totalTokens, byProject } = useMemo(() => {
+    let totalCost = 0;
+    let totalTokens = 0;
+    const byProject = new Map<
+      string,
+      { project_name: string | null; cost: number; tokens: number; count: number }
+    >();
+    for (const e of experiments) {
+      totalCost += e.total_cost_usd;
+      totalTokens += e.total_tokens;
+      const cur = byProject.get(e.project_id) ?? {
+        project_name: e.project_name,
+        cost: 0,
+        tokens: 0,
+        count: 0,
+      };
+      cur.cost += e.total_cost_usd;
+      cur.tokens += e.total_tokens;
+      cur.count += 1;
+      byProject.set(e.project_id, cur);
+    }
+    const rows = Array.from(byProject.entries())
+      .map(([project_id, v]) => ({ project_id, ...v }))
+      .sort((a, b) => b.cost - a.cost);
+    return { totalCost, totalTokens, byProject: rows };
+  }, [experiments]);
+
+  if (error) {
+    return <div className="cost-error">⚠ {error}</div>;
+  }
+
+  return (
+    <div className="cost-historical">
+      <header className="historical-stats">
+        <div className="cost-stat cost-stat-primary">
+          <span className="cost-stat-label">Lifetime cost</span>
+          <span className="cost-stat-value">{formatUsd(totalCost)}</span>
+        </div>
+        <div className="cost-stat">
+          <span className="cost-stat-label">Total tokens</span>
+          <span className="cost-stat-value">{formatTokens(totalTokens)}</span>
+        </div>
+        <div className="cost-stat">
+          <span className="cost-stat-label">Experiments</span>
+          <span className="cost-stat-value">{experiments.length}</span>
+        </div>
+      </header>
+
+      <section className="cost-panel">
+        <h3>Cost per experiment</h3>
+        <CostTimeSeries
+          experiments={experiments}
+          onSelect={onSelectExperiment}
+        />
+      </section>
+
+      <section className="cost-panel">
+        <h3>By project</h3>
+        {byProject.length === 0 ? (
+          <p className="empty">No experiments yet.</p>
+        ) : (
+          <table className="cost-table">
+            <thead>
+              <tr>
+                <th>Project</th>
+                <th>Runs</th>
+                <th>Tokens</th>
+                <th>Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {byProject.map((p) => (
+                <tr key={p.project_id}>
+                  <td>{p.project_name ?? p.project_id}</td>
+                  <td>{p.count}</td>
+                  <td>{formatTokens(p.tokens)}</td>
+                  <td className="cost-cell">{formatUsd(p.cost)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default HistoricalTab;

--- a/dashboard/src/components/MetricsPanel.css
+++ b/dashboard/src/components/MetricsPanel.css
@@ -94,6 +94,51 @@
   color: #f59e0b;
 }
 
+.metric-value.project-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.7rem;
+  color: #94a3b8;
+  font-weight: 500;
+  cursor: pointer;
+  max-width: 65%;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.4rem;
+  background: transparent;
+  border: 1px solid #334155;
+  border-radius: 0.25rem;
+  transition: background-color 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.metric-value.project-id:hover {
+  color: #e2e8f0;
+  background: #1e293b;
+  border-color: #475569;
+}
+
+.metric-value.project-id:active {
+  background: #0f172a;
+}
+
+.project-id-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  text-align: left;
+}
+
+.project-id-icon {
+  flex-shrink: 0;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.metric-value.project-id:hover .project-id-icon {
+  color: #94a3b8;
+}
+
 .agent-autonomy-item {
   margin-bottom: 0.75rem;
   padding-bottom: 0.75rem;

--- a/dashboard/src/components/MetricsPanel.tsx
+++ b/dashboard/src/components/MetricsPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useVisualizationStore } from '../store/visualizationStore';
 import './MetricsPanel.css';
 
@@ -5,8 +6,28 @@ const MetricsPanel = () => {
   const snapshot = useVisualizationStore((state) => state.snapshot);
   const getMetrics = useVisualizationStore((state) => state.getMetrics);
   const activeAgents = useVisualizationStore((state) => state.getActiveAgentsAtCurrentTime());
+  const [copied, setCopied] = useState(false);
 
   const metrics = getMetrics();
+
+  const copyProjectId = async () => {
+    if (!snapshot?.project_id) return;
+    try {
+      await navigator.clipboard.writeText(snapshot.project_id);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard API blocked (e.g. insecure context) — fallback select
+      const range = document.createRange();
+      const sel = window.getSelection();
+      const el = document.querySelector('.metric-value.project-id');
+      if (el && sel) {
+        range.selectNodeContents(el);
+        sel.removeAllRanges();
+        sel.addRange(range);
+      }
+    }
+  };
 
   if (!snapshot || !metrics) {
     return (
@@ -35,6 +56,21 @@ const MetricsPanel = () => {
             <span className="metric-label">Project Name</span>
             <span className="metric-value">{snapshot.project_name}</span>
           </div>
+          {snapshot.project_id && (
+            <div className="metric-item">
+              <span className="metric-label">Project ID</span>
+              <button
+                type="button"
+                className="metric-value project-id"
+                title={copied ? 'Copied!' : `Copy: ${snapshot.project_id}`}
+                onClick={copyProjectId}
+                aria-label={`Copy project ID ${snapshot.project_id}`}
+              >
+                <span className="project-id-text">{snapshot.project_id}</span>
+                <span className="project-id-icon">{copied ? '✓' : '⧉'}</span>
+              </button>
+            </div>
+          )}
           <div className="metric-item">
             <span className="metric-label">Total Duration</span>
             <span className="metric-value">{snapshot.duration_minutes}m</span>

--- a/dashboard/src/components/NetworkGraphView.tsx
+++ b/dashboard/src/components/NetworkGraphView.tsx
@@ -3,6 +3,7 @@ import * as d3 from 'd3';
 import { useVisualizationStore } from '../store/visualizationStore';
 import { Task } from '../services/dataService';
 import { getTaskStateAtTime } from '../utils/timelineUtils';
+import ViewModeToggle from './ViewModeToggle';
 import './NetworkGraphView.css';
 
 type TaskStatus = 'todo' | 'in_progress' | 'done' | 'blocked';
@@ -606,6 +607,7 @@ const NetworkGraphView = () => {
 
   return (
     <div className="network-graph-view">
+      <ViewModeToggle />
       {designTasks.length > 0 && (
         <div className="design-origins-strip">
           <div className="strip-label">Design Origins</div>

--- a/dashboard/src/components/OperationsPanel.tsx
+++ b/dashboard/src/components/OperationsPanel.tsx
@@ -1,0 +1,264 @@
+/**
+ * Per-LLM-call drill-down panel for the Real-time tab.
+ *
+ * Renders the ``by_operation`` slice grouped by category
+ * (decomposition / runtime / monitoring / other), with:
+ *
+ * - Filter pills at the top — toggle whole categories on/off.
+ * - Collapsible category sections with per-category aggregates,
+ *   so the table stays scannable past 40 operations.
+ * - A 🔥 badge on the single worst cold-cache offender (the
+ *   operation with the highest ``cache_creation_tokens *
+ *   (1 - cache_hit_rate)``) — that's the prompt-tightening
+ *   target Kaia called out in her review.
+ *
+ * The component is purely presentational: it owns its filter /
+ * collapse UI state, but the data comes from a parent prop and the
+ * catalog from a separate prop so it can be tested in isolation.
+ */
+
+import { useMemo, useState } from 'react';
+import type {
+  OperationCatalogEntry,
+  OperationSlice,
+} from '../services/costService';
+import {
+  ALL_CATEGORIES,
+  CATEGORY_LABELS,
+  bucketByCategory,
+  pickColdOffender,
+  type CategoryKey,
+} from './operationsPanel.logic';
+
+interface Props {
+  operations: OperationSlice[];
+  catalog: Record<string, OperationCatalogEntry>;
+}
+
+function formatUsd(v: number, decimals = 2): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function formatTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}
+
+function formatPct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+function cacheCellClass(rate: number): string {
+  if (rate < 0.3) return 'cache-cell cache-cold';
+  if (rate > 0.7) return 'cache-cell cache-hot';
+  return 'cache-cell';
+}
+
+const OperationsPanel = ({ operations, catalog }: Props) => {
+  // Default: all categories visible. Pills toggle off-states.
+  const [visibleCategories, setVisibleCategories] = useState<
+    Set<CategoryKey>
+  >(new Set(ALL_CATEGORIES));
+  // Default: all categories expanded. Headers toggle collapse.
+  const [collapsed, setCollapsed] = useState<Set<CategoryKey>>(new Set());
+
+  // Map operations into category groups. Pure logic in
+  // ``operationsPanel.logic.ts`` — see that file's docstring for the
+  // ``'other'`` fallback semantics and the rationale for empty-bucket
+  // filtering.
+  const groups = useMemo(
+    () => bucketByCategory(operations, catalog),
+    [operations, catalog],
+  );
+
+  // Find the worst cold-cache offender across all operations.
+  // Compute *before* visibility filtering so the badge always points
+  // at the global worst, even if the user has the relevant category
+  // off (avoids the chip jumping around as filters change). The
+  // pure logic is in ``operationsPanel.logic.ts``; it skips
+  // unregistered/typo operations and applies the 1000-token
+  // threshold.
+  const coldOffenderKey = useMemo(
+    () => pickColdOffender(operations, catalog),
+    [operations, catalog],
+  );
+
+  // ID prefix for table elements so aria-controls on each group
+  // header points at the correct table. Using a stable per-category
+  // suffix means the relationship is stable across re-renders.
+  const tableIdFor = (cat: CategoryKey) => `cost-operations-table-${cat}`;
+
+  const toggleCategory = (cat: CategoryKey) => {
+    setVisibleCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  };
+
+  const toggleCollapsed = (cat: CategoryKey) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  };
+
+  if (operations.length === 0) return null;
+
+  return (
+    <section className="cost-panel">
+      <h3>
+        Tokens by operation{' '}
+        <small className="cost-panel-hint">
+          Grouped by category. Click a pill to filter, a header to collapse.
+          🔥 marks the biggest cold-cache opportunity — the row where
+          tightening the prompt would save the most tokens.
+        </small>
+      </h3>
+
+      <div className="cost-operation-filters" role="toolbar">
+        {groups.map((g) => {
+          const active = visibleCategories.has(g.category);
+          return (
+            <button
+              key={g.category}
+              type="button"
+              className={`cost-operation-pill cat-${g.category} ${
+                active ? 'is-active' : 'is-inactive'
+              }`}
+              onClick={() => toggleCategory(g.category)}
+              aria-pressed={active}
+              title={`Toggle ${CATEGORY_LABELS[g.category]} (${g.ops.length} ops)`}
+            >
+              {CATEGORY_LABELS[g.category]}{' '}
+              <span className="cost-operation-pill-count">
+                {g.ops.length}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {(() => {
+        const visibleGroups = groups.filter((g) =>
+          visibleCategories.has(g.category),
+        );
+        if (visibleGroups.length === 0) {
+          // All categories filtered off — keep the toolbar usable but
+          // tell the user why the table area is empty. Kaia review on
+          // PR #39.
+          return (
+            <p className="cost-panel-hint cost-operation-empty">
+              No operations match the active filters. Click a category
+              pill above to bring its rows back.
+            </p>
+          );
+        }
+        return visibleGroups.map((g) => {
+          const isCollapsed = collapsed.has(g.category);
+          const tableId = tableIdFor(g.category);
+          return (
+            <div key={g.category} className="cost-operation-group">
+              <button
+                type="button"
+                className={`cost-operation-group-header cat-${g.category}`}
+                onClick={() => toggleCollapsed(g.category)}
+                aria-expanded={!isCollapsed}
+                aria-controls={tableId}
+              >
+                <span className="cost-operation-group-chevron">
+                  {isCollapsed ? '▶' : '▼'}
+                </span>
+                <span className="cost-operation-group-title">
+                  {CATEGORY_LABELS[g.category]}
+                </span>
+                <span className="cost-operation-group-stats">
+                  {g.ops.length} ops · {g.totalCalls} calls ·{' '}
+                  {formatTokens(g.totalTokens)} tokens ·{' '}
+                  {formatUsd(g.totalCost, 4)}
+                </span>
+              </button>
+
+              {!isCollapsed && (
+                <table
+                  id={tableId}
+                  className="cost-table cost-table-dense"
+                >
+                  <thead>
+                    <tr>
+                      <th>Operation</th>
+                      <th>Calls</th>
+                      <th>Input</th>
+                      <th>Cache create</th>
+                      <th>Cache read</th>
+                      <th>Output</th>
+                      <th>Cache %</th>
+                      <th>Cost</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {g.ops.map((op) => {
+                      const entry = catalog[op.operation];
+                      const label = entry?.label ?? op.operation;
+                      const tooltip = entry
+                        ? `${entry.label} — ${entry.description}`
+                        : `Unregistered operation '${op.operation}'. ` +
+                          'Add it to Marcus operations.py for a description.';
+                      const isColdOffender =
+                        op.operation === coldOffenderKey;
+                      return (
+                        <tr
+                          key={op.operation}
+                          className={
+                            isColdOffender ? 'cost-operation-cold-offender' : ''
+                          }
+                        >
+                          <td>
+                            <span
+                              className="cost-operation-label"
+                              title={tooltip}
+                            >
+                              {label}
+                            </span>
+                            {isColdOffender && (
+                              <span
+                                className="cost-operation-offender-badge"
+                                title={
+                                  'Highest cold-cache opportunity. ' +
+                                  'Tightening this prompt to fit the ' +
+                                  'cache window would save the most ' +
+                                  'tokens of any operation.'
+                                }
+                              >
+                                🔥
+                              </span>
+                            )}
+                          </td>
+                          <td>{op.events}</td>
+                          <td>{formatTokens(op.input_tokens ?? 0)}</td>
+                          <td>{formatTokens(op.cache_creation_tokens ?? 0)}</td>
+                          <td>{formatTokens(op.cache_read_tokens ?? 0)}</td>
+                          <td>{formatTokens(op.output_tokens ?? 0)}</td>
+                          <td className={cacheCellClass(op.cache_hit_rate ?? 0)}>
+                            {formatPct(op.cache_hit_rate ?? 0)}
+                          </td>
+                          <td>{formatUsd(op.cost_usd, 4)}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          );
+        });
+      })()}
+    </section>
+  );
+};
+
+export default OperationsPanel;

--- a/dashboard/src/components/OperationsPanel.tsx
+++ b/dashboard/src/components/OperationsPanel.tsx
@@ -12,6 +12,14 @@
  *   (1 - cache_hit_rate)``) — that's the prompt-tightening
  *   target Kaia called out in her review.
  *
+ * Marcus #527: worker rows are filtered OUT of this panel. The
+ * ``operation`` column only carries semantic meaning for planner
+ * rows; for workers it's always ``'turn'``, and the right
+ * attribution axes are task_id / agent_id / session_id — surfaced
+ * by ``TaskSpendPanel`` and ``AgentSpendBars``. Worker totals are
+ * still shown as a one-line summary at the bottom of this panel
+ * so spending isn't invisible.
+ *
  * The component is purely presentational: it owns its filter /
  * collapse UI state, but the data comes from a parent prop and the
  * catalog from a separate prop so it can be tested in isolation.
@@ -27,6 +35,7 @@ import {
   CATEGORY_LABELS,
   bucketByCategory,
   pickColdOffender,
+  splitByRole,
   type CategoryKey,
 } from './operationsPanel.logic';
 
@@ -63,13 +72,24 @@ const OperationsPanel = ({ operations, catalog }: Props) => {
   // Default: all categories expanded. Headers toggle collapse.
   const [collapsed, setCollapsed] = useState<Set<CategoryKey>>(new Set());
 
+  // Marcus #527: separate planner from worker rows. The chart only
+  // makes sense for planner ops (operation column is semantic there);
+  // worker rows are surfaced as a one-line summary at the bottom so
+  // total spend stays visible without polluting the breakdown. Pure
+  // logic lives in operationsPanel.logic so it can be unit-tested
+  // without DOM/React.
+  const { plannerOps, workerSummary } = useMemo(
+    () => splitByRole(operations),
+    [operations],
+  );
+
   // Map operations into category groups. Pure logic in
   // ``operationsPanel.logic.ts`` — see that file's docstring for the
   // ``'other'`` fallback semantics and the rationale for empty-bucket
   // filtering.
   const groups = useMemo(
-    () => bucketByCategory(operations, catalog),
-    [operations, catalog],
+    () => bucketByCategory(plannerOps, catalog),
+    [plannerOps, catalog],
   );
 
   // Find the worst cold-cache offender across all operations.
@@ -78,10 +98,11 @@ const OperationsPanel = ({ operations, catalog }: Props) => {
   // off (avoids the chip jumping around as filters change). The
   // pure logic is in ``operationsPanel.logic.ts``; it skips
   // unregistered/typo operations and applies the 1000-token
-  // threshold.
+  // threshold. Scoped to plannerOps for the same reason this whole
+  // panel is — see #527.
   const coldOffenderKey = useMemo(
-    () => pickColdOffender(operations, catalog),
-    [operations, catalog],
+    () => pickColdOffender(plannerOps, catalog),
+    [plannerOps, catalog],
   );
 
   // ID prefix for table elements so aria-controls on each group
@@ -114,9 +135,10 @@ const OperationsPanel = ({ operations, catalog }: Props) => {
       <h3>
         Tokens by operation{' '}
         <small className="cost-panel-hint">
-          Grouped by category. Click a pill to filter, a header to collapse.
-          🔥 marks the biggest cold-cache opportunity — the row where
-          tightening the prompt would save the most tokens.
+          <strong>Planner only.</strong> Worker turns are aggregated below —
+          see <em>Tokens by task</em> and <em>Cost by agent</em> for worker
+          attribution. Grouped by category. Click a pill to filter, a header
+          to collapse. 🔥 marks the biggest cold-cache opportunity.
         </small>
       </h3>
 
@@ -157,6 +179,12 @@ const OperationsPanel = ({ operations, catalog }: Props) => {
               pill above to bring its rows back.
             </p>
           );
+        }
+        if (plannerOps.length === 0) {
+          // Edge case: the run made worker calls but zero planner
+          // calls. Don't show an empty planner chart — surface the
+          // worker total directly so the user knows where to look.
+          return null;
         }
         return visibleGroups.map((g) => {
           const isCollapsed = collapsed.has(g.category);
@@ -257,6 +285,21 @@ const OperationsPanel = ({ operations, catalog }: Props) => {
           );
         });
       })()}
+
+      {workerSummary.events > 0 && (
+        <div className="cost-operation-worker-summary">
+          <span className="cost-operation-worker-summary-label">
+            Worker turns (one bucket, all agents):
+          </span>{' '}
+          <strong>{workerSummary.events.toLocaleString()}</strong> events ·{' '}
+          <strong>{formatTokens(workerSummary.tokens)}</strong> tokens ·{' '}
+          <strong>{formatUsd(workerSummary.cost, 4)}</strong>
+          <p className="cost-panel-hint">
+            For per-task and per-agent breakdown of worker spend, see the
+            panels above. Per-tool breakdown is planned (#527 Phase 2).
+          </p>
+        </div>
+      )}
     </section>
   );
 };

--- a/dashboard/src/components/PricingTab.css
+++ b/dashboard/src/components/PricingTab.css
@@ -27,6 +27,13 @@
   font-size: 13px;
 }
 
+/* Cost table rows previously inherited the muted color so the prices
+   were invisible against the dark theme (user feedback on PR #33).
+   Explicit color anchors all cells to the readable foreground. */
+.cost-pricing .cost-table td {
+  color: var(--text-color, #1e293b);
+}
+
 .cost-pricing .model-cell {
   font-family: var(--font-mono, ui-monospace, 'SF Mono', monospace);
   font-size: 12px;
@@ -35,6 +42,21 @@
 .cost-pricing .price-cell {
   font-variant-numeric: tabular-nums;
   text-align: right;
+}
+
+.cost-pricing .override-btn {
+  font-size: 11px;
+  padding: 2px 8px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  background: var(--bg-elevated, #ffffff);
+  color: var(--text-color, #1e293b);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.cost-pricing .override-btn:hover {
+  border-color: #0ea5e9;
+  color: #0ea5e9;
 }
 
 .source-tag {

--- a/dashboard/src/components/PricingTab.css
+++ b/dashboard/src/components/PricingTab.css
@@ -1,0 +1,141 @@
+.cost-pricing {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 24px;
+}
+
+.cost-pricing .empty {
+  padding: 16px;
+  color: var(--text-muted, #64748b);
+  font-style: italic;
+}
+
+.cost-pricing .hint {
+  font-size: 13px;
+  color: var(--text-muted, #64748b);
+  margin: 0 0 12px;
+}
+
+.cost-pricing .cost-error.inline {
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  background: rgba(220, 38, 38, 0.08);
+  border: 1px solid rgba(220, 38, 38, 0.3);
+  border-radius: 6px;
+  color: #b91c1c;
+  font-size: 13px;
+}
+
+.cost-pricing .model-cell {
+  font-family: var(--font-mono, ui-monospace, 'SF Mono', monospace);
+  font-size: 12px;
+}
+
+.cost-pricing .price-cell {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.source-tag {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 500;
+}
+
+.source-default {
+  background: rgba(100, 116, 139, 0.15);
+  color: #475569;
+}
+
+.source-cato_user {
+  background: rgba(14, 165, 233, 0.15);
+  color: #0369a1;
+}
+
+.source-contract {
+  background: rgba(124, 58, 237, 0.15);
+  color: #6d28d9;
+}
+
+/* Form */
+
+.price-form {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.price-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.price-form label > span {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #64748b);
+}
+
+.price-form input,
+.price-form select {
+  padding: 6px 8px;
+  font-size: 13px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 4px;
+  background: var(--bg-elevated, #ffffff);
+  font-family: inherit;
+}
+
+.price-form input:focus,
+.price-form select:focus {
+  outline: 2px solid rgba(14, 165, 233, 0.4);
+  outline-offset: 0;
+  border-color: #0ea5e9;
+}
+
+.form-footer {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-color, #e2e8f0);
+  margin-top: 8px;
+}
+
+.form-footer button {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  background: #0ea5e9;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.form-footer button:hover:not(:disabled) {
+  background: #0284c7;
+}
+
+.form-footer button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.form-msg {
+  font-size: 13px;
+}
+
+.form-error {
+  color: #b91c1c;
+}
+
+.form-success {
+  color: #15803d;
+}

--- a/dashboard/src/components/PricingTab.tsx
+++ b/dashboard/src/components/PricingTab.tsx
@@ -118,6 +118,7 @@ const PricingTab = () => {
                 <th>Cache read / M</th>
                 <th>Output / M</th>
                 <th>Source</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -138,6 +139,38 @@ const PricingTab = () => {
                     <span className={`source-tag source-${p.source ?? 'default'}`}>
                       {p.source ?? 'default'}
                     </span>
+                  </td>
+                  <td>
+                    <button
+                      type="button"
+                      className="override-btn"
+                      title={
+                        'Pre-fill the form below with this row, bumped to ' +
+                        'effective now. Pricing is versioned — old experiments ' +
+                        'keep their cost; new events use the override going ' +
+                        'forward.'
+                      }
+                      onClick={() => {
+                        setForm({
+                          model: p.model,
+                          provider: p.provider,
+                          input_per_million: p.input_per_million,
+                          output_per_million: p.output_per_million,
+                          cache_creation_per_million: p.cache_creation_per_million,
+                          cache_read_per_million: p.cache_read_per_million,
+                          source: 'cato_user',
+                          // Default effective_from to "now" so the override
+                          // wins for subsequent events. User can adjust.
+                          effective_from: new Date().toISOString(),
+                        });
+                        // Scroll the form into view so the prefill is obvious.
+                        document
+                          .querySelector('.price-form')
+                          ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                      }}
+                    >
+                      Override
+                    </button>
                   </td>
                 </tr>
               ))}

--- a/dashboard/src/components/PricingTab.tsx
+++ b/dashboard/src/components/PricingTab.tsx
@@ -1,0 +1,280 @@
+/**
+ * Tab 4 — Pricing.
+ *
+ * Two panels:
+ * 1. Current-prices table (the latest ``effective_from`` row per
+ *    model+provider). Powers the cost calculations everywhere else.
+ * 2. "Add new rate" form that POSTs to ``/api/cost/prices``. Marcus's
+ *    versioning means inserting a new ``effective_from`` overrides the
+ *    seed price for future events without rewriting history.
+ *
+ * Per #409's pricing model, prices are versioned by ``effective_from``
+ * and the latest row wins. Edits are append-only.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  createPrice,
+  fetchCurrentPrices,
+  type ModelPriceRow,
+  type PriceCreatePayload,
+} from '../services/costService';
+import './PricingTab.css';
+
+function formatPrice(v: number | null): string {
+  if (v == null) return '—';
+  if (v >= 1) return `$${v.toFixed(2)}`;
+  return `$${v.toFixed(4)}`;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+const EMPTY_FORM: PriceCreatePayload = {
+  model: '',
+  provider: 'anthropic',
+  input_per_million: 0,
+  output_per_million: 0,
+  cache_creation_per_million: null,
+  cache_read_per_million: null,
+  source: 'cato_user',
+};
+
+const PricingTab = () => {
+  const [prices, setPrices] = useState<ModelPriceRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState<PriceCreatePayload>(EMPTY_FORM);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formSuccess, setFormSuccess] = useState<string | null>(null);
+
+  const load = async () => {
+    try {
+      const { prices } = await fetchCurrentPrices();
+      setPrices(prices);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+    setFormSuccess(null);
+
+    if (!form.model.trim() || !form.provider.trim()) {
+      setFormError('Model and provider are required.');
+      return;
+    }
+    if (form.input_per_million < 0 || form.output_per_million < 0) {
+      setFormError('Prices must be non-negative.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await createPrice(form);
+      setFormSuccess(
+        `Inserted ${form.model} (${form.provider}) effective ` +
+          `${formatDate(result.effective_from)}`,
+      );
+      setForm(EMPTY_FORM);
+      await load();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="cost-pricing">
+      <section className="cost-panel">
+        <h3>Current prices</h3>
+        {error && <div className="cost-error inline">⚠ {error}</div>}
+        {prices.length === 0 ? (
+          <p className="empty">No prices loaded yet — Marcus's seed should populate on first server start.</p>
+        ) : (
+          <table className="cost-table">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>Provider</th>
+                <th>Effective from</th>
+                <th>Input / M</th>
+                <th>Cache create / M</th>
+                <th>Cache read / M</th>
+                <th>Output / M</th>
+                <th>Source</th>
+              </tr>
+            </thead>
+            <tbody>
+              {prices.map((p) => (
+                <tr key={`${p.model}-${p.provider}-${p.effective_from}`}>
+                  <td className="model-cell">{p.model}</td>
+                  <td>{p.provider}</td>
+                  <td>{formatDate(p.effective_from)}</td>
+                  <td className="price-cell">{formatPrice(p.input_per_million)}</td>
+                  <td className="price-cell">
+                    {formatPrice(p.cache_creation_per_million)}
+                  </td>
+                  <td className="price-cell">
+                    {formatPrice(p.cache_read_per_million)}
+                  </td>
+                  <td className="price-cell">{formatPrice(p.output_per_million)}</td>
+                  <td>
+                    <span className={`source-tag source-${p.source ?? 'default'}`}>
+                      {p.source ?? 'default'}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <section className="cost-panel">
+        <h3>Add new rate</h3>
+        <p className="hint">
+          Inserts a versioned row. Old experiments keep their original cost;
+          new events use this rate going forward.
+        </p>
+
+        <form className="price-form" onSubmit={handleSubmit}>
+          <label>
+            <span>Model</span>
+            <input
+              type="text"
+              required
+              value={form.model}
+              onChange={(e) => setForm({ ...form, model: e.target.value })}
+              placeholder="claude-sonnet-4-6"
+            />
+          </label>
+          <label>
+            <span>Provider</span>
+            <select
+              value={form.provider}
+              onChange={(e) => setForm({ ...form, provider: e.target.value })}
+            >
+              <option value="anthropic">anthropic</option>
+              <option value="openai">openai</option>
+              <option value="cloud">cloud</option>
+              <option value="local">local</option>
+            </select>
+          </label>
+          <label>
+            <span>Input $/M</span>
+            <input
+              type="number"
+              step="0.0001"
+              min="0"
+              required
+              value={form.input_per_million}
+              onChange={(e) =>
+                setForm({ ...form, input_per_million: Number(e.target.value) })
+              }
+            />
+          </label>
+          <label>
+            <span>Output $/M</span>
+            <input
+              type="number"
+              step="0.0001"
+              min="0"
+              required
+              value={form.output_per_million}
+              onChange={(e) =>
+                setForm({ ...form, output_per_million: Number(e.target.value) })
+              }
+            />
+          </label>
+          <label>
+            <span>Cache create $/M</span>
+            <input
+              type="number"
+              step="0.0001"
+              min="0"
+              value={form.cache_creation_per_million ?? ''}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  cache_creation_per_million:
+                    e.target.value === '' ? null : Number(e.target.value),
+                })
+              }
+              placeholder="(none)"
+            />
+          </label>
+          <label>
+            <span>Cache read $/M</span>
+            <input
+              type="number"
+              step="0.0001"
+              min="0"
+              value={form.cache_read_per_million ?? ''}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  cache_read_per_million:
+                    e.target.value === '' ? null : Number(e.target.value),
+                })
+              }
+              placeholder="(none)"
+            />
+          </label>
+          <label>
+            <span>Source</span>
+            <select
+              value={form.source ?? 'cato_user'}
+              onChange={(e) => setForm({ ...form, source: e.target.value })}
+            >
+              <option value="cato_user">cato_user</option>
+              <option value="contract">contract</option>
+            </select>
+          </label>
+          <label>
+            <span>Effective from</span>
+            <input
+              type="datetime-local"
+              value={form.effective_from?.slice(0, 16) ?? ''}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  effective_from: e.target.value
+                    ? new Date(e.target.value).toISOString()
+                    : undefined,
+                })
+              }
+            />
+          </label>
+
+          <div className="form-footer">
+            <button type="submit" disabled={submitting}>
+              {submitting ? 'Adding…' : 'Add rate'}
+            </button>
+            {formError && <span className="form-msg form-error">{formError}</span>}
+            {formSuccess && (
+              <span className="form-msg form-success">{formSuccess}</span>
+            )}
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+};
+
+export default PricingTab;

--- a/dashboard/src/components/RealTimeTab.css
+++ b/dashboard/src/components/RealTimeTab.css
@@ -443,3 +443,133 @@
   border: 1px dashed var(--border-color, #e2e8f0);
   border-radius: 6px;
 }
+
+/* ---------------------------------------------------------------------------
+ * Audit banner (Marcus #527)
+ * Sits at the top of the tab. Green when every token reconciles to a
+ * known role; amber when the audit found a gap.
+ * ------------------------------------------------------------------------- */
+.cost-audit-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 6px;
+  margin-bottom: 16px;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.cost-audit-healthy {
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  color: rgb(21, 128, 61);
+}
+
+.cost-audit-unhealthy {
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  color: rgb(180, 83, 9);
+}
+
+.cost-audit-icon {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.cost-audit-message {
+  flex: 1;
+}
+
+/* ---------------------------------------------------------------------------
+ * Worker total summary inside OperationsPanel (#527 Phase 1)
+ * Single line under the planner table reporting the aggregate worker
+ * spend, since per-tool breakdown isn't ready yet (Phase 2).
+ * ------------------------------------------------------------------------- */
+.cost-operation-worker-summary {
+  margin-top: 18px;
+  padding: 12px 14px;
+  background: rgba(99, 102, 241, 0.06);
+  border-left: 3px solid rgba(99, 102, 241, 0.4);
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.cost-operation-worker-summary-label {
+  color: var(--text-muted, #64748b);
+}
+
+.cost-operation-worker-summary .cost-panel-hint {
+  margin-top: 6px;
+  margin-bottom: 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * Task spend panel (#527 Phase 1)
+ * Truncated task_id with full id available on hover via title attribute.
+ * ------------------------------------------------------------------------- */
+.cost-task-id {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 12px;
+  color: var(--text-muted, #64748b);
+  cursor: help;
+}
+
+/* ---------------------------------------------------------------------------
+ * Tool intent badges (Marcus #527 Phase 2)
+ * One badge color per worker tool_intent. The Marcus MCP bucket is the
+ * one we most want to highlight — it's the coordination tax.
+ * ------------------------------------------------------------------------- */
+.cost-tool-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.cost-tool-worker-marcus-call {
+  background: rgba(99, 102, 241, 0.12);
+  color: rgb(67, 56, 202);
+  font-weight: 600;
+}
+
+.cost-tool-worker-mcp-call {
+  background: rgba(168, 85, 247, 0.10);
+  color: rgb(126, 34, 206);
+}
+
+.cost-tool-worker-edit {
+  background: rgba(34, 197, 94, 0.10);
+  color: rgb(21, 128, 61);
+}
+
+.cost-tool-worker-bash {
+  background: rgba(245, 158, 11, 0.10);
+  color: rgb(180, 83, 9);
+}
+
+.cost-tool-worker-search,
+.cost-tool-worker-read {
+  background: rgba(100, 116, 139, 0.10);
+  color: rgb(71, 85, 105);
+}
+
+.cost-tool-worker-text {
+  background: rgba(148, 163, 184, 0.10);
+  color: rgb(100, 116, 139);
+  font-style: italic;
+}
+
+.cost-tool-unknown {
+  background: rgba(239, 68, 68, 0.08);
+  color: rgb(153, 27, 27);
+}
+
+/* Task name in TaskSpendPanel (Marcus #530). Plain weight so it reads
+   as a real label, not a code identifier. cost-task-id (existing
+   class above) keeps its mono styling for the id-fallback case. */
+.cost-task-name {
+  font-weight: 500;
+  color: var(--text-primary, #0f172a);
+}

--- a/dashboard/src/components/RealTimeTab.css
+++ b/dashboard/src/components/RealTimeTab.css
@@ -1,0 +1,194 @@
+.cost-realtime {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 24px;
+  font-family: var(--font-sans, system-ui, -apple-system, sans-serif);
+}
+
+.cost-loading,
+.cost-error {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-muted, #64748b);
+}
+
+.cost-error {
+  color: var(--error-color, #dc2626);
+}
+
+/* Headline */
+
+.cost-headline {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 8px;
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-headline-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.cost-experiment-name {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.cost-status-pill {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.cost-status-pill.running {
+  background: rgba(34, 197, 94, 0.15);
+  color: #16a34a;
+}
+
+.cost-status-pill.done {
+  background: rgba(100, 116, 139, 0.15);
+  color: #475569;
+}
+
+.cost-headline-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.cost-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cost-stat-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted, #64748b);
+}
+
+.cost-stat-value {
+  font-size: 22px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.cost-stat-primary .cost-stat-value {
+  color: #0ea5e9;
+}
+
+/* Tokens row */
+
+.cost-tokens-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.cost-token-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 16px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-token-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #64748b);
+}
+
+.cost-token-value {
+  font-size: 18px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Breakdown row */
+
+.cost-breakdown {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 12px;
+}
+
+.cost-panel {
+  padding: 16px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 8px;
+  background: var(--bg-elevated, #ffffff);
+}
+
+.cost-panel h3 {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #475569);
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.cost-session-hint {
+  font-size: 11px;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text-muted, #64748b);
+  font-weight: 400;
+}
+
+.cost-role-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cost-role-list li {
+  display: grid;
+  grid-template-columns: 12px 1fr auto auto;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.role-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #94a3b8;
+}
+
+.role-dot.role-planner { background: #7c3aed; }
+.role-dot.role-worker  { background: #0ea5e9; }
+.role-dot.role-creator { background: #10b981; }
+.role-dot.role-monitor { background: #f59e0b; }
+.role-dot.role-subagent{ background: #8b5cf6; }
+
+.role-cost {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.role-events {
+  font-size: 11px;
+  color: var(--text-muted, #64748b);
+}

--- a/dashboard/src/components/RealTimeTab.css
+++ b/dashboard/src/components/RealTimeTab.css
@@ -192,3 +192,48 @@
   font-size: 11px;
   color: var(--text-muted, #64748b);
 }
+
+/* Dense token-breakdown table (Tokens by operation / Tokens by model).
+   Tighter padding so the 8-column layout doesn't wrap. */
+.cost-table-dense {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.cost-table-dense th,
+.cost-table-dense td {
+  padding: 6px 10px;
+  text-align: right;
+}
+
+.cost-table-dense th:first-child,
+.cost-table-dense td:first-child,
+.cost-table-dense th:nth-child(2),
+.cost-table-dense td:nth-child(2) {
+  text-align: left;
+}
+
+/* Cache-hit % cell color coding so cold-cache rows pop out.
+   <30% (cold) = the prompt-tightening target. >70% (hot) = cache is
+   doing its job. */
+.cache-cell {
+  font-weight: 500;
+}
+
+.cache-cell.cache-cold {
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.cache-cell.cache-hot {
+  color: #22c55e;
+  background: rgba(34, 197, 94, 0.08);
+}
+
+.cost-panel-hint {
+  display: block;
+  margin-top: 2px;
+  font-weight: 400;
+  font-size: 11px;
+  color: var(--text-muted, #94a3b8);
+}

--- a/dashboard/src/components/RealTimeTab.css
+++ b/dashboard/src/components/RealTimeTab.css
@@ -237,3 +237,209 @@
   font-size: 11px;
   color: var(--text-muted, #94a3b8);
 }
+
+/* Operation drill-down cells: `.cost-operation-label` is the primary
+   human label (hover for full description from the catalog).
+   `.cost-operation-cat` is a small tag chip showing which category
+   (decomposition / runtime / monitoring / other) the call belongs to,
+   so users can scan for "which setup-time call burned all those
+   cache-creation tokens?" without expanding rows. */
+.cost-operation-label {
+  cursor: help;
+  border-bottom: 1px dotted var(--text-muted, #94a3b8);
+}
+
+.cost-operation-cat {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  vertical-align: middle;
+}
+
+.cost-operation-cat.cat-decomposition {
+  background: rgba(59, 130, 246, 0.15);
+  color: #3b82f6;
+}
+
+.cost-operation-cat.cat-runtime {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+}
+
+.cost-operation-cat.cat-monitoring {
+  background: rgba(168, 85, 247, 0.15);
+  color: #a855f7;
+}
+
+.cost-operation-cat.cat-other {
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--text-muted, #94a3b8);
+}
+
+/* Filter pill row above the operations table. Each pill toggles the
+   visibility of one category. Inactive (toggled-off) pills dim out
+   so the active filter is unambiguous at a glance. */
+.cost-operation-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 12px;
+}
+
+.cost-operation-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-elevated, #ffffff);
+  color: var(--text-primary, #1e293b);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: opacity 120ms, background 120ms;
+}
+
+.cost-operation-pill.is-inactive {
+  opacity: 0.4;
+  background: transparent;
+}
+
+.cost-operation-pill.cat-decomposition.is-active {
+  border-color: rgba(59, 130, 246, 0.5);
+  background: rgba(59, 130, 246, 0.1);
+  color: #3b82f6;
+}
+
+.cost-operation-pill.cat-runtime.is-active {
+  border-color: rgba(34, 197, 94, 0.5);
+  background: rgba(34, 197, 94, 0.1);
+  color: #22c55e;
+}
+
+.cost-operation-pill.cat-monitoring.is-active {
+  border-color: rgba(168, 85, 247, 0.5);
+  background: rgba(168, 85, 247, 0.1);
+  color: #a855f7;
+}
+
+.cost-operation-pill.cat-other.is-active {
+  border-color: rgba(148, 163, 184, 0.5);
+  background: rgba(148, 163, 184, 0.1);
+  color: var(--text-muted, #94a3b8);
+}
+
+.cost-operation-pill-count {
+  display: inline-block;
+  min-width: 18px;
+  padding: 0 4px;
+  border-radius: 9px;
+  background: rgba(148, 163, 184, 0.2);
+  font-size: 10px;
+  font-weight: 600;
+  text-align: center;
+}
+
+/* Collapsible category groups within the operations table. Each
+   group has a header (chevron + label + aggregates) and an embedded
+   dense table. Headers are buttons so the whole bar is clickable. */
+.cost-operation-group {
+  margin: 0 0 16px;
+}
+
+.cost-operation-group-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 6px 10px;
+  margin: 0 0 4px;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+  background: var(--bg-elevated, #ffffff);
+  color: var(--text-primary, #1e293b);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  text-align: left;
+  transition: background 120ms;
+}
+
+.cost-operation-group-header:hover {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.cost-operation-group-chevron {
+  color: var(--text-muted, #94a3b8);
+  font-size: 10px;
+  width: 12px;
+  display: inline-block;
+}
+
+.cost-operation-group-title {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 11px;
+}
+
+.cost-operation-group-header.cat-decomposition .cost-operation-group-title {
+  color: #3b82f6;
+}
+
+.cost-operation-group-header.cat-runtime .cost-operation-group-title {
+  color: #22c55e;
+}
+
+.cost-operation-group-header.cat-monitoring .cost-operation-group-title {
+  color: #a855f7;
+}
+
+.cost-operation-group-header.cat-other .cost-operation-group-title {
+  color: var(--text-muted, #94a3b8);
+}
+
+.cost-operation-group-stats {
+  margin-left: auto;
+  color: var(--text-muted, #94a3b8);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+}
+
+/* Cold-cache offender badge: the 🔥 marks the single operation row
+   where tightening the prompt would save the most tokens
+   (cache_creation_tokens × (1 - cache_hit_rate)). The whole row gets
+   a subtle warning tint so it pops in a scan. */
+.cost-operation-offender-badge {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 12px;
+  cursor: help;
+}
+
+.cost-operation-cold-offender {
+  background: rgba(239, 68, 68, 0.06);
+}
+
+.cost-operation-cold-offender:hover {
+  background: rgba(239, 68, 68, 0.1);
+}
+
+/* Empty state when all category filter pills are toggled off. Keeps
+   the toolbar visible (so the user can flip a pill back on) but
+   replaces the table area with a hint. */
+.cost-operation-empty {
+  margin: 12px 0;
+  padding: 16px;
+  text-align: center;
+  border: 1px dashed var(--border-color, #e2e8f0);
+  border-radius: 6px;
+}

--- a/dashboard/src/components/RealTimeTab.tsx
+++ b/dashboard/src/components/RealTimeTab.tsx
@@ -1,0 +1,230 @@
+/**
+ * Tab 1 — Real-time experiment view.
+ *
+ * Polls Cato's ``/api/cost/experiments/{id}`` every 5s for the active
+ * experiment and renders the headline numbers plus two D3 charts:
+ * per-agent spend bars and a per-turn cost trajectory for the most
+ * recent session.
+ *
+ * Why polling, not SSE: Marcus's coordination model is board-mediated
+ * and pull-based; polling fits that paradigm and is much simpler to
+ * debug. We can layer SSE on later if real time matters more.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  fetchExperimentSummary,
+  fetchSessionTurns,
+  type ExperimentSummary,
+  type TurnPoint,
+} from '../services/costService';
+import AgentSpendBars from './AgentSpendBars';
+import TurnTrajectory from './TurnTrajectory';
+import './RealTimeTab.css';
+
+interface Props {
+  experimentId: string;
+  /** Poll interval in ms. Default 5000. Set to 0 to disable polling. */
+  pollIntervalMs?: number;
+}
+
+function formatUsd(v: number, decimals = 2): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function formatTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}
+
+function formatPct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+const RealTimeTab = ({ experimentId, pollIntervalMs = 5000 }: Props) => {
+  const [summary, setSummary] = useState<ExperimentSummary | null>(null);
+  const [turns, setTurns] = useState<TurnPoint[]>([]);
+  const [selectedSession, setSelectedSession] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Poll the experiment summary.
+  useEffect(() => {
+    let cancelled = false;
+
+    const tick = async () => {
+      try {
+        const s = await fetchExperimentSummary(experimentId);
+        if (!cancelled) {
+          setSummary(s);
+          setError(null);
+          // Pick the agent with the most turns as default session source.
+          // This is a heuristic — we surface a session picker once
+          // sessions become a first-class concept in the UI.
+          if (selectedSession === null) {
+            const topAgent = s.by_agent.find((a) => a.sessions > 0);
+            if (topAgent) {
+              // Use the agent_id-keyed convention: agents working a task
+              // commonly run one session. The session list isn't in the
+              // summary today; the trajectory chart stays empty until
+              // the user picks one via /api/cost/sessions/{id}/turns.
+              // For Phase 7, we leave selectedSession null until the
+              // session picker lands in Tabs 2-4.
+            }
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    };
+
+    tick();
+    if (pollIntervalMs > 0) {
+      const id = window.setInterval(tick, pollIntervalMs);
+      return () => {
+        cancelled = true;
+        window.clearInterval(id);
+      };
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [experimentId, pollIntervalMs, selectedSession]);
+
+  // Fetch turns when a session is selected.
+  useEffect(() => {
+    if (!selectedSession) {
+      setTurns([]);
+      return;
+    }
+    let cancelled = false;
+    fetchSessionTurns(selectedSession)
+      .then((d) => {
+        if (!cancelled) setTurns(d.turns);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedSession]);
+
+  if (error) {
+    return <div className="cost-error">⚠ {error}</div>;
+  }
+  if (!summary) {
+    return <div className="cost-loading">Loading cost data…</div>;
+  }
+
+  const s = summary.summary;
+  const isRunning = summary.ended_at === null;
+
+  return (
+    <div className="cost-realtime">
+      {/* Headline strip */}
+      <header className="cost-headline">
+        <div className="cost-headline-title">
+          <span className="cost-experiment-name">
+            {summary.project_name ?? summary.experiment_id}
+          </span>
+          <span
+            className={`cost-status-pill ${isRunning ? 'running' : 'done'}`}
+          >
+            {isRunning ? '● running' : '✓ done'}
+          </span>
+        </div>
+        <div className="cost-headline-metrics">
+          <div className="cost-stat">
+            <span className="cost-stat-label">Total tokens</span>
+            <span className="cost-stat-value">{formatTokens(s.total_tokens)}</span>
+          </div>
+          <div className="cost-stat cost-stat-primary">
+            <span className="cost-stat-label">Total cost</span>
+            <span className="cost-stat-value">{formatUsd(s.total_cost_usd, 2)}</span>
+          </div>
+          <div className="cost-stat">
+            <span className="cost-stat-label">Cache hit rate</span>
+            <span className="cost-stat-value">{formatPct(s.cache_hit_rate)}</span>
+          </div>
+          <div className="cost-stat">
+            <span className="cost-stat-label">Events</span>
+            <span className="cost-stat-value">{s.total_events}</span>
+          </div>
+        </div>
+      </header>
+
+      {/* Token breakdown row */}
+      <section className="cost-tokens-row">
+        <div className="cost-token-card">
+          <span className="cost-token-label">Input</span>
+          <span className="cost-token-value">{formatTokens(s.input_tokens)}</span>
+        </div>
+        <div className="cost-token-card">
+          <span className="cost-token-label">Cache created</span>
+          <span className="cost-token-value">
+            {formatTokens(s.cache_creation_tokens)}
+          </span>
+        </div>
+        <div className="cost-token-card">
+          <span className="cost-token-label">Cache read</span>
+          <span className="cost-token-value">
+            {formatTokens(s.cache_read_tokens)}
+          </span>
+        </div>
+        <div className="cost-token-card">
+          <span className="cost-token-label">Output</span>
+          <span className="cost-token-value">{formatTokens(s.output_tokens)}</span>
+        </div>
+      </section>
+
+      {/* Role + agent breakdowns */}
+      <section className="cost-breakdown">
+        <div className="cost-panel">
+          <h3>Cost by role</h3>
+          <ul className="cost-role-list">
+            {summary.by_role.map((r) => (
+              <li key={r.role}>
+                <span className={`role-dot role-${r.role}`}></span>
+                <span className="role-name">{r.role}</span>
+                <span className="role-cost">{formatUsd(r.cost_usd, 4)}</span>
+                <span className="role-events">({r.events} events)</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="cost-panel cost-panel-wide">
+          <h3>Cost by agent</h3>
+          <AgentSpendBars
+            agents={summary.by_agent}
+            onAgentClick={(agentId) => {
+              // First-pass: clicking an agent sets the session source
+              // to the agent_id. The session_id is not in the summary
+              // payload today; for Phase 7 we leave the chart empty
+              // until the session-picker lands in Tabs 2-4.
+              setSelectedSession(agentId);
+            }}
+          />
+        </div>
+      </section>
+
+      {/* Turn trajectory */}
+      <section className="cost-panel">
+        <h3>
+          Per-turn trajectory
+          {selectedSession && (
+            <span className="cost-session-hint">session: {selectedSession}</span>
+          )}
+        </h3>
+        <TurnTrajectory turns={turns} />
+      </section>
+    </div>
+  );
+};
+
+export default RealTimeTab;

--- a/dashboard/src/components/RealTimeTab.tsx
+++ b/dashboard/src/components/RealTimeTab.tsx
@@ -12,10 +12,13 @@
 
 import { useEffect, useState } from 'react';
 import {
+  fetchOperationCatalog,
   fetchProjectFullSummary,
+  type OperationCatalogEntry,
   type ProjectFullSummary,
 } from '../services/costService';
 import AgentSpendBars from './AgentSpendBars';
+import OperationsPanel from './OperationsPanel';
 import './RealTimeTab.css';
 
 interface Props {
@@ -46,6 +49,26 @@ const RealTimeTab = ({ projectId, pollIntervalMs = 5000 }: Props) => {
   // from a generic error — render a friendly empty state.
   const [noActivity, setNoActivity] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  // Operation taxonomy (label + description per operation key). Loaded
+  // once on first render; survives polling. Empty when Marcus is older
+  // and lacks the operations module — falls through to raw keys.
+  const [opCatalog, setOpCatalog] = useState<
+    Record<string, OperationCatalogEntry>
+  >({});
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchOperationCatalog()
+      .then((c) => {
+        if (!cancelled) setOpCatalog(c.operations);
+      })
+      .catch(() => {
+        // intentionally swallowed — endpoint may not exist on old Marcus
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -187,48 +210,11 @@ const RealTimeTab = ({ projectId, pollIntervalMs = 5000 }: Props) => {
         </div>
       </section>
 
-      {summary.by_operation.length > 0 && (
-        <section className="cost-panel">
-          <h3>
-            Tokens by operation{' '}
-            <small className="cost-panel-hint">
-              Sorted by total tokens — the heaviest call is the prompt-
-              tightening target. Low cache-hit % on a heavy row means
-              that operation isn't benefiting from the prompt cache.
-            </small>
-          </h3>
-          <table className="cost-table cost-table-dense">
-            <thead>
-              <tr>
-                <th>Operation</th>
-                <th>Calls</th>
-                <th>Input</th>
-                <th>Cache create</th>
-                <th>Cache read</th>
-                <th>Output</th>
-                <th>Cache %</th>
-                <th>Cost</th>
-              </tr>
-            </thead>
-            <tbody>
-              {summary.by_operation.map((op) => (
-                <tr key={op.operation}>
-                  <td>{op.operation}</td>
-                  <td>{op.events}</td>
-                  <td>{formatTokens(op.input_tokens ?? 0)}</td>
-                  <td>{formatTokens(op.cache_creation_tokens ?? 0)}</td>
-                  <td>{formatTokens(op.cache_read_tokens ?? 0)}</td>
-                  <td>{formatTokens(op.output_tokens ?? 0)}</td>
-                  <td className={cacheCellClass(op.cache_hit_rate ?? 0)}>
-                    {formatPct(op.cache_hit_rate ?? 0)}
-                  </td>
-                  <td>{formatUsd(op.cost_usd, 4)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </section>
-      )}
+      <OperationsPanel
+        operations={summary.by_operation}
+        catalog={opCatalog}
+      />
+
 
       {summary.by_model.length > 0 && (
         <section className="cost-panel">

--- a/dashboard/src/components/RealTimeTab.tsx
+++ b/dashboard/src/components/RealTimeTab.tsx
@@ -1,29 +1,25 @@
 /**
- * Tab 1 — Real-time experiment view.
+ * Tab 1 — Real-time project view.
  *
- * Polls Cato's ``/api/cost/experiments/{id}`` every 5s for the active
- * experiment and renders the headline numbers plus two D3 charts:
- * per-agent spend bars and a per-turn cost trajectory for the most
- * recent session.
+ * Project-first (Marcus #503): renders the cost breakdown for one
+ * project across all agents, roles, sessions, and turns. Replaces the
+ * old experiment-keyed view because Marcus's main code path doesn't
+ * open MLflow experiments — project_id is the universal identity.
  *
- * Why polling, not SSE: Marcus's coordination model is board-mediated
- * and pull-based; polling fits that paradigm and is much simpler to
- * debug. We can layer SSE on later if real time matters more.
+ * Pulls from ``/api/cost/projects/{id}/summary`` which mirrors the
+ * shape ``/api/cost/experiments/{id}`` used to return.
  */
 
 import { useEffect, useState } from 'react';
 import {
-  fetchExperimentSummary,
-  fetchSessionTurns,
-  type ExperimentSummary,
-  type TurnPoint,
+  fetchProjectFullSummary,
+  type ProjectFullSummary,
 } from '../services/costService';
 import AgentSpendBars from './AgentSpendBars';
-import TurnTrajectory from './TurnTrajectory';
 import './RealTimeTab.css';
 
 interface Props {
-  experimentId: string;
+  projectId: string;
   /** Poll interval in ms. Default 5000. Set to 0 to disable polling. */
   pollIntervalMs?: number;
 }
@@ -42,45 +38,44 @@ function formatPct(v: number): string {
   return `${(v * 100).toFixed(1)}%`;
 }
 
-const RealTimeTab = ({ experimentId, pollIntervalMs = 5000 }: Props) => {
-  const [summary, setSummary] = useState<ExperimentSummary | null>(null);
-  const [turns, setTurns] = useState<TurnPoint[]>([]);
-  const [selectedSession, setSelectedSession] = useState<string | null>(null);
+const RealTimeTab = ({ projectId, pollIntervalMs = 5000 }: Props) => {
+  const [summary, setSummary] = useState<ProjectFullSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // 404 from /summary means the project exists in the picker (it has a
+  // ProjectRow entry from /projects) but has zero token_events. Distinct
+  // from a generic error — render a friendly empty state.
+  const [noActivity, setNoActivity] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
-  // Poll the experiment summary.
   useEffect(() => {
     let cancelled = false;
+    setLoaded(false);
+    setNoActivity(false);
+    setSummary(null);
 
     const tick = async () => {
       try {
-        const s = await fetchExperimentSummary(experimentId);
+        const s = await fetchProjectFullSummary(projectId);
         if (!cancelled) {
           setSummary(s);
+          setNoActivity(false);
           setError(null);
-          // Pick the agent with the most turns as default session source.
-          // This is a heuristic — we surface a session picker once
-          // sessions become a first-class concept in the UI.
-          if (selectedSession === null) {
-            const topAgent = s.by_agent.find((a) => a.sessions > 0);
-            if (topAgent) {
-              // Use the agent_id-keyed convention: agents working a task
-              // commonly run one session. The session list isn't in the
-              // summary today; the trajectory chart stays empty until
-              // the user picks one via /api/cost/sessions/{id}/turns.
-              // For Phase 7, we leave selectedSession null until the
-              // session picker lands in Tabs 2-4.
-            }
-          }
         }
       } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("HTTP 404")) {
+          setNoActivity(true);
+          setError(null);
+        } else {
+          setError(msg);
         }
+      } finally {
+        if (!cancelled) setLoaded(true);
       }
     };
 
-    tick();
+    void tick();
     if (pollIntervalMs > 0) {
       const id = window.setInterval(tick, pollIntervalMs);
       return () => {
@@ -91,51 +86,37 @@ const RealTimeTab = ({ experimentId, pollIntervalMs = 5000 }: Props) => {
     return () => {
       cancelled = true;
     };
-  }, [experimentId, pollIntervalMs, selectedSession]);
-
-  // Fetch turns when a session is selected.
-  useEffect(() => {
-    if (!selectedSession) {
-      setTurns([]);
-      return;
-    }
-    let cancelled = false;
-    fetchSessionTurns(selectedSession)
-      .then((d) => {
-        if (!cancelled) setTurns(d.turns);
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedSession]);
+  }, [projectId, pollIntervalMs]);
 
   if (error) {
     return <div className="cost-error">⚠ {error}</div>;
   }
-  if (!summary) {
+  if (noActivity) {
+    return (
+      <div className="cost-empty">
+        <p>No LLM activity recorded for this project yet.</p>
+        <p className="hint">
+          Cost data appears here as soon as Marcus or an agent makes its
+          first LLM call against this project.
+        </p>
+      </div>
+    );
+  }
+  if (!summary && !loaded) {
     return <div className="cost-loading">Loading cost data…</div>;
+  }
+  if (!summary) {
+    return <div className="cost-empty">No data.</div>;
   }
 
   const s = summary.summary;
-  const isRunning = summary.ended_at === null;
 
   return (
     <div className="cost-realtime">
-      {/* Headline strip */}
       <header className="cost-headline">
         <div className="cost-headline-title">
           <span className="cost-experiment-name">
-            {summary.project_name ?? summary.experiment_id}
-          </span>
-          <span
-            className={`cost-status-pill ${isRunning ? 'running' : 'done'}`}
-          >
-            {isRunning ? '● running' : '✓ done'}
+            {summary.project_name ?? summary.project_id}
           </span>
         </div>
         <div className="cost-headline-metrics">
@@ -155,10 +136,13 @@ const RealTimeTab = ({ experimentId, pollIntervalMs = 5000 }: Props) => {
             <span className="cost-stat-label">Events</span>
             <span className="cost-stat-value">{s.total_events}</span>
           </div>
+          <div className="cost-stat">
+            <span className="cost-stat-label">Agents</span>
+            <span className="cost-stat-value">{s.agents}</span>
+          </div>
         </div>
       </header>
 
-      {/* Token breakdown row */}
       <section className="cost-tokens-row">
         <div className="cost-token-card">
           <span className="cost-token-label">Input</span>
@@ -182,7 +166,6 @@ const RealTimeTab = ({ experimentId, pollIntervalMs = 5000 }: Props) => {
         </div>
       </section>
 
-      {/* Role + agent breakdowns */}
       <section className="cost-breakdown">
         <div className="cost-panel">
           <h3>Cost by role</h3>
@@ -200,31 +183,109 @@ const RealTimeTab = ({ experimentId, pollIntervalMs = 5000 }: Props) => {
 
         <div className="cost-panel cost-panel-wide">
           <h3>Cost by agent</h3>
-          <AgentSpendBars
-            agents={summary.by_agent}
-            onAgentClick={(agentId) => {
-              // First-pass: clicking an agent sets the session source
-              // to the agent_id. The session_id is not in the summary
-              // payload today; for Phase 7 we leave the chart empty
-              // until the session-picker lands in Tabs 2-4.
-              setSelectedSession(agentId);
-            }}
-          />
+          <AgentSpendBars agents={summary.by_agent} />
         </div>
       </section>
 
-      {/* Turn trajectory */}
-      <section className="cost-panel">
-        <h3>
-          Per-turn trajectory
-          {selectedSession && (
-            <span className="cost-session-hint">session: {selectedSession}</span>
-          )}
-        </h3>
-        <TurnTrajectory turns={turns} />
-      </section>
+      {summary.by_operation.length > 0 && (
+        <section className="cost-panel">
+          <h3>
+            Tokens by operation{' '}
+            <small className="cost-panel-hint">
+              Sorted by total tokens — the heaviest call is the prompt-
+              tightening target. Low cache-hit % on a heavy row means
+              that operation isn't benefiting from the prompt cache.
+            </small>
+          </h3>
+          <table className="cost-table cost-table-dense">
+            <thead>
+              <tr>
+                <th>Operation</th>
+                <th>Calls</th>
+                <th>Input</th>
+                <th>Cache create</th>
+                <th>Cache read</th>
+                <th>Output</th>
+                <th>Cache %</th>
+                <th>Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.by_operation.map((op) => (
+                <tr key={op.operation}>
+                  <td>{op.operation}</td>
+                  <td>{op.events}</td>
+                  <td>{formatTokens(op.input_tokens ?? 0)}</td>
+                  <td>{formatTokens(op.cache_creation_tokens ?? 0)}</td>
+                  <td>{formatTokens(op.cache_read_tokens ?? 0)}</td>
+                  <td>{formatTokens(op.output_tokens ?? 0)}</td>
+                  <td className={cacheCellClass(op.cache_hit_rate ?? 0)}>
+                    {formatPct(op.cache_hit_rate ?? 0)}
+                  </td>
+                  <td>{formatUsd(op.cost_usd, 4)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+
+      {summary.by_model.length > 0 && (
+        <section className="cost-panel">
+          <h3>
+            Tokens by model{' '}
+            <small className="cost-panel-hint">
+              Each provider/model with its cache effectiveness.
+            </small>
+          </h3>
+          <table className="cost-table cost-table-dense">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>Provider</th>
+                <th>Calls</th>
+                <th>Input</th>
+                <th>Cache create</th>
+                <th>Cache read</th>
+                <th>Output</th>
+                <th>Cache %</th>
+                <th>Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.by_model.map((m) => (
+                <tr key={`${m.model}-${m.provider}`}>
+                  <td>{m.model}</td>
+                  <td>{m.provider}</td>
+                  <td>{m.events}</td>
+                  <td>{formatTokens(m.input_tokens ?? 0)}</td>
+                  <td>{formatTokens(m.cache_creation_tokens ?? 0)}</td>
+                  <td>{formatTokens(m.cache_read_tokens ?? 0)}</td>
+                  <td>{formatTokens(m.output_tokens ?? 0)}</td>
+                  <td className={cacheCellClass(m.cache_hit_rate ?? 0)}>
+                    {formatPct(m.cache_hit_rate ?? 0)}
+                  </td>
+                  <td>{formatUsd(m.cost_usd, 4)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
     </div>
   );
 };
+
+/**
+ * Color-code the cache-hit cell so low-cache rows pop out.
+ * Below 30%: amber (the row that needs prompt-tightening attention).
+ * 30–70%: neutral.
+ * Above 70%: green (cache is working).
+ */
+function cacheCellClass(rate: number): string {
+  if (rate < 0.3) return 'cache-cell cache-cold';
+  if (rate > 0.7) return 'cache-cell cache-hot';
+  return 'cache-cell';
+}
 
 export default RealTimeTab;

--- a/dashboard/src/components/RealTimeTab.tsx
+++ b/dashboard/src/components/RealTimeTab.tsx
@@ -19,6 +19,8 @@ import {
 } from '../services/costService';
 import AgentSpendBars from './AgentSpendBars';
 import OperationsPanel from './OperationsPanel';
+import TaskSpendPanel from './TaskSpendPanel';
+import ToolIntentPanel from './ToolIntentPanel';
 import './RealTimeTab.css';
 
 interface Props {
@@ -209,6 +211,10 @@ const RealTimeTab = ({ projectId, pollIntervalMs = 5000 }: Props) => {
           <AgentSpendBars agents={summary.by_agent} />
         </div>
       </section>
+
+      <TaskSpendPanel tasks={summary.by_task} />
+
+      <ToolIntentPanel tools={summary.by_tool} />
 
       <OperationsPanel
         operations={summary.by_operation}

--- a/dashboard/src/components/TaskSpendPanel.tsx
+++ b/dashboard/src/components/TaskSpendPanel.tsx
@@ -1,0 +1,103 @@
+/**
+ * Per-task token spend (Marcus #527 Phase 1).
+ *
+ * Surfaces ``by_task`` from the run/project summary. The data has
+ * been fetched all along; this panel just renders it. For worker
+ * rows, this is the natural attribution axis — not ``operation``,
+ * which is always ``'turn'`` for workers.
+ *
+ * Each row shows the task_id (truncated for readability), the number
+ * of LLM events that worker turns produced under that task, the
+ * total tokens, and the estimated cost. Sorted server-side by cost
+ * descending so the most-expensive task surfaces first — that's the
+ * one to investigate.
+ */
+
+import type { TaskSlice } from '../services/costService';
+
+interface Props {
+  tasks: TaskSlice[];
+}
+
+function formatUsd(v: number, decimals = 4): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function formatTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}
+
+function shortId(id: string): string {
+  // task_ids are typically dashless UUIDs or long hex; show the
+  // leading 8 chars so rows are scannable but still copy-clickable
+  // via the full id in the title attribute.
+  if (id.length > 12) return `${id.slice(0, 8)}…`;
+  return id;
+}
+
+/**
+ * Display label for a task row. Prefer the snapshotted kanban name
+ * (Marcus #530, populated by ``costs.db::task_names`` LEFT JOIN);
+ * fall back to the truncated task_id when the task_metadata entry
+ * doesn't exist for this id (historical data, orphaned subtask).
+ */
+function taskLabel(t: TaskSlice): string {
+  if (t.task_name) return t.task_name;
+  return shortId(t.task_id);
+}
+
+const TaskSpendPanel = ({ tasks }: Props) => {
+  if (tasks.length === 0) {
+    return null;
+  }
+
+  const total = tasks.reduce((sum, t) => sum + t.tokens, 0);
+
+  return (
+    <section className="cost-panel">
+      <h3>
+        Tokens by task{' '}
+        <small className="cost-panel-hint">
+          Where worker spend actually goes. The chart "Tokens by operation"
+          is planner-only — workers are attributed by task here.
+        </small>
+      </h3>
+      <table className="cost-table cost-table-dense">
+        <thead>
+          <tr>
+            <th>Task</th>
+            <th>Events</th>
+            <th>Tokens</th>
+            <th>Share</th>
+            <th>Cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tasks.map((t) => {
+            const share = total > 0 ? t.tokens / total : 0;
+            return (
+              <tr key={t.task_id}>
+                <td>
+                  <span
+                    className={t.task_name ? 'cost-task-name' : 'cost-task-id'}
+                    title={t.task_id}
+                  >
+                    {taskLabel(t)}
+                  </span>
+                </td>
+                <td>{t.events}</td>
+                <td>{formatTokens(t.tokens)}</td>
+                <td>{(share * 100).toFixed(1)}%</td>
+                <td>{formatUsd(t.cost_usd)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </section>
+  );
+};
+
+export default TaskSpendPanel;

--- a/dashboard/src/components/ToolIntentPanel.tsx
+++ b/dashboard/src/components/ToolIntentPanel.tsx
@@ -1,0 +1,94 @@
+/**
+ * Per-tool worker spend breakdown (Marcus #527 Phase 2).
+ *
+ * Renders ``summary.by_tool`` as a table. Worker rows are bucketed
+ * by what tool the agent invoked on each LLM call — coordination
+ * with Marcus (``worker_marcus_call``), editing code
+ * (``worker_edit``), running tests (``worker_bash``), and so on.
+ *
+ * The most valuable bucket here is ``worker_marcus_call``: it's the
+ * coordination tax (tokens spent talking to Marcus through MCP),
+ * the metric every user wants to optimize but nobody could see
+ * before the parser landed.
+ */
+
+import type { ToolSlice } from '../services/costService';
+
+interface Props {
+  tools: ToolSlice[] | undefined;
+}
+
+const INTENT_LABELS: Record<string, string> = {
+  worker_marcus_call: 'Marcus MCP (coordination)',
+  worker_mcp_call: 'Other MCP servers',
+  worker_edit: 'Edit / Write code',
+  worker_bash: 'Bash (tests, builds, git)',
+  worker_search: 'Grep / Glob / search',
+  worker_read: 'Read files',
+  worker_text: 'Text reasoning (no tool)',
+  unknown: 'Unclassified',
+};
+
+function formatUsd(v: number, decimals = 4): string {
+  return `$${v.toFixed(decimals)}`;
+}
+
+function formatTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}
+
+const ToolIntentPanel = ({ tools }: Props) => {
+  if (!tools || tools.length === 0) {
+    return null;
+  }
+  const total = tools.reduce((sum, t) => sum + t.tokens, 0);
+
+  return (
+    <section className="cost-panel">
+      <h3>
+        Tokens by tool intent{' '}
+        <small className="cost-panel-hint">
+          What the agent was doing on each LLM call. The{' '}
+          <strong>Marcus MCP</strong> bucket is the coordination tax —
+          tokens spent talking to Marcus, not on actual work.
+        </small>
+      </h3>
+      <table className="cost-table cost-table-dense">
+        <thead>
+          <tr>
+            <th>Tool intent</th>
+            <th>Events</th>
+            <th>Tokens</th>
+            <th>Share</th>
+            <th>Cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tools.map((t) => {
+            const share = total > 0 ? t.tokens / total : 0;
+            const label = INTENT_LABELS[t.tool_intent] ?? t.tool_intent;
+            return (
+              <tr key={t.tool_intent}>
+                <td>
+                  <span
+                    className={`cost-tool-badge cost-tool-${t.tool_intent.replace(/_/g, '-')}`}
+                  >
+                    {label}
+                  </span>
+                </td>
+                <td>{t.events.toLocaleString()}</td>
+                <td>{formatTokens(t.tokens)}</td>
+                <td>{(share * 100).toFixed(1)}%</td>
+                <td>{formatUsd(t.cost_usd)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </section>
+  );
+};
+
+export default ToolIntentPanel;

--- a/dashboard/src/components/TurnTrajectory.css
+++ b/dashboard/src/components/TurnTrajectory.css
@@ -1,0 +1,44 @@
+.turn-trajectory {
+  font-family: var(--font-mono, ui-monospace, 'SF Mono', monospace);
+}
+
+.turn-trajectory .grid {
+  stroke: var(--border-color, #e2e8f0);
+  stroke-dasharray: 2 4;
+}
+
+.turn-trajectory .area {
+  fill: rgba(14, 165, 233, 0.12);
+}
+
+.turn-trajectory .line {
+  fill: none;
+  stroke: #0ea5e9;
+  stroke-width: 2;
+}
+
+.turn-trajectory .point {
+  fill: #0ea5e9;
+  stroke: white;
+  stroke-width: 1.5;
+}
+
+.turn-trajectory .axis-label,
+.turn-trajectory .axis-caption {
+  font-size: 11px;
+  fill: var(--text-muted, #64748b);
+}
+
+.turn-trajectory .axis-caption {
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.turn-trajectory-empty {
+  padding: 24px;
+  color: var(--text-muted, #64748b);
+  font-size: 13px;
+  font-style: italic;
+  text-align: center;
+}

--- a/dashboard/src/components/TurnTrajectory.tsx
+++ b/dashboard/src/components/TurnTrajectory.tsx
@@ -1,0 +1,149 @@
+/**
+ * Per-turn cost trajectory for a single Claude Code session.
+ *
+ * Renders a D3 line chart with turn_index on the x-axis and cost_usd
+ * on the y-axis, plus a faint area under the line. Used in the
+ * real-time tab to spot runaway loops — a session whose cost climbs
+ * sharply across consecutive turns is usually stuck.
+ */
+
+import { useMemo } from 'react';
+import * as d3 from 'd3';
+import type { TurnPoint } from '../services/costService';
+import './TurnTrajectory.css';
+
+interface Props {
+  turns: TurnPoint[];
+  width?: number;
+  height?: number;
+}
+
+const MARGIN = { top: 16, right: 16, bottom: 24, left: 48 };
+
+const TurnTrajectory = ({ turns, width = 640, height = 220 }: Props) => {
+  const innerW = width - MARGIN.left - MARGIN.right;
+  const innerH = height - MARGIN.top - MARGIN.bottom;
+
+  const xScale = useMemo(() => {
+    const maxTurn = d3.max(turns, (d) => d.turn_index) ?? 1;
+    return d3.scaleLinear().domain([1, Math.max(maxTurn, 1)]).range([0, innerW]);
+  }, [turns, innerW]);
+
+  const yScale = useMemo(() => {
+    const maxCost = d3.max(turns, (d) => d.cost_usd) ?? 0.001;
+    return d3.scaleLinear().domain([0, maxCost * 1.1]).range([innerH, 0]);
+  }, [turns, innerH]);
+
+  const linePath = useMemo(() => {
+    return d3
+      .line<TurnPoint>()
+      .x((d) => xScale(d.turn_index))
+      .y((d) => yScale(d.cost_usd))
+      .curve(d3.curveMonotoneX)(turns);
+  }, [turns, xScale, yScale]);
+
+  const areaPath = useMemo(() => {
+    return d3
+      .area<TurnPoint>()
+      .x((d) => xScale(d.turn_index))
+      .y0(innerH)
+      .y1((d) => yScale(d.cost_usd))
+      .curve(d3.curveMonotoneX)(turns);
+  }, [turns, xScale, yScale, innerH]);
+
+  if (turns.length === 0) {
+    return (
+      <div className="turn-trajectory-empty">
+        Pick a session to see its per-turn cost.
+      </div>
+    );
+  }
+
+  // 5 horizontal gridlines.
+  const yTicks = yScale.ticks(5);
+  const xTicks = xScale.ticks(Math.min(turns.length, 8));
+
+  return (
+    <svg
+      className="turn-trajectory"
+      width="100%"
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      aria-label="Per-turn cost trajectory"
+    >
+      <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+        {/* Gridlines */}
+        {yTicks.map((t) => (
+          <line
+            key={`yg-${t}`}
+            x1={0}
+            x2={innerW}
+            y1={yScale(t)}
+            y2={yScale(t)}
+            className="grid"
+          />
+        ))}
+
+        {/* Area + line */}
+        {areaPath && <path d={areaPath} className="area" />}
+        {linePath && <path d={linePath} className="line" />}
+
+        {/* Points */}
+        {turns.map((t) => (
+          <circle
+            key={`p-${t.turn_index}`}
+            cx={xScale(t.turn_index)}
+            cy={yScale(t.cost_usd)}
+            r={3}
+            className="point"
+          >
+            <title>
+              turn {t.turn_index} — ${t.cost_usd.toFixed(4)} ({t.total_tokens} tok)
+            </title>
+          </circle>
+        ))}
+
+        {/* Y axis labels */}
+        {yTicks.map((t) => (
+          <text
+            key={`yl-${t}`}
+            x={-8}
+            y={yScale(t)}
+            dominantBaseline="middle"
+            textAnchor="end"
+            className="axis-label"
+          >
+            ${t.toFixed(3)}
+          </text>
+        ))}
+
+        {/* X axis labels */}
+        {xTicks.map((t) => (
+          <text
+            key={`xl-${t}`}
+            x={xScale(t)}
+            y={innerH + 16}
+            textAnchor="middle"
+            className="axis-label"
+          >
+            {t}
+          </text>
+        ))}
+
+        {/* X axis caption */}
+        <text
+          x={innerW / 2}
+          y={innerH + 32}
+          textAnchor="middle"
+          className="axis-caption"
+        >
+          turn
+        </text>
+      </g>
+    </svg>
+  );
+};
+
+export default TurnTrajectory;

--- a/dashboard/src/components/ViewModeToggle.css
+++ b/dashboard/src/components/ViewModeToggle.css
@@ -1,0 +1,42 @@
+.view-mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  background-color: #0f172a;
+  border-bottom: 1px solid #334155;
+  flex-shrink: 0;
+}
+
+.view-mode-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-right: 0.4rem;
+}
+
+.view-mode-button {
+  appearance: none;
+  background: transparent;
+  border: 1px solid #334155;
+  color: #94a3b8;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  border-radius: 0.3rem;
+  cursor: pointer;
+  transition: background-color 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.view-mode-button:hover {
+  color: #e2e8f0;
+  border-color: #475569;
+}
+
+.view-mode-button.active {
+  background: #1e3a8a;
+  border-color: #3b82f6;
+  color: #e0e7ff;
+}

--- a/dashboard/src/components/ViewModeToggle.tsx
+++ b/dashboard/src/components/ViewModeToggle.tsx
@@ -1,0 +1,32 @@
+import { useVisualizationStore } from '../store/visualizationStore';
+import './ViewModeToggle.css';
+
+const MODES: Array<{ key: 'subtasks' | 'parents' | 'all'; label: string }> = [
+  { key: 'subtasks', label: 'Subtasks' },
+  { key: 'parents', label: 'Parents' },
+  { key: 'all', label: 'All' },
+];
+
+const ViewModeToggle = () => {
+  const viewMode = useVisualizationStore((state) => state.viewMode);
+  const setViewMode = useVisualizationStore((state) => state.setViewMode);
+
+  return (
+    <div className="view-mode-toggle" role="group" aria-label="Task view mode">
+      <span className="view-mode-label">Show</span>
+      {MODES.map(({ key, label }) => (
+        <button
+          key={key}
+          type="button"
+          className={`view-mode-button ${viewMode === key ? 'active' : ''}`}
+          onClick={() => viewMode !== key && setViewMode(key)}
+          aria-pressed={viewMode === key}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default ViewModeToggle;

--- a/dashboard/src/components/operationsPanel.logic.test.ts
+++ b/dashboard/src/components/operationsPanel.logic.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for OperationsPanel's pure logic.
+ *
+ * Kaia review on PR #39 flagged the panel's branching as
+ * uncovered. These tests exercise the helpers that don't require
+ * React or DOM: ``coldCacheScore``, ``pickColdOffender``, and
+ * ``bucketByCategory``. Run with ``npm test``.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+  OperationCatalogEntry,
+  OperationSlice,
+} from '../services/costService';
+import {
+  ALL_CATEGORIES,
+  bucketByCategory,
+  coldCacheScore,
+  pickColdOffender,
+} from './operationsPanel.logic';
+
+// -----------------------------------------------------------------
+// Test fixtures
+// -----------------------------------------------------------------
+
+function makeOp(over: Partial<OperationSlice>): OperationSlice {
+  return {
+    operation: 'decompose_prd',
+    events: 1,
+    tokens: 0,
+    input_tokens: 0,
+    cache_creation_tokens: 0,
+    cache_read_tokens: 0,
+    output_tokens: 0,
+    cache_hit_rate: 0,
+    cost_usd: 0,
+    ...over,
+  };
+}
+
+const CATALOG: Record<string, OperationCatalogEntry> = {
+  decompose_prd: {
+    label: 'Decompose PRD',
+    description: 'parses the PRD',
+    category: 'decomposition',
+  },
+  analyze_blocker: {
+    label: 'Analyze blocker',
+    description: 'reads a blocker report',
+    category: 'runtime',
+  },
+  validate_work: {
+    label: 'Validate work',
+    description: 'validates an agent submission',
+    category: 'monitoring',
+  },
+};
+
+// -----------------------------------------------------------------
+// coldCacheScore
+// -----------------------------------------------------------------
+
+describe('coldCacheScore', () => {
+  it('returns 0 when there are no creation tokens', () => {
+    expect(coldCacheScore(makeOp({ cache_creation_tokens: 0 }))).toBe(0);
+  });
+
+  it('returns 0 when hit rate is 100%', () => {
+    expect(
+      coldCacheScore(
+        makeOp({ cache_creation_tokens: 5000, cache_hit_rate: 1.0 }),
+      ),
+    ).toBe(0);
+  });
+
+  it('returns the full creation cost when hit rate is 0%', () => {
+    expect(
+      coldCacheScore(
+        makeOp({ cache_creation_tokens: 5000, cache_hit_rate: 0 }),
+      ),
+    ).toBe(5000);
+  });
+
+  it('scales linearly between extremes', () => {
+    expect(
+      coldCacheScore(
+        makeOp({ cache_creation_tokens: 10000, cache_hit_rate: 0.4 }),
+      ),
+    ).toBeCloseTo(6000, 5);
+  });
+
+  it('treats missing fields as zero', () => {
+    // OperationSlice fields are optional; the function must not blow
+    // up on rows from older API versions.
+    expect(coldCacheScore({ operation: 'x', events: 0, tokens: 0, cost_usd: 0 })).toBe(0);
+  });
+});
+
+// -----------------------------------------------------------------
+// pickColdOffender
+// -----------------------------------------------------------------
+
+describe('pickColdOffender', () => {
+  it('returns null when no operations exceed the threshold', () => {
+    const ops = [
+      makeOp({ operation: 'decompose_prd', cache_creation_tokens: 500 }),
+    ];
+    expect(pickColdOffender(ops, CATALOG)).toBeNull();
+  });
+
+  it('returns the highest-scoring registered operation above threshold', () => {
+    const ops = [
+      makeOp({
+        operation: 'decompose_prd',
+        cache_creation_tokens: 12000,
+        cache_hit_rate: 0,
+      }),
+      makeOp({
+        operation: 'analyze_blocker',
+        cache_creation_tokens: 5000,
+        cache_hit_rate: 0,
+      }),
+    ];
+    expect(pickColdOffender(ops, CATALOG)).toBe('decompose_prd');
+  });
+
+  it('skips unregistered (typo) operations even when they would win', () => {
+    // Kaia review on PR #39: a typo'd op with huge spend should not
+    // win the badge. The recorder already warned in logs; the UI
+    // doesn't double down on the typo.
+    const ops = [
+      makeOp({
+        operation: 'decopmose_prd', // typo — not in catalog
+        cache_creation_tokens: 100_000,
+        cache_hit_rate: 0,
+      }),
+      makeOp({
+        operation: 'analyze_blocker',
+        cache_creation_tokens: 5000,
+        cache_hit_rate: 0,
+      }),
+    ];
+    expect(pickColdOffender(ops, CATALOG)).toBe('analyze_blocker');
+  });
+
+  it('returns null when only unregistered operations are present', () => {
+    const ops = [
+      makeOp({
+        operation: 'totally_made_up',
+        cache_creation_tokens: 50_000,
+        cache_hit_rate: 0,
+      }),
+    ];
+    expect(pickColdOffender(ops, CATALOG)).toBeNull();
+  });
+
+  it('respects a custom threshold', () => {
+    const ops = [
+      makeOp({
+        operation: 'decompose_prd',
+        cache_creation_tokens: 500,
+        cache_hit_rate: 0,
+      }),
+    ];
+    // Score = 500. Default threshold (1000) excludes it; custom
+    // threshold of 100 admits it.
+    expect(pickColdOffender(ops, CATALOG)).toBeNull();
+    expect(pickColdOffender(ops, CATALOG, 100)).toBe('decompose_prd');
+  });
+
+  it('ignores hot-cache operations regardless of size', () => {
+    const ops = [
+      makeOp({
+        operation: 'decompose_prd',
+        cache_creation_tokens: 100_000,
+        cache_hit_rate: 1.0,
+      }),
+    ];
+    expect(pickColdOffender(ops, CATALOG)).toBeNull();
+  });
+});
+
+// -----------------------------------------------------------------
+// bucketByCategory
+// -----------------------------------------------------------------
+
+describe('bucketByCategory', () => {
+  it('returns an empty array when there are no operations', () => {
+    expect(bucketByCategory([], CATALOG)).toEqual([]);
+  });
+
+  it('groups registered operations into their declared categories', () => {
+    const ops = [
+      makeOp({ operation: 'decompose_prd', cost_usd: 1.0, tokens: 100 }),
+      makeOp({ operation: 'analyze_blocker', cost_usd: 0.5, tokens: 50 }),
+    ];
+    const groups = bucketByCategory(ops, CATALOG);
+    const map = Object.fromEntries(groups.map((g) => [g.category, g]));
+    expect(Object.keys(map).sort()).toEqual(
+      ['decomposition', 'runtime'].sort(),
+    );
+    expect(map.decomposition.ops).toHaveLength(1);
+    expect(map.runtime.ops).toHaveLength(1);
+  });
+
+  it('drops categories with zero operations', () => {
+    // Only one decomposition op; other three categories must not
+    // appear in the result.
+    const ops = [makeOp({ operation: 'decompose_prd' })];
+    const groups = bucketByCategory(ops, CATALOG);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].category).toBe('decomposition');
+  });
+
+  it("buckets unregistered operations into 'other'", () => {
+    const ops = [makeOp({ operation: 'totally_made_up_op' })];
+    const groups = bucketByCategory(ops, CATALOG);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].category).toBe('other');
+    expect(groups[0].ops[0].operation).toBe('totally_made_up_op');
+  });
+
+  it('aggregates cost / tokens / calls per group', () => {
+    const ops = [
+      makeOp({
+        operation: 'decompose_prd',
+        events: 3,
+        tokens: 1000,
+        cost_usd: 0.5,
+      }),
+      makeOp({
+        operation: 'decompose_prd',
+        events: 2,
+        tokens: 500,
+        cost_usd: 0.25,
+      }),
+    ];
+    const groups = bucketByCategory(ops, CATALOG);
+    expect(groups[0].totalCalls).toBe(5);
+    expect(groups[0].totalTokens).toBe(1500);
+    expect(groups[0].totalCost).toBeCloseTo(0.75, 5);
+  });
+
+  it('preserves the canonical category order for stable rendering', () => {
+    const ops = [
+      makeOp({ operation: 'validate_work' }), // monitoring
+      makeOp({ operation: 'decompose_prd' }), // decomposition
+      makeOp({ operation: 'analyze_blocker' }), // runtime
+    ];
+    const groups = bucketByCategory(ops, CATALOG);
+    // ``ALL_CATEGORIES`` defines decomposition → runtime → monitoring
+    // → other; groups must follow that order regardless of input
+    // order so the UI is deterministic across renders.
+    const observed = groups.map((g) => g.category);
+    const expected = ALL_CATEGORIES.filter((c) => observed.includes(c));
+    expect(observed).toEqual(expected);
+  });
+});

--- a/dashboard/src/components/operationsPanel.logic.test.ts
+++ b/dashboard/src/components/operationsPanel.logic.test.ts
@@ -17,6 +17,7 @@ import {
   bucketByCategory,
   coldCacheScore,
   pickColdOffender,
+  splitByRole,
 } from './operationsPanel.logic';
 
 // -----------------------------------------------------------------
@@ -254,5 +255,69 @@ describe('bucketByCategory', () => {
     const observed = groups.map((g) => g.category);
     const expected = ALL_CATEGORIES.filter((c) => observed.includes(c));
     expect(observed).toEqual(expected);
+  });
+});
+
+
+// ---------------------------------------------------------------------
+// splitByRole — Marcus #527 Phase 1
+// ---------------------------------------------------------------------
+
+describe('splitByRole', () => {
+  it('puts planner rows into plannerOps and aggregates worker rows', () => {
+    const ops: OperationSlice[] = [
+      makeOp({ operation: 'parse_prd', role: 'planner', events: 1, tokens: 1500, cost_usd: 0.01 }),
+      makeOp({ operation: 'decompose_prd', role: 'planner', events: 1, tokens: 2000, cost_usd: 0.02 }),
+      makeOp({ operation: 'turn', role: 'worker', events: 67000, tokens: 7_000_000_000, cost_usd: 25.0 }),
+    ];
+    const { plannerOps, workerSummary } = splitByRole(ops);
+    expect(plannerOps.map((o) => o.operation)).toEqual(['parse_prd', 'decompose_prd']);
+    expect(workerSummary).toEqual({
+      events: 67000,
+      tokens: 7_000_000_000,
+      cost: 25.0,
+    });
+  });
+
+  it('aggregates multiple worker rows into one summary', () => {
+    // Even if backend ever emits multiple worker buckets (e.g. by
+    // tool_intent in #527 Phase 2), splitByRole collapses them so the
+    // current panel keeps showing a single worker total.
+    const ops: OperationSlice[] = [
+      makeOp({ operation: 'turn', role: 'worker', events: 100, tokens: 1_000_000, cost_usd: 5.0 }),
+      makeOp({ operation: 'turn', role: 'worker', events: 50, tokens: 500_000, cost_usd: 2.5 }),
+    ];
+    const { plannerOps, workerSummary } = splitByRole(ops);
+    expect(plannerOps).toEqual([]);
+    expect(workerSummary.events).toBe(150);
+    expect(workerSummary.tokens).toBe(1_500_000);
+    expect(workerSummary.cost).toBe(7.5);
+  });
+
+  it('treats role-less slices as planner for legacy compatibility', () => {
+    // Pre-#527 backends emit by_operation without a ``role`` field.
+    // The dashboard must keep working against an old Marcus until
+    // both sides upgrade — treating missing role as planner means
+    // the chart looks the same as before the split.
+    const ops: OperationSlice[] = [
+      makeOp({ operation: 'parse_prd', events: 1, tokens: 1500, cost_usd: 0.01 }),
+    ];
+    const { plannerOps, workerSummary } = splitByRole(ops);
+    expect(plannerOps).toHaveLength(1);
+    expect(workerSummary.events).toBe(0);
+  });
+
+  it('returns zero workerSummary when there are no worker rows', () => {
+    const ops: OperationSlice[] = [
+      makeOp({ operation: 'parse_prd', role: 'planner', events: 1, tokens: 1500, cost_usd: 0.01 }),
+    ];
+    const { workerSummary } = splitByRole(ops);
+    expect(workerSummary).toEqual({ events: 0, tokens: 0, cost: 0 });
+  });
+
+  it('handles empty input', () => {
+    const { plannerOps, workerSummary } = splitByRole([]);
+    expect(plannerOps).toEqual([]);
+    expect(workerSummary).toEqual({ events: 0, tokens: 0, cost: 0 });
   });
 });

--- a/dashboard/src/components/operationsPanel.logic.ts
+++ b/dashboard/src/components/operationsPanel.logic.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure helpers for OperationsPanel — extracted for unit testability.
+ *
+ * Kaia review on PR #39 called out that the OperationsPanel's
+ * filter/collapse/cold-offender branching has real surface area and
+ * zero coverage. Cato's dashboard has Vitest configured but no
+ * React-Testing-Library setup; rather than introduce that just to
+ * test branching logic, we extract the pure functions (no React,
+ * no DOM) into this file and exercise them directly. The component
+ * keeps rendering responsibilities; this file owns the data
+ * transformations.
+ *
+ * Functions here intentionally take only the data they need — no
+ * Props or React state — so tests can construct inputs by hand
+ * without mocking the component tree.
+ */
+
+import type {
+  OperationCatalogEntry,
+  OperationSlice,
+} from '../services/costService';
+
+export type CategoryKey =
+  | 'decomposition'
+  | 'runtime'
+  | 'monitoring'
+  | 'other';
+
+export const ALL_CATEGORIES: CategoryKey[] = [
+  'decomposition',
+  'runtime',
+  'monitoring',
+  'other',
+];
+
+export const CATEGORY_LABELS: Record<CategoryKey, string> = {
+  decomposition: 'Decomposition',
+  runtime: 'Runtime',
+  monitoring: 'Monitoring',
+  other: 'Other',
+};
+
+export interface CategoryGroup {
+  category: CategoryKey;
+  ops: OperationSlice[];
+  totalCost: number;
+  totalTokens: number;
+  totalCalls: number;
+}
+
+/**
+ * Approximate the tokens we'd save by tightening the prompt of
+ * ``op`` so it hits the cache window on every call.
+ *
+ * The heuristic is ``cache_creation_tokens × (1 - cache_hit_rate)``:
+ * cache_creation_tokens captures how much we paid to set up the
+ * prompt cache, and ``1 - hit_rate`` captures how often that
+ * investment was wasted (i.e., a fresh creation rather than a hit).
+ * Higher score = more headroom for optimization.
+ */
+export function coldCacheScore(op: OperationSlice): number {
+  const creation = op.cache_creation_tokens ?? 0;
+  const rate = op.cache_hit_rate ?? 0;
+  return creation * (1 - rate);
+}
+
+/**
+ * Identify the single biggest cold-cache offender, or ``null``.
+ *
+ * Two gates:
+ * 1. Operations whose key isn't in ``catalog`` are skipped — Kaia
+ *    review on PR #39 called out that landing the 🔥 badge on a
+ *    typo'd operation just amplifies the typo. Marcus's recorder
+ *    already warns about unregistered keys in dev logs.
+ * 2. Score must exceed ``threshold`` (default 1000 tokens). Below
+ *    that, "biggest offender" is noise. The threshold is exposed
+ *    as an argument so tests can drive corner cases without
+ *    constructing absurdly large mock data.
+ *
+ * Returns the operation key of the worst offender, or ``null``
+ * when nothing meets the threshold.
+ */
+export function pickColdOffender(
+  operations: OperationSlice[],
+  catalog: Record<string, OperationCatalogEntry>,
+  threshold = 1000,
+): string | null {
+  let bestKey: string | null = null;
+  let bestScore = 0;
+  for (const op of operations) {
+    if (catalog[op.operation] == null) continue;
+    const score = coldCacheScore(op);
+    if (score > bestScore && score > threshold) {
+      bestScore = score;
+      bestKey = op.operation;
+    }
+  }
+  return bestKey;
+}
+
+/**
+ * Group operations by their catalog category, computing per-group
+ * aggregates and dropping empty buckets.
+ *
+ * Operations whose key is not in the catalog fall into the
+ * ``'other'`` bucket so they remain visible in the dashboard. The
+ * recorder logs a WARNING for those (see Marcus
+ * ``cost_recorder.py``), making the gap discoverable.
+ */
+export function bucketByCategory(
+  operations: OperationSlice[],
+  catalog: Record<string, OperationCatalogEntry>,
+): CategoryGroup[] {
+  const buckets: Record<CategoryKey, OperationSlice[]> = {
+    decomposition: [],
+    runtime: [],
+    monitoring: [],
+    other: [],
+  };
+  for (const op of operations) {
+    const cat =
+      (catalog[op.operation]?.category as CategoryKey | undefined) ?? 'other';
+    buckets[cat].push(op);
+  }
+  return ALL_CATEGORIES.map((cat) => {
+    const ops = buckets[cat];
+    return {
+      category: cat,
+      ops,
+      totalCost: ops.reduce((s, o) => s + o.cost_usd, 0),
+      totalTokens: ops.reduce((s, o) => s + o.tokens, 0),
+      totalCalls: ops.reduce((s, o) => s + o.events, 0),
+    };
+  }).filter((g) => g.ops.length > 0);
+}

--- a/dashboard/src/components/operationsPanel.logic.ts
+++ b/dashboard/src/components/operationsPanel.logic.ts
@@ -133,3 +133,47 @@ export function bucketByCategory(
     };
   }).filter((g) => g.ops.length > 0);
 }
+
+/**
+ * Split a list of operation slices into planner rows and a single
+ * aggregated worker summary (Marcus issue #527).
+ *
+ * The dashboard's per-operation chart only makes sense for planner
+ * rows — for those, ``operation`` carries semantic meaning
+ * (parse_prd, decompose_prd, ...). Worker rows always have
+ * ``operation='turn'``; they would dominate the chart with one
+ * useless bucket while drowning out the planner ops that are
+ * actually informative. We split here so the panel can render
+ * planner ops as the main view and surface the worker aggregate
+ * separately.
+ *
+ * Slices without a ``role`` field are treated as planner so legacy
+ * databases (pre-#527, before the GROUP BY agent_role) keep
+ * rendering exactly as before.
+ *
+ * @param operations The full ``by_operation`` slice array.
+ * @returns ``{plannerOps, workerSummary}`` where ``workerSummary``
+ *          collapses all worker rows into one totals object.
+ */
+export function splitByRole(operations: OperationSlice[]): {
+  plannerOps: OperationSlice[];
+  workerSummary: { events: number; tokens: number; cost: number };
+} {
+  const planner: OperationSlice[] = [];
+  let wEvents = 0;
+  let wTokens = 0;
+  let wCost = 0;
+  for (const op of operations) {
+    if (op.role === 'worker') {
+      wEvents += op.events;
+      wTokens += op.tokens;
+      wCost += op.cost_usd;
+    } else {
+      planner.push(op);
+    }
+  }
+  return {
+    plannerOps: planner,
+    workerSummary: { events: wEvents, tokens: wTokens, cost: wCost },
+  };
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1,3 +1,26 @@
+/* Theme tokens. Cato historically used hardcoded hex everywhere; the
+   cost dashboard CSS introduced ``var()`` references with light-theme
+   fallbacks that always applied because nothing defined the vars,
+   producing low-contrast text on Cato's dark background. Defining the
+   tokens here makes every ``var(--…)`` resolve to the dark palette
+   that matches the rest of the app. */
+:root {
+  --bg-canvas: #0f172a;
+  --bg-elevated: #1e293b;
+  --bg-hover: #334155;
+
+  --text-primary: #f1f5f9;
+  --text-color: #f1f5f9;
+  --text-muted: #cbd5e1;
+
+  --border-color: #475569;
+
+  --primary: #3b82f6;
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+}
+
 * {
   margin: 0;
   padding: 0;

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -140,3 +140,60 @@ export async function fetchSessionTurns(
 ): Promise<{ session_id: string; turns: TurnPoint[] }> {
   return _get(`/api/cost/sessions/${encodeURIComponent(sessionId)}/turns`);
 }
+
+// ---------------------------------------------------------------------------
+// Pricing
+// ---------------------------------------------------------------------------
+
+export interface ModelPriceRow {
+  model: string;
+  provider: string;
+  effective_from: string;
+  input_per_million: number;
+  output_per_million: number;
+  cache_creation_per_million: number | null;
+  cache_read_per_million: number | null;
+  source: string | null;
+}
+
+export interface PriceCreatePayload {
+  model: string;
+  provider: string;
+  effective_from?: string; // ISO; defaults to "now" server-side
+  input_per_million: number;
+  output_per_million: number;
+  cache_creation_per_million?: number | null;
+  cache_read_per_million?: number | null;
+  source?: string;
+}
+
+/** Current pricing table (latest ``effective_from`` per model+provider). */
+export async function fetchCurrentPrices(): Promise<{ prices: ModelPriceRow[] }> {
+  return _get('/api/cost/prices');
+}
+
+/** Full price history, optionally filtered to one model. */
+export async function fetchPriceHistory(
+  model?: string,
+): Promise<{ prices: ModelPriceRow[] }> {
+  const params = new URLSearchParams();
+  if (model) params.set('model', model);
+  const qs = params.toString();
+  return _get(`/api/cost/prices/history${qs ? `?${qs}` : ''}`);
+}
+
+/** Insert a new versioned price row. Throws on 409 (duplicate effective_from). */
+export async function createPrice(
+  payload: PriceCreatePayload,
+): Promise<{ status: string; effective_from: string }> {
+  const resp = await fetch(`${API_BASE_URL}/api/cost/prices`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!resp.ok) {
+    const detail = await resp.text();
+    throw new Error(`HTTP ${resp.status}: ${detail}`);
+  }
+  return resp.json();
+}

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -55,6 +55,17 @@ export interface OperationSlice {
   operation: string;
   events: number;
   tokens: number;
+  /**
+   * Full token-type split (Marcus #513 followup): lets users see
+   * which operations are heavy on uncached input vs. cache reads.
+   * cache_hit_rate is computed server-side as
+   * cache_read / (input + cache_creation + cache_read).
+   */
+  input_tokens?: number;
+  cache_creation_tokens?: number;
+  cache_read_tokens?: number;
+  output_tokens?: number;
+  cache_hit_rate?: number;
   cost_usd: number;
 }
 
@@ -63,6 +74,11 @@ export interface ModelSlice {
   provider: string;
   events: number;
   tokens: number;
+  input_tokens?: number;
+  cache_creation_tokens?: number;
+  cache_read_tokens?: number;
+  output_tokens?: number;
+  cache_hit_rate?: number;
   cost_usd: number;
 }
 
@@ -148,10 +164,14 @@ export async function fetchSessionTurns(
 export interface ProjectRow {
   project_id: string;
   /**
-   * Human-readable name pulled from the experiments table when an
-   * MLflow run was registered for this project. NULL for projects
-   * whose runs never called start_experiment — the picker falls back
-   * to a truncated project_id in that case.
+   * Human-readable name. Resolved in order of preference:
+   * 1. experiments.project_name (set explicitly via start_experiment)
+   * 2. Marcus's project registry (data/marcus_state/projects.json),
+   *    which is the same source the regular Cato projects panel uses
+   * 3. NULL — picker falls back to a truncated project_id
+   *
+   * Most Marcus runs never open an MLflow experiment, so #2 is the
+   * usual source.
    */
   project_name: string | null;
   events: number;
@@ -197,6 +217,98 @@ export async function fetchProjectSummary(
   projectId: string,
 ): Promise<ProjectSummary> {
   return _get(`/api/cost/projects/${encodeURIComponent(projectId)}`);
+}
+
+/**
+ * Full per-project breakdown — drives the Real-time / Historical /
+ * Budget tabs in the project-first dashboard.
+ *
+ * Same shape as :func:`fetchExperimentSummary` but scoped to project_id,
+ * which is the only universal identity in Marcus's coordination model
+ * (Marcus #503). Marcus runs that never opened an MLflow experiment
+ * still have project_id on every event, so this is the universal
+ * surface for cost data.
+ */
+export interface ProjectFullSummary {
+  project_id: string;
+  project_name: string | null;
+  summary: {
+    total_events: number;
+    experiments: number;
+    agents: number;
+    sessions: number;
+    total_tokens: number;
+    input_tokens: number;
+    cache_creation_tokens: number;
+    cache_read_tokens: number;
+    output_tokens: number;
+    total_cost_usd: number;
+    cache_hit_rate: number;
+    first_event_at: string;
+    last_event_at: string;
+  };
+  by_role: RoleSlice[];
+  by_agent: AgentSlice[];
+  by_task: TaskSlice[];
+  by_operation: OperationSlice[];
+  by_model: ModelSlice[];
+}
+
+export async function fetchProjectFullSummary(
+  projectId: string,
+): Promise<ProjectFullSummary> {
+  return _get(
+    `/api/cost/projects/${encodeURIComponent(projectId)}/summary`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Project budget caps
+// ---------------------------------------------------------------------------
+
+export interface ProjectBudget {
+  budget_usd: number;
+  set_at: string;
+  note: string | null;
+}
+
+export interface ProjectBudgetResponse {
+  project_id: string;
+  /** Null when no cap is set. */
+  budget: ProjectBudget | null;
+}
+
+/** Read the budget cap (if any) for a project. */
+export async function fetchProjectBudget(
+  projectId: string,
+): Promise<ProjectBudgetResponse> {
+  return _get(`/api/cost/projects/${encodeURIComponent(projectId)}/budget`);
+}
+
+/**
+ * Set (or clear) a project's budget cap.
+ *
+ * Pass ``budget_usd <= 0`` to remove the cap entirely. The Marcus side
+ * upserts in place — the cap survives across Cato restarts since it
+ * persists to costs.db.
+ */
+export async function setProjectBudget(
+  projectId: string,
+  budgetUsd: number,
+  note?: string,
+): Promise<ProjectBudgetResponse> {
+  const resp = await fetch(
+    `${API_BASE_URL}/api/cost/projects/${encodeURIComponent(projectId)}/budget`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ budget_usd: budgetUsd, note: note ?? null }),
+    },
+  );
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status} (set budget)`);
+  }
+  return resp.json();
 }
 
 /**

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -12,10 +12,18 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:4301';
 // Response types
 // ---------------------------------------------------------------------------
 
-export interface ExperimentRow {
-  experiment_id: string;
+export interface RunRow {
+  run_id: string;
   project_id: string;
   project_name: string | null;
+  /**
+   * Entry point that produced this run. ``'direct'`` for human MCP
+   * users, ``'marcus'`` for ``/marcus`` runs, ``'posidonius'`` for
+   * Posidonius automated trials, ``'unknown'`` for legacy rows.
+   * Renamed from the old ExperimentRow shape in coordination with
+   * Marcus's ``experiments`` → ``runs`` rename.
+   */
+  path: string;
   started_at: string;
   ended_at: string | null;
   num_agents: number | null;
@@ -82,8 +90,8 @@ export interface ModelSlice {
   cost_usd: number;
 }
 
-export interface ExperimentSummary {
-  experiment_id: string;
+export interface RunSummary {
+  run_id: string;
   project_id: string;
   project_name: string | null;
   started_at: string;
@@ -129,25 +137,29 @@ async function _get<T>(path: string): Promise<T> {
 }
 
 /**
- * List experiments with token + cost totals attached.
+ * List runs with token + cost totals attached.
+ *
+ * Renamed from ``fetchExperiments`` in coordination with Marcus's
+ * ``runs`` table rename (Simon ``7ed3074d``); the term "experiment"
+ * was colliding with MLflow's separate concept.
  *
  * @param projectId Optional project filter.
  * @param limit Cap at 1000. Default 100.
  */
-export async function fetchExperiments(
+export async function fetchRuns(
   projectId?: string,
   limit = 100,
-): Promise<{ experiments: ExperimentRow[]; count: number }> {
+): Promise<{ runs: RunRow[]; count: number }> {
   const params = new URLSearchParams({ limit: String(limit) });
   if (projectId) params.set('project_id', projectId);
-  return _get(`/api/cost/experiments?${params}`);
+  return _get(`/api/cost/runs?${params}`);
 }
 
-/** Full per-experiment breakdown (summary + by_role / agent / task / etc.). */
-export async function fetchExperimentSummary(
-  experimentId: string,
-): Promise<ExperimentSummary> {
-  return _get(`/api/cost/experiments/${encodeURIComponent(experimentId)}`);
+/** Full per-run breakdown (summary + by_role / agent / task / etc.). */
+export async function fetchRunSummary(
+  runId: string,
+): Promise<RunSummary> {
+  return _get(`/api/cost/runs/${encodeURIComponent(runId)}`);
 }
 
 /** Per-turn cost trajectory for one Claude Code session. */
@@ -165,17 +177,14 @@ export interface ProjectRow {
   project_id: string;
   /**
    * Human-readable name. Resolved in order of preference:
-   * 1. experiments.project_name (set explicitly via start_experiment)
+   * 1. runs.project_name (the wrapper-recorded primary run)
    * 2. Marcus's project registry (data/marcus_state/projects.json),
    *    which is the same source the regular Cato projects panel uses
    * 3. NULL — picker falls back to a truncated project_id
-   *
-   * Most Marcus runs never open an MLflow experiment, so #2 is the
-   * usual source.
    */
   project_name: string | null;
   events: number;
-  experiments: number;
+  runs: number;
   agents: number;
   total_tokens: number;
   total_cost_usd: number;
@@ -192,12 +201,12 @@ export interface UnassignedTotals {
 export interface ProjectSummary {
   project_id: string;
   totals: {
-    experiments: number;
+    runs: number;
     events: number;
     total_tokens: number;
     total_cost_usd: number;
   };
-  experiments: ExperimentRow[];
+  runs: RunRow[];
 }
 
 /** List projects with cost rollups (primary picker for the dashboard). */
@@ -223,18 +232,17 @@ export async function fetchProjectSummary(
  * Full per-project breakdown — drives the Real-time / Historical /
  * Budget tabs in the project-first dashboard.
  *
- * Same shape as :func:`fetchExperimentSummary` but scoped to project_id,
- * which is the only universal identity in Marcus's coordination model
- * (Marcus #503). Marcus runs that never opened an MLflow experiment
- * still have project_id on every event, so this is the universal
- * surface for cost data.
+ * Same shape as :func:`fetchRunSummary` but scoped to project_id,
+ * which is the only universal identity in Marcus's coordination
+ * model (Marcus #503). Every cost event carries a project_id, so
+ * this is the universal surface for cost data.
  */
 export interface ProjectFullSummary {
   project_id: string;
   project_name: string | null;
   summary: {
     total_events: number;
-    experiments: number;
+    runs: number;
     agents: number;
     sessions: number;
     total_tokens: number;

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -142,6 +142,64 @@ export async function fetchSessionTurns(
 }
 
 // ---------------------------------------------------------------------------
+// Projects (primary axis — Marcus #409)
+// ---------------------------------------------------------------------------
+
+export interface ProjectRow {
+  project_id: string;
+  /**
+   * Human-readable name pulled from the experiments table when an
+   * MLflow run was registered for this project. NULL for projects
+   * whose runs never called start_experiment — the picker falls back
+   * to a truncated project_id in that case.
+   */
+  project_name: string | null;
+  events: number;
+  experiments: number;
+  agents: number;
+  total_tokens: number;
+  total_cost_usd: number;
+  first_event_at: string;
+  last_event_at: string;
+}
+
+export interface UnassignedTotals {
+  events: number;
+  total_tokens: number;
+  total_cost_usd: number;
+}
+
+export interface ProjectSummary {
+  project_id: string;
+  totals: {
+    experiments: number;
+    events: number;
+    total_tokens: number;
+    total_cost_usd: number;
+  };
+  experiments: ExperimentRow[];
+}
+
+/** List projects with cost rollups (primary picker for the dashboard). */
+export async function fetchProjects(
+  limit = 100,
+): Promise<{ projects: ProjectRow[]; count: number }> {
+  return _get(`/api/cost/projects?limit=${limit}`);
+}
+
+/** Totals for events without an active PlannerContext. */
+export async function fetchUnassignedTotals(): Promise<UnassignedTotals> {
+  return _get('/api/cost/projects/unassigned');
+}
+
+/** Project rollup + per-experiment list. */
+export async function fetchProjectSummary(
+  projectId: string,
+): Promise<ProjectSummary> {
+  return _get(`/api/cost/projects/${encodeURIComponent(projectId)}`);
+}
+
+// ---------------------------------------------------------------------------
 // Pricing
 // ---------------------------------------------------------------------------
 

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -199,6 +199,28 @@ export async function fetchProjectSummary(
   return _get(`/api/cost/projects/${encodeURIComponent(projectId)}`);
 }
 
+/**
+ * Trigger a worker JSONL ingestion sweep on the backend.
+ *
+ * Marcus's WorkerJSONLIngester reads ~/.claude/projects/<dir>/<session>.jsonl
+ * files and writes token_events rows. Calling this is idempotent (UUID
+ * dedup), so the dashboard hits it on mount and on every poll tick to
+ * keep worker cost current without a background daemon.
+ */
+export async function triggerIngest(): Promise<{
+  ingested: number;
+  files: number;
+  skipped_unbound: number;
+}> {
+  const resp = await fetch(`${API_BASE_URL}/api/cost/ingest`, {
+    method: 'POST',
+  });
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status} (ingest)`);
+  }
+  return resp.json();
+}
+
 // ---------------------------------------------------------------------------
 // Pricing
 // ---------------------------------------------------------------------------

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -263,6 +263,39 @@ export async function fetchProjectFullSummary(
 }
 
 // ---------------------------------------------------------------------------
+// Operation taxonomy (per-LLM-call drill-down labels + descriptions)
+// ---------------------------------------------------------------------------
+
+/**
+ * One entry in the operation catalog returned by ``/api/cost/operations``.
+ *
+ * Sourced from Marcus's ``src/cost_tracking/operations.py``. The
+ * dashboard joins ``OperationSlice.operation`` keys against this
+ * mapping to render hover-tooltips that explain what each LLM call
+ * does and why it spent tokens.
+ */
+export interface OperationCatalogEntry {
+  label: string;
+  description: string;
+  category: 'decomposition' | 'runtime' | 'monitoring' | 'other';
+}
+
+export interface OperationCatalog {
+  operations: Record<string, OperationCatalogEntry>;
+}
+
+/**
+ * Fetch the operation taxonomy once on page load.
+ *
+ * Older Marcus checkouts may not ship the operations module — in
+ * that case the endpoint returns ``{operations: {}}`` and the UI
+ * falls back to the raw operation key as the label.
+ */
+export async function fetchOperationCatalog(): Promise<OperationCatalog> {
+  return _get('/api/cost/operations');
+}
+
+// ---------------------------------------------------------------------------
 // Project budget caps
 // ---------------------------------------------------------------------------
 

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -54,6 +54,15 @@ export interface AgentSlice {
 
 export interface TaskSlice {
   task_id: string;
+  /**
+   * Human-readable kanban task name (Marcus #530). Snapshotted from
+   * Marcus's task_metadata into costs.db::task_names at the moment
+   * the task is created on the kanban. NULL when the task_id was
+   * never paired with a name (e.g. historical rows whose source
+   * marcus.db entry is gone, or subtask IDs that couldn't be
+   * derived from a parent). Dashboard falls back to truncated task_id.
+   */
+  task_name?: string | null;
   events: number;
   tokens: number;
   cost_usd: number;
@@ -61,6 +70,14 @@ export interface TaskSlice {
 
 export interface OperationSlice {
   operation: string;
+  /**
+   * ``'planner'`` or ``'worker'``. Lets the dashboard split planner
+   * rows (where ``operation`` carries semantic meaning like
+   * ``parse_prd``) from worker rows (which are always ``'turn'`` and
+   * are better attributed via ``by_task`` / ``by_agent``). See
+   * Marcus issue #527.
+   */
+  role?: string;
   events: number;
   tokens: number;
   /**
@@ -77,6 +94,26 @@ export interface OperationSlice {
   cost_usd: number;
 }
 
+/**
+ * Token-attribution audit for a run or project (Marcus issue #527).
+ *
+ * Answers the question *"is every token recorded for this scope
+ * accounted for?"*. A healthy audit shows ``reconciles=true`` and
+ * zero ``worker_events_without_task_id``. The dashboard's
+ * ``AuditBanner`` renders this as a single line.
+ */
+export interface CostAudit {
+  total_events: number;
+  total_tokens: number;
+  by_role_total_tokens: number;
+  reconciles: boolean;
+  tokens_outside_known_roles: number;
+  planner_events: number;
+  worker_events: number;
+  worker_events_without_task_id: number;
+  worker_events_without_agent_id: number;
+}
+
 export interface ModelSlice {
   model: string;
   provider: string;
@@ -87,6 +124,27 @@ export interface ModelSlice {
   cache_read_tokens?: number;
   output_tokens?: number;
   cache_hit_rate?: number;
+  cost_usd: number;
+}
+
+/**
+ * Worker-only slice grouped by the Claude Code tool the agent invoked
+ * on each turn (Marcus issue #527 Phase 2). Populated by the JSONL
+ * parser; null on planner rows.
+ *
+ * Values for ``tool_intent``:
+ * - ``worker_marcus_call`` — talking to Marcus via MCP (coordination tax)
+ * - ``worker_mcp_call`` — non-Marcus MCP servers
+ * - ``worker_edit`` — Edit / Write / NotebookEdit
+ * - ``worker_bash`` — Bash (tests, builds, git)
+ * - ``worker_search`` — Grep / Glob / ToolSearch
+ * - ``worker_read`` — Read
+ * - ``worker_text`` — text-only response, no tool use
+ */
+export interface ToolSlice {
+  tool_intent: string;
+  events: number;
+  tokens: number;
   cost_usd: number;
 }
 
@@ -115,6 +173,10 @@ export interface RunSummary {
   by_task: TaskSlice[];
   by_operation: OperationSlice[];
   by_model: ModelSlice[];
+  /** Marcus #527 Phase 2: per-tool worker spend breakdown. */
+  by_tool?: ToolSlice[];
+  /** Marcus #527: token-attribution audit inline on the summary. */
+  audit?: CostAudit;
 }
 
 export interface TurnPoint {
@@ -260,6 +322,10 @@ export interface ProjectFullSummary {
   by_task: TaskSlice[];
   by_operation: OperationSlice[];
   by_model: ModelSlice[];
+  /** Marcus #527 Phase 2: per-tool worker spend breakdown. */
+  by_tool?: ToolSlice[];
+  /** Marcus #527: token-attribution audit inline on the summary. */
+  audit?: CostAudit;
 }
 
 export async function fetchProjectFullSummary(

--- a/dashboard/src/services/costService.ts
+++ b/dashboard/src/services/costService.ts
@@ -1,0 +1,142 @@
+/**
+ * Cost-tracking data service for the Cato dashboard (Marcus issue #409).
+ *
+ * Wraps the /api/cost/* endpoints exposed by backend/cost_routes.py with
+ * typed fetchers. Response shapes mirror Marcus's CostAggregator return
+ * values exactly, so React components consume them directly.
+ */
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:4301';
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+export interface ExperimentRow {
+  experiment_id: string;
+  project_id: string;
+  project_name: string | null;
+  started_at: string;
+  ended_at: string | null;
+  num_agents: number | null;
+  total_tasks: number | null;
+  completed_tasks: number | null;
+  blocked_tasks: number | null;
+  total_tokens: number;
+  total_cost_usd: number;
+}
+
+export interface RoleSlice {
+  role: string;
+  events: number;
+  tokens: number;
+  cost_usd: number;
+}
+
+export interface AgentSlice {
+  agent_id: string;
+  role: string;
+  events: number;
+  tokens: number;
+  cost_usd: number;
+  tasks_worked: number;
+  sessions: number;
+  turns: number;
+}
+
+export interface TaskSlice {
+  task_id: string;
+  events: number;
+  tokens: number;
+  cost_usd: number;
+}
+
+export interface OperationSlice {
+  operation: string;
+  events: number;
+  tokens: number;
+  cost_usd: number;
+}
+
+export interface ModelSlice {
+  model: string;
+  provider: string;
+  events: number;
+  tokens: number;
+  cost_usd: number;
+}
+
+export interface ExperimentSummary {
+  experiment_id: string;
+  project_id: string;
+  project_name: string | null;
+  started_at: string;
+  ended_at: string | null;
+  num_agents: number | null;
+  total_tasks: number | null;
+  completed_tasks: number | null;
+  blocked_tasks: number | null;
+  summary: {
+    total_events: number;
+    total_tokens: number;
+    input_tokens: number;
+    cache_creation_tokens: number;
+    cache_read_tokens: number;
+    output_tokens: number;
+    total_cost_usd: number;
+    cache_hit_rate: number;
+  };
+  by_role: RoleSlice[];
+  by_agent: AgentSlice[];
+  by_task: TaskSlice[];
+  by_operation: OperationSlice[];
+  by_model: ModelSlice[];
+}
+
+export interface TurnPoint {
+  turn_index: number;
+  total_tokens: number;
+  cost_usd: number;
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// Fetchers
+// ---------------------------------------------------------------------------
+
+async function _get<T>(path: string): Promise<T> {
+  const resp = await fetch(`${API_BASE_URL}${path}`);
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status} ${resp.statusText} (${path})`);
+  }
+  return resp.json() as Promise<T>;
+}
+
+/**
+ * List experiments with token + cost totals attached.
+ *
+ * @param projectId Optional project filter.
+ * @param limit Cap at 1000. Default 100.
+ */
+export async function fetchExperiments(
+  projectId?: string,
+  limit = 100,
+): Promise<{ experiments: ExperimentRow[]; count: number }> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (projectId) params.set('project_id', projectId);
+  return _get(`/api/cost/experiments?${params}`);
+}
+
+/** Full per-experiment breakdown (summary + by_role / agent / task / etc.). */
+export async function fetchExperimentSummary(
+  experimentId: string,
+): Promise<ExperimentSummary> {
+  return _get(`/api/cost/experiments/${encodeURIComponent(experimentId)}`);
+}
+
+/** Per-turn cost trajectory for one Claude Code session. */
+export async function fetchSessionTurns(
+  sessionId: string,
+): Promise<{ session_id: string; turns: TurnPoint[] }> {
+  return _get(`/api/cost/sessions/${encodeURIComponent(sessionId)}/turns`);
+}

--- a/dashboard/src/services/dataService.ts
+++ b/dashboard/src/services/dataService.ts
@@ -108,6 +108,10 @@ export interface Task {
     required_resources?: string[];
     prevention_measures?: string[];
   } | null;
+
+  // Parent auto-completed via subtasks. SwimLane skips these — their
+  // rolled-up span isn't a contiguous work bar (subtasks interleave).
+  work_via_subtasks?: boolean;
 }
 
 /**

--- a/dashboard/src/store/visualizationStore.ts
+++ b/dashboard/src/store/visualizationStore.ts
@@ -12,7 +12,8 @@ export type ViewLayer =
   | 'fidelity'
   | 'decisions'
   | 'failures'
-  | 'redundancy';
+  | 'redundancy'
+  | 'cost';
 export type TaskView = 'subtasks' | 'parents' | 'all';
 
 interface VisualizationState {

--- a/dashboard/src/store/visualizationStore.ts
+++ b/dashboard/src/store/visualizationStore.ts
@@ -50,6 +50,12 @@ interface VisualizationState {
   resetTimeOnTabSwitch: boolean;
   setResetTimeOnTabSwitch: (value: boolean) => void;
 
+  // Snapshot view mode — controls whether subtasks, parents, or all tasks
+  // are returned by the backend. Persisted in localStorage; changing it
+  // triggers a snapshot reload.
+  viewMode: 'subtasks' | 'parents' | 'all';
+  setViewMode: (mode: 'subtasks' | 'parents' | 'all') => void;
+
   // Project Info drawer state
   isProjectInfoOpen: boolean;
 
@@ -120,6 +126,16 @@ export const useVisualizationStore = create<VisualizationState>((set, get) => {
       localStorage.setItem('cato_resetTimeOnTabSwitch', String(value));
       set({ resetTimeOnTabSwitch: value });
     },
+    viewMode:
+      ((localStorage.getItem('cato_viewMode') as 'subtasks' | 'parents' | 'all') ||
+        'parents'),
+    setViewMode: (mode) => {
+      localStorage.setItem('cato_viewMode', mode);
+      set({ viewMode: mode });
+      // Reload current project under the new view
+      const { selectedProjectId, loadData } = get();
+      void loadData(selectedProjectId || undefined);
+    },
     lifecycleTask: null,
     setLifecycleTask: (task) => set({ lifecycleTask: task }),
     autoRefreshIntervalId: null,
@@ -133,7 +149,7 @@ export const useVisualizationStore = create<VisualizationState>((set, get) => {
         console.log('Fetching live snapshot from API...');
         const newSnapshot = await fetchSnapshot(
           projectId,
-          'subtasks', // Always use subtasks view
+          get().viewMode,
           1.0, // Power scale exponent (linear timeline)
           true // Use cache
         );

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -5,7 +5,8 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173,
+    port: 5847,
+    strictPort: false,
     open: true,
   },
 })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ exclude = ["tests*", "dashboard*"]
 
 [project]
 name = "cato"
-version = "0.3.2"
+version = "0.3.3"
 description = "Multi-agent parallelization visualization dashboard for Marcus"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -136,6 +136,82 @@ def client(store: Any) -> TestClient:
 
 
 @requires_marcus
+class TestProjectsList:
+    """/api/cost/projects — primary entry point for the dashboard."""
+
+    def test_lists_projects_with_totals(self, client: TestClient) -> None:
+        """One row per distinct project_id, derived from token_events."""
+        resp = client.get("/api/cost/projects")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 1
+        assert body["projects"][0]["project_id"] == "proj_1"
+        assert (
+            body["projects"][0]["total_tokens"]
+            == 1000 + 500 + 2000 + 500 + 100 + 300 + 50
+        )
+
+    def test_excludes_unassigned_from_project_list(
+        self, store: Any, client: TestClient
+    ) -> None:
+        """Events in the 'unassigned' bucket do not appear as a project."""
+        from src.cost_tracking.cost_store import TokenEvent
+
+        store.record_event(
+            TokenEvent(
+                experiment_id="unassigned",
+                project_id="unassigned",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=10,
+                output_tokens=10,
+            )
+        )
+        resp = client.get("/api/cost/projects")
+        ids = {p["project_id"] for p in resp.json()["projects"]}
+        assert "unassigned" not in ids
+
+
+@requires_marcus
+class TestUnassignedTotals:
+    """/api/cost/projects/unassigned — gap visibility."""
+
+    def test_returns_zeros_when_empty(self, client: TestClient) -> None:
+        """No unassigned events → zero totals (200, not 404)."""
+        resp = client.get("/api/cost/projects/unassigned")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["events"] == 0
+        assert body["total_cost_usd"] == 0.0
+
+    def test_sums_unassigned_events(self, store: Any, client: TestClient) -> None:
+        """An event tagged 'unassigned' shows up in the totals."""
+        from src.cost_tracking.cost_store import TokenEvent
+
+        store.record_event(
+            TokenEvent(
+                experiment_id="unassigned",
+                project_id="unassigned",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=1_000_000,
+                output_tokens=0,
+            )
+        )
+        resp = client.get("/api/cost/projects/unassigned")
+        body = resp.json()
+        assert body["events"] == 1
+        # 1M input * $3/M = $3
+        assert body["total_cost_usd"] == pytest.approx(3.0, rel=1e-6)
+
+
+@requires_marcus
 class TestExperimentsList:
     def test_lists_experiments(self, client: TestClient) -> None:
         """Endpoint returns the seeded experiment with totals."""

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -396,6 +396,86 @@ class TestProjectNameEnrichment:
         orphan = next(p for p in projects if p["project_id"] == "proj_no_mlflow")
         assert orphan["project_name"] == "registry-named-project"
 
+    def test_project_names_table_overrides_registry(
+        self,
+        store: Any,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Snapshotted name (project_names table) wins over registry.
+
+        After Marcus PR #515 lands, project_names captures the name as
+        of when work was attributed. The dashboard should prefer that
+        snapshot over the registry so renames / deletions don't break
+        the display.
+        """
+        from src.cost_tracking.cost_store import TokenEvent
+
+        from backend import cost_routes
+
+        # Seed an event + a snapshotted name for a project not in the
+        # registry.
+        store.record_event(
+            TokenEvent(
+                experiment_id="exp_snap",
+                project_id="snap_proj",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=10,
+                output_tokens=5,
+                request_id="req_snap",
+            )
+        )
+        store.upsert_project_name("snap_proj", "snapshotted-name")
+
+        fake_root = tmp_path / "marcus"
+        (fake_root / "data" / "marcus_state").mkdir(parents=True)
+        (fake_root / "data" / "marcus_state" / "projects.json").write_text("{}")
+        monkeypatch.setattr(cost_routes, "_marcus_root", fake_root)
+        cost_routes.clear_project_names_cache()
+
+        resp = client.get("/api/cost/projects")
+        assert resp.status_code == 200
+        names = {p["project_id"]: p["project_name"] for p in resp.json()["projects"]}
+        assert names["snap_proj"] == "snapshotted-name"
+
+    def test_cache_is_keyed_by_store_identity(
+        self,
+        store: Any,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Different stores don't share cache entries (Kaia review on #36).
+
+        The module-level cache used to be a single dict; tests using
+        ``app.dependency_overrides[get_store]`` with tmp stores could
+        leak names across tests. Keying by ``id(store)`` isolates them.
+        """
+        from src.cost_tracking.cost_store import CostStore
+
+        from backend import cost_routes
+
+        # First store sees one name.
+        store.upsert_project_name("p1", "from-store-1")
+        cost_routes.clear_project_names_cache()
+        names_a = cost_routes._load_project_names(store=store)
+        assert names_a.get("p1") == "from-store-1"
+
+        # Second store has a different (or no) name for the same id.
+        # Without per-store keying, the cache would return store-1's
+        # entry here.
+        other_store = CostStore(db_path=tmp_path / "other.db")
+        other_store.upsert_project_name("p1", "from-store-2")
+        names_b = cost_routes._load_project_names(store=other_store)
+        assert names_b.get("p1") == "from-store-2"
+        # And the first store's cache still resolves to its own value.
+        names_a_again = cost_routes._load_project_names(store=store)
+        assert names_a_again.get("p1") == "from-store-1"
+
     def test_existing_mlflow_name_takes_precedence(
         self, client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -40,8 +40,8 @@ def store(tmp_path: Path) -> Any:
     """Tmp CostStore seeded with one Anthropic price and a few events."""
     from src.cost_tracking.cost_store import (
         CostStore,
-        Experiment,
         ModelPrice,
+        Run,
         TokenEvent,
     )
 
@@ -58,9 +58,9 @@ def store(tmp_path: Path) -> Any:
             source="default",
         )
     )
-    s.record_experiment(
-        Experiment(
-            experiment_id="exp_1",
+    s.record_run(
+        Run(
+            run_id="exp_1",
             project_id="proj_1",
             project_name="hangman",
             started_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
@@ -70,7 +70,7 @@ def store(tmp_path: Path) -> Any:
         )
     )
     base = dict(
-        experiment_id="exp_1",
+        run_id="exp_1",
         project_id="proj_1",
         provider="anthropic",
         model="claude-sonnet-4-6",
@@ -132,7 +132,7 @@ def client(store: Any) -> TestClient:
 
 
 # ---------------------------------------------------------------------------
-# /api/cost/experiments
+# /api/cost/runs
 # ---------------------------------------------------------------------------
 
 
@@ -160,7 +160,7 @@ class TestProjectsList:
 
         store.record_event(
             TokenEvent(
-                experiment_id="unassigned",
+                run_id="unassigned",
                 project_id="unassigned",
                 agent_id="planner",
                 agent_role="planner",
@@ -194,7 +194,7 @@ class TestUnassignedTotals:
 
         store.record_event(
             TokenEvent(
-                experiment_id="unassigned",
+                run_id="unassigned",
                 project_id="unassigned",
                 agent_id="planner",
                 agent_role="planner",
@@ -213,34 +213,33 @@ class TestUnassignedTotals:
 
 
 @requires_marcus
-class TestExperimentsList:
-    def test_lists_experiments(self, client: TestClient) -> None:
-        """Endpoint returns the seeded experiment with totals."""
-        resp = client.get("/api/cost/experiments")
+class TestRunsList:
+    def test_lists_runs(self, client: TestClient) -> None:
+        """Endpoint returns the seeded run with totals."""
+        resp = client.get("/api/cost/runs")
         assert resp.status_code == 200
         body = resp.json()
         assert body["count"] == 1
-        assert body["experiments"][0]["experiment_id"] == "exp_1"
+        assert body["runs"][0]["run_id"] == "exp_1"
         assert (
-            body["experiments"][0]["total_tokens"]
-            == 1000 + 500 + 2000 + 500 + 100 + 300 + 50
+            body["runs"][0]["total_tokens"] == 1000 + 500 + 2000 + 500 + 100 + 300 + 50
         )
 
     def test_filter_by_project(self, client: TestClient) -> None:
         """Unknown project returns empty list, not 404."""
-        resp = client.get("/api/cost/experiments?project_id=nope")
+        resp = client.get("/api/cost/runs?project_id=nope")
         assert resp.status_code == 200
         assert resp.json()["count"] == 0
 
 
 @requires_marcus
-class TestExperimentSummary:
+class TestRunSummary:
     def test_returns_full_breakdown(self, client: TestClient) -> None:
-        """Endpoint returns the same shape as CostAggregator.experiment_summary."""
-        resp = client.get("/api/cost/experiments/exp_1")
+        """Endpoint returns the same shape as CostAggregator.run_summary."""
+        resp = client.get("/api/cost/runs/exp_1")
         assert resp.status_code == 200
         body = resp.json()
-        assert body["experiment_id"] == "exp_1"
+        assert body["run_id"] == "exp_1"
         assert {
             "summary",
             "by_role",
@@ -251,21 +250,21 @@ class TestExperimentSummary:
         } <= set(body.keys())
 
     def test_unknown_returns_404(self, client: TestClient) -> None:
-        """Missing experiment_id yields a 404."""
-        resp = client.get("/api/cost/experiments/nope")
+        """Missing run_id yields a 404."""
+        resp = client.get("/api/cost/runs/nope")
         assert resp.status_code == 404
 
 
 @requires_marcus
 class TestProjectSummary:
     def test_returns_project_totals(self, client: TestClient) -> None:
-        """Project endpoint returns totals + experiments list."""
+        """Project endpoint returns totals + runs list."""
         resp = client.get("/api/cost/projects/proj_1")
         assert resp.status_code == 200
         body = resp.json()
         assert body["project_id"] == "proj_1"
         assert body["totals"]["events"] == 3
-        assert len(body["experiments"]) == 1
+        assert len(body["runs"]) == 1
 
 
 @requires_marcus
@@ -360,7 +359,7 @@ class TestProjectNameEnrichment:
 
         store.record_event(
             TokenEvent(
-                experiment_id="exp_orphan",
+                run_id="exp_orphan",
                 project_id="proj_no_mlflow",
                 agent_id="planner",
                 agent_role="planner",
@@ -418,7 +417,7 @@ class TestProjectNameEnrichment:
         # registry.
         store.record_event(
             TokenEvent(
-                experiment_id="exp_snap",
+                run_id="exp_snap",
                 project_id="snap_proj",
                 agent_id="planner",
                 agent_role="planner",

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -510,6 +510,38 @@ class TestSessionTurns:
 
 
 # ---------------------------------------------------------------------------
+# /api/cost/operations
+# ---------------------------------------------------------------------------
+
+
+@requires_marcus
+class TestOperationsTaxonomy:
+    """``GET /api/cost/operations`` exposes the Marcus operation catalog.
+
+    The dashboard reads this once on load to populate per-event
+    tooltips that explain what each LLM call does.
+    """
+
+    def test_returns_known_operations(self, client: TestClient) -> None:
+        """Catalog includes the well-known keys used by call sites."""
+        resp = client.get("/api/cost/operations")
+        assert resp.status_code == 200
+        ops = resp.json()["operations"]
+        # Spot-check a handful of high-traffic operations
+        for key in ("decompose_prd", "analyze_blocker", "extract_outcomes"):
+            assert key in ops, f"missing {key} from taxonomy"
+            entry = ops[key]
+            assert entry["label"]
+            assert entry["description"]
+            assert entry["category"] in {
+                "decomposition",
+                "runtime",
+                "monitoring",
+                "other",
+            }
+
+
+# ---------------------------------------------------------------------------
 # /api/cost/prices  (GET + POST)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -1,0 +1,270 @@
+"""
+Integration tests for Cato's ``/api/cost/*`` endpoints.
+
+These tests use FastAPI's TestClient + a tmp SQLite store seeded with
+deterministic data. The store dependency is overridden via
+``app.dependency_overrides`` so the tests never touch
+``~/.marcus/costs.db``.
+
+Tests are skipped if Marcus cost_tracking modules aren't importable.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+try:
+    from backend.cost_routes import COST_TRACKING_AVAILABLE
+except ImportError:
+    COST_TRACKING_AVAILABLE = False
+
+requires_marcus = pytest.mark.skipif(
+    not COST_TRACKING_AVAILABLE,
+    reason="Marcus cost_tracking modules unavailable",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Any:
+    """Tmp CostStore seeded with one Anthropic price and a few events."""
+    from src.cost_tracking.cost_store import (
+        CostStore,
+        Experiment,
+        ModelPrice,
+        TokenEvent,
+    )
+
+    s = CostStore(db_path=tmp_path / "costs.db")
+    s.record_price(
+        ModelPrice(
+            model="claude-sonnet-4-6",
+            provider="anthropic",
+            effective_from=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            input_per_million=3.0,
+            cache_creation_per_million=3.75,
+            cache_read_per_million=0.30,
+            output_per_million=15.0,
+            source="default",
+        )
+    )
+    s.record_experiment(
+        Experiment(
+            experiment_id="exp_1",
+            project_id="proj_1",
+            project_name="hangman",
+            started_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+            num_agents=2,
+            total_tasks=10,
+            completed_tasks=4,
+        )
+    )
+    base = dict(
+        experiment_id="exp_1",
+        project_id="proj_1",
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+    s.record_event(
+        TokenEvent(
+            agent_id="planner",
+            agent_role="planner",
+            operation="parse_prd",
+            input_tokens=1000,
+            output_tokens=500,
+            **base,
+        )
+    )
+    s.record_event(
+        TokenEvent(
+            agent_id="agent_1",
+            agent_role="worker",
+            operation="turn",
+            task_id="t_1",
+            session_id="s_1",
+            turn_index=1,
+            input_tokens=2000,
+            cache_read_tokens=500,
+            output_tokens=100,
+            **base,
+        )
+    )
+    s.record_event(
+        TokenEvent(
+            agent_id="agent_1",
+            agent_role="worker",
+            operation="turn",
+            task_id="t_1",
+            session_id="s_1",
+            turn_index=2,
+            input_tokens=300,
+            output_tokens=50,
+            **base,
+        )
+    )
+    return s
+
+
+@pytest.fixture
+def client(store: Any) -> TestClient:
+    """TestClient with store / aggregator dependencies overridden."""
+    from src.cost_tracking.cost_aggregator import CostAggregator
+
+    from backend.api import app
+    from backend.cost_routes import get_aggregator, get_store
+
+    app.dependency_overrides[get_store] = lambda: store
+    app.dependency_overrides[get_aggregator] = lambda: CostAggregator(store=store)
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# /api/cost/experiments
+# ---------------------------------------------------------------------------
+
+
+@requires_marcus
+class TestExperimentsList:
+    def test_lists_experiments(self, client: TestClient) -> None:
+        """Endpoint returns the seeded experiment with totals."""
+        resp = client.get("/api/cost/experiments")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 1
+        assert body["experiments"][0]["experiment_id"] == "exp_1"
+        assert (
+            body["experiments"][0]["total_tokens"]
+            == 1000 + 500 + 2000 + 500 + 100 + 300 + 50
+        )
+
+    def test_filter_by_project(self, client: TestClient) -> None:
+        """Unknown project returns empty list, not 404."""
+        resp = client.get("/api/cost/experiments?project_id=nope")
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 0
+
+
+@requires_marcus
+class TestExperimentSummary:
+    def test_returns_full_breakdown(self, client: TestClient) -> None:
+        """Endpoint returns the same shape as CostAggregator.experiment_summary."""
+        resp = client.get("/api/cost/experiments/exp_1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["experiment_id"] == "exp_1"
+        assert {
+            "summary",
+            "by_role",
+            "by_agent",
+            "by_task",
+            "by_operation",
+            "by_model",
+        } <= set(body.keys())
+
+    def test_unknown_returns_404(self, client: TestClient) -> None:
+        """Missing experiment_id yields a 404."""
+        resp = client.get("/api/cost/experiments/nope")
+        assert resp.status_code == 404
+
+
+@requires_marcus
+class TestProjectSummary:
+    def test_returns_project_totals(self, client: TestClient) -> None:
+        """Project endpoint returns totals + experiments list."""
+        resp = client.get("/api/cost/projects/proj_1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["project_id"] == "proj_1"
+        assert body["totals"]["events"] == 3
+        assert len(body["experiments"]) == 1
+
+
+@requires_marcus
+class TestSessionTurns:
+    def test_returns_ordered_turns(self, client: TestClient) -> None:
+        """Per-session turn trajectory is ordered by turn_index."""
+        resp = client.get("/api/cost/sessions/s_1/turns")
+        assert resp.status_code == 200
+        turns = resp.json()["turns"]
+        assert [t["turn_index"] for t in turns] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# /api/cost/prices  (GET + POST)
+# ---------------------------------------------------------------------------
+
+
+@requires_marcus
+class TestPrices:
+    def test_get_current_prices(self, client: TestClient) -> None:
+        """GET /prices returns the latest row per (model, provider)."""
+        resp = client.get("/api/cost/prices")
+        assert resp.status_code == 200
+        prices = resp.json()["prices"]
+        assert any(p["model"] == "claude-sonnet-4-6" for p in prices)
+
+    def test_post_inserts_new_price_version(self, client: TestClient) -> None:
+        """POST /prices inserts a versioned row that wins for new events."""
+        new = {
+            "model": "claude-sonnet-4-6",
+            "provider": "anthropic",
+            "effective_from": "2026-06-01T00:00:00+00:00",
+            "input_per_million": 2.5,
+            "output_per_million": 14.0,
+            "cache_creation_per_million": 3.0,
+            "cache_read_per_million": 0.25,
+            "source": "cato_user",
+        }
+        resp = client.post("/api/cost/prices", json=new)
+        assert resp.status_code == 200
+
+        # New row should appear in /prices/history
+        resp2 = client.get("/api/cost/prices/history?model=claude-sonnet-4-6")
+        assert resp2.status_code == 200
+        rows = resp2.json()["prices"]
+        assert any(r["source"] == "cato_user" for r in rows)
+
+    def test_duplicate_post_returns_409(self, client: TestClient) -> None:
+        """Re-POSTing the same (model, provider, effective_from) returns 409."""
+        new = {
+            "model": "x",
+            "provider": "y",
+            "effective_from": "2026-06-02T00:00:00+00:00",
+            "input_per_million": 1.0,
+            "output_per_million": 1.0,
+            "source": "cato_user",
+        }
+        first = client.post("/api/cost/prices", json=new)
+        assert first.status_code == 200
+        dup = client.post("/api/cost/prices", json=new)
+        assert dup.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# /api/cost/export
+# ---------------------------------------------------------------------------
+
+
+@requires_marcus
+class TestExport:
+    def test_csv_export(self, client: TestClient) -> None:
+        """CSV export returns all events for an experiment."""
+        resp = client.get("/api/cost/export/exp_1")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/csv")
+        rows = resp.text.strip().split("\n")
+        # Header + 3 events
+        assert len(rows) == 4
+        assert "agent_id" in rows[0]

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -11,6 +11,7 @@ Tests are skipped if Marcus cost_tracking modules aren't importable.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -265,6 +266,157 @@ class TestProjectSummary:
         assert body["project_id"] == "proj_1"
         assert body["totals"]["events"] == 3
         assert len(body["experiments"]) == 1
+
+
+@requires_marcus
+class TestProjectBudget:
+    """``GET/PUT /api/cost/projects/{id}/budget`` — project-level cap."""
+
+    def test_get_returns_null_when_unset(self, client: TestClient) -> None:
+        """A project with no cap returns ``budget: null``."""
+        resp = client.get("/api/cost/projects/proj_1/budget")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["project_id"] == "proj_1"
+        assert body["budget"] is None
+
+    def test_put_then_get_roundtrips(self, client: TestClient) -> None:
+        """Setting a cap persists across a fresh GET."""
+        resp = client.put(
+            "/api/cost/projects/proj_1/budget",
+            json={"budget_usd": 25.5, "note": "poc"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["budget"]["budget_usd"] == 25.5
+        assert body["budget"]["note"] == "poc"
+
+        resp2 = client.get("/api/cost/projects/proj_1/budget")
+        assert resp2.json()["budget"]["budget_usd"] == 25.5
+
+    def test_put_zero_clears_the_cap(self, client: TestClient) -> None:
+        """PUT with budget_usd=0 removes the row (no cap)."""
+        client.put(
+            "/api/cost/projects/proj_1/budget",
+            json={"budget_usd": 25.0},
+        )
+        resp = client.put(
+            "/api/cost/projects/proj_1/budget",
+            json={"budget_usd": 0},
+        )
+        assert resp.json()["budget"] is None
+
+
+@requires_marcus
+class TestProjectFullSummary:
+    """``GET /api/cost/projects/{id}/summary`` — drives project-first tabs."""
+
+    def test_returns_full_breakdown(self, client: TestClient) -> None:
+        """Same shape as /experiments/{id} but scoped to project_id."""
+        resp = client.get("/api/cost/projects/proj_1/summary")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["project_id"] == "proj_1"
+        # fixture has 3 events: planner(1500) + worker_turn1(2600) + worker_turn2(350)
+        assert body["summary"]["total_events"] == 3
+        assert body["summary"]["total_tokens"] == 4450
+        roles = {r["role"]: r for r in body["by_role"]}
+        assert "planner" in roles and "worker" in roles
+        assert any(a["agent_id"] == "agent_1" for a in body["by_agent"])
+
+    def test_unknown_returns_404(self, client: TestClient) -> None:
+        """Project with no events → 404, not empty payload."""
+        resp = client.get("/api/cost/projects/no_such_project/summary")
+        assert resp.status_code == 404
+
+
+@requires_marcus
+class TestProjectNameEnrichment:
+    """Picker names come from Marcus's projects.json, not MLflow.
+
+    Marcus's main code path never opens an MLflow experiment, so the
+    ``experiments`` table is usually empty. The project list endpoint
+    must still surface human-readable names by reading Marcus's
+    project registry (same source as Cato's main projects panel).
+    """
+
+    def test_list_projects_overlays_registry_name(
+        self,
+        store: Any,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A project_id with no MLflow row gets its name from projects.json.
+
+        Simulates production: Marcus's main code path emits token events
+        for a project without ever calling start_experiment. The
+        ``experiments`` table has no row, so list_projects.project_name
+        is NULL — the registry must fill it.
+        """
+        from src.cost_tracking.cost_store import TokenEvent
+
+        from backend import cost_routes
+
+        store.record_event(
+            TokenEvent(
+                experiment_id="exp_orphan",
+                project_id="proj_no_mlflow",
+                agent_id="planner",
+                agent_role="planner",
+                operation="parse_prd",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                output_tokens=50,
+                request_id="req_orphan",
+            )
+        )
+
+        fake_root = tmp_path / "marcus"
+        state_dir = fake_root / "data" / "marcus_state"
+        state_dir.mkdir(parents=True)
+        (state_dir / "projects.json").write_text(
+            json.dumps(
+                {
+                    "proj_no_mlflow": {
+                        "id": "proj_no_mlflow",
+                        "name": "registry-named-project",
+                    },
+                    "active_project": {"id": "proj_no_mlflow"},
+                }
+            )
+        )
+        monkeypatch.setattr(cost_routes, "_marcus_root", fake_root)
+        cost_routes.clear_project_names_cache()
+
+        resp = client.get("/api/cost/projects")
+        assert resp.status_code == 200
+        projects = resp.json()["projects"]
+        orphan = next(p for p in projects if p["project_id"] == "proj_no_mlflow")
+        assert orphan["project_name"] == "registry-named-project"
+
+    def test_existing_mlflow_name_takes_precedence(
+        self, client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit project_name from start_experiment beats the registry."""
+        from backend import cost_routes
+
+        # The fixture seeds 'hangman' via the experiments table for proj_1.
+        # If registry says something different, MLflow wins (user-explicit).
+        fake_root = tmp_path / "marcus"
+        state_dir = fake_root / "data" / "marcus_state"
+        state_dir.mkdir(parents=True)
+        (state_dir / "projects.json").write_text(
+            json.dumps({"proj_1": {"id": "proj_1", "name": "different-name"}})
+        )
+        monkeypatch.setattr(cost_routes, "_marcus_root", fake_root)
+        cost_routes.clear_project_names_cache()
+
+        resp = client.get("/api/cost/projects")
+        projects = resp.json()["projects"]
+        proj_1 = next(p for p in projects if p["project_id"] == "proj_1")
+        assert proj_1["project_name"] == "hangman"  # from experiments table
 
 
 @requires_marcus

--- a/tests/test_cost_ingest.py
+++ b/tests/test_cost_ingest.py
@@ -1,0 +1,240 @@
+"""
+Unit tests for backend.cost_ingest.
+
+Covers the cwd→AgentBinding resolver and the run_ingest sweep against
+synthetic experiment directories laid out the way Marcus's
+spawn_agents.py creates them. No real ``~/.claude/projects/`` access.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+try:
+    from backend.cost_ingest import (
+        clear_project_info_cache,
+        resolve_binding_from_cwd,
+        run_ingest,
+    )
+    from backend.cost_routes import COST_TRACKING_AVAILABLE
+except ImportError:
+    COST_TRACKING_AVAILABLE = False
+
+requires_marcus = pytest.mark.skipif(
+    not COST_TRACKING_AVAILABLE,
+    reason="Marcus cost_tracking modules unavailable",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: synthetic experiment layout matching spawn_agents.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    """Drop the lru_cache between tests so each one re-reads project_info."""
+    clear_project_info_cache()
+
+
+@pytest.fixture
+def experiment_dir(tmp_path: Path) -> Path:
+    """Mimic the layout spawn_agents.py produces under tmp_path."""
+    exp = tmp_path / "my-experiment"
+    (exp / "worktrees" / "agent_1").mkdir(parents=True)
+    (exp / "worktrees" / "agent_2").mkdir(parents=True)
+    (exp / "project_info.json").write_text(
+        json.dumps({"project_id": "proj_42", "board_id": "b_1"})
+    )
+    return exp
+
+
+# ---------------------------------------------------------------------------
+# resolve_binding_from_cwd
+# ---------------------------------------------------------------------------
+
+
+@requires_marcus
+class TestResolveBinding:
+    """cwd-based agent → project resolution."""
+
+    def test_resolves_agent_in_worktree(self, experiment_dir: Path) -> None:
+        """Standard worker layout maps cwd → (agent_id, project_id)."""
+        binding = resolve_binding_from_cwd(
+            {"cwd": str(experiment_dir / "worktrees" / "agent_1")}
+        )
+        assert binding is not None
+        assert binding.agent_id == "agent_1"
+        assert binding.project_id == "proj_42"
+
+    def test_returns_none_when_cwd_missing(self) -> None:
+        """No cwd field at all → drop the record."""
+        assert resolve_binding_from_cwd({}) is None
+
+    def test_returns_none_when_cwd_not_in_worktree(self, experiment_dir: Path) -> None:
+        """A project-creator working in the experiment root has no agent_id.
+
+        Their cwd is the experiment dir, not <exp>/worktrees/<agent>, so
+        the resolver returns None and their events are skipped.
+        """
+        assert resolve_binding_from_cwd({"cwd": str(experiment_dir)}) is None
+
+    def test_returns_none_when_project_info_missing(self, tmp_path: Path) -> None:
+        """Experiment dir without project_info.json → cannot bind."""
+        broken = tmp_path / "no-info"
+        (broken / "worktrees" / "agent_1").mkdir(parents=True)
+        # No project_info.json written.
+        assert (
+            resolve_binding_from_cwd({"cwd": str(broken / "worktrees" / "agent_1")})
+            is None
+        )
+
+    def test_returns_none_when_project_info_lacks_project_id(
+        self, tmp_path: Path
+    ) -> None:
+        """project_info.json missing project_id field → drop."""
+        broken = tmp_path / "bad-info"
+        (broken / "worktrees" / "agent_1").mkdir(parents=True)
+        (broken / "project_info.json").write_text(json.dumps({"board_id": "b"}))
+        assert (
+            resolve_binding_from_cwd({"cwd": str(broken / "worktrees" / "agent_1")})
+            is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# run_ingest sweep
+# ---------------------------------------------------------------------------
+
+
+@requires_marcus
+class TestRunIngest:
+    """End-to-end: synthetic JSONL → ingest sweep → token_events row."""
+
+    @pytest.fixture
+    def store(self, tmp_path: Path) -> Any:
+        """Tmp CostStore with default seed prices."""
+        from src.cost_tracking.cost_store import CostStore
+
+        s = CostStore(db_path=tmp_path / "costs.db")
+        s.load_seed_prices()
+        return s
+
+    def test_ingests_worker_session(
+        self,
+        store: Any,
+        experiment_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A session file in the synthetic ~/.claude/projects dir is ingested."""
+        # Lay out the synthetic Claude Code session log.
+        claude_root = tmp_path / "claude_projects"
+        sess_dir = claude_root / "fake-project"
+        sess_dir.mkdir(parents=True)
+        record = {
+            "type": "assistant",
+            "uuid": "u1",
+            "sessionId": "s1",
+            "requestId": "req1",
+            "timestamp": "2026-05-10T14:00:00.000Z",
+            "cwd": str(experiment_dir / "worktrees" / "agent_1"),
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "usage": {
+                    "input_tokens": 100,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                    "output_tokens": 50,
+                },
+            },
+        }
+        (sess_dir / "s1.jsonl").write_text(json.dumps(record) + "\n")
+
+        # Redirect Path.home() so run_ingest looks at our tmp tree.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # _read_project_info is cached; clear it.
+        clear_project_info_cache()
+
+        # ``Path.home()`` reads from $HOME on POSIX. Sanity-check.
+        assert Path.home() == tmp_path
+
+        # Move the session dir to where run_ingest expects it.
+        target = tmp_path / ".claude" / "projects" / "fake-project"
+        target.parent.mkdir(parents=True)
+        sess_dir.rename(target)
+
+        result = run_ingest(store)
+        assert result["ingested"] == 1
+        assert result["files"] == 1
+        assert result["skipped_unbound"] == 0
+
+        row = store.conn.execute(
+            "SELECT project_id, agent_id, input_tokens, output_tokens "
+            "FROM token_events"
+        ).fetchone()
+        assert row == ("proj_42", "agent_1", 100, 50)
+
+    def test_run_ingest_is_idempotent_across_calls(
+        self,
+        store: Any,
+        experiment_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sweeping the same JSONL twice must not duplicate token_events.
+
+        Cato's dashboard polls run_ingest every 30s with a fresh
+        WorkerJSONLIngester whose in-memory dedup set is empty. The
+        Marcus side enforces dedup at the DB layer (partial UNIQUE
+        INDEX on request_id + INSERT OR IGNORE), so calling run_ingest
+        repeatedly on the same files inserts the row only once.
+        """
+        sess_dir = tmp_path / ".claude" / "projects" / "fake-project"
+        sess_dir.mkdir(parents=True)
+        record = {
+            "type": "assistant",
+            "uuid": "u1",
+            "sessionId": "s1",
+            "requestId": "req_idem_1",
+            "timestamp": "2026-05-10T14:00:00.000Z",
+            "cwd": str(experiment_dir / "worktrees" / "agent_1"),
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "usage": {
+                    "input_tokens": 100,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                    "output_tokens": 50,
+                },
+            },
+        }
+        (sess_dir / "s1.jsonl").write_text(json.dumps(record) + "\n")
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        first = run_ingest(store)
+        second = run_ingest(store)
+
+        assert first["ingested"] == 1
+        # Second sweep may report ingested>0 from the library's perspective,
+        # but the DB-level UNIQUE constraint guarantees no duplicate rows.
+        count = store.conn.execute(
+            "SELECT COUNT(*) FROM token_events WHERE request_id = 'req_idem_1'"
+        ).fetchone()[0]
+        assert count == 1, f"expected 1 row after 2 sweeps, got {count}"
+        assert second["files"] == 1
+
+    def test_returns_zeros_when_claude_projects_missing(
+        self,
+        store: Any,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No ~/.claude/projects/ dir → graceful zero return, no error."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = run_ingest(store)
+        assert result == {"ingested": 0, "files": 0, "skipped_unbound": 0}


### PR DESCRIPTION
Release **v0.3.3** — cost dashboard.

> Note: v0.3.2 already shipped via PR #26. This release takes the next version.

Merges `develop` into `main`: the cost dashboard work (#28–#43) plus release prep.

## Highlights
- **Cost dashboard** — `/api/cost/*` endpoints, real-time cost tab, Historical / Budget / Pricing tabs, per-task and per-tool audit views.
- Project-first dashboard layout; unified project picker.

Also fixes `version-gate.yml` (adds `pull-requests: write` so the checklist comment posts instead of 403-crashing).

See `CHANGELOG.md` `[0.3.3]` for full notes.

After merge: tag `v0.3.3` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)