### PR TITLE
fix: make Marcus install path configurable per machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ Thumbs.db
 # data/marcus_state/
 data
 
+# Local machine-specific config (Marcus path) — written by `./cato`
+config.local.json
+
 # Build
 *.egg-info/
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,17 @@ minimum compatible Marcus version.
   anyone else. The Marcus location is now resolved dynamically: the `MARCUS_ROOT`
   environment variable, then `config.local.json` / `config.json`, then
   auto-detection (Marcus as a sibling of Cato, or `~/dev/marcus`). On first
-  `./cato start`, the CLI prompts for the Marcus root and saves it to
-  `config.local.json` (gitignored); subsequent starts reuse it silently.
+  `./cato start`, the CLI prompts for the Marcus root, validates that it
+  contains both `data/` and `src/`, and saves it to `config.local.json`
+  (gitignored); subsequent starts reuse it silently.
+- **`Aggregator` auto-detection now uses the shared resolver.** Its previous
+  fallback assumed Cato was a subdirectory of Marcus (a leftover from when
+  Cato lived in the Marcus repo) and silently pointed at the Cato root.
+
+### Fixed
+- **Cato now fails loudly when Marcus cannot be located** instead of serving
+  an empty dashboard. A no-arg `Aggregator()` and backend startup raise a
+  clear error directing the user to set `MARCUS_ROOT` or run `./cato`.
 
 ## [0.3.4] - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ minimum compatible Marcus version.
 
 ## [Unreleased]
 
+### Changed
+- **The Marcus install path is now configurable per machine.** Cato previously
+  hardcoded `/Users/lwgray/dev/marcus` in several places, making it unusable by
+  anyone else. The Marcus location is now resolved dynamically: the `MARCUS_ROOT`
+  environment variable, then `config.local.json` / `config.json`, then
+  auto-detection (Marcus as a sibling of Cato, or `~/dev/marcus`). On first
+  `./cato start`, the CLI prompts for the Marcus root and saves it to
+  `config.local.json` (gitignored); subsequent starts reuse it silently.
+
 ## [0.3.4] - 2026-05-17
 
 Bugfix release.

--- a/backend/api.py
+++ b/backend/api.py
@@ -158,14 +158,30 @@ from backend.cost_routes import router as cost_router  # noqa: E402
 
 app.include_router(cost_router)
 
-# Initialize aggregator for snapshot API — multi-root if configured
-aggregator = (
-    Aggregator(
+# Initialize aggregator for snapshot API — multi-root if configured.
+# Resolve a concrete Marcus root up front so a missing/misconfigured
+# install fails loudly at startup instead of silently serving an empty
+# dashboard (the worst failure mode for an observability tool).
+if _extra_marcus_roots:
+    aggregator = Aggregator(
         marcus_roots=_extra_marcus_roots, history_cutoff_date=_history_cutoff_date
     )
-    if _extra_marcus_roots
-    else Aggregator(marcus_root=marcus_root, history_cutoff_date=_history_cutoff_date)
-)
+else:
+    from cato_src.core.marcus_paths import (  # noqa: E402
+        discover_marcus_root as _discover,
+    )
+
+    _live_root = marcus_root or marcus_data_path_root or _discover("data")
+    if _live_root is None:
+        raise RuntimeError(
+            "Cato could not locate the Marcus installation. Set the "
+            "MARCUS_ROOT environment variable, or run `./cato` to configure "
+            "it (this writes config.local.json)."
+        )
+    logger.info(f"Live-mode aggregator using Marcus root: {_live_root}")
+    aggregator = Aggregator(
+        marcus_root=_live_root, history_cutoff_date=_history_cutoff_date
+    )
 
 # Simple in-memory cache for snapshots (60s TTL for better performance)
 snapshot_cache: Dict[str, tuple[Dict[str, Any], datetime]] = {}

--- a/backend/api.py
+++ b/backend/api.py
@@ -160,8 +160,17 @@ app.include_router(cost_router)
 
 # Initialize aggregator for snapshot API — multi-root if configured.
 # Resolve a concrete Marcus root up front so a missing/misconfigured
-# install fails loudly at startup instead of silently serving an empty
-# dashboard (the worst failure mode for an observability tool).
+# install fails loudly *at server startup* (see the startup event) rather
+# than silently serving an empty dashboard.
+#
+# Import must not raise: the test suite imports this module without Marcus
+# present. When resolution fails we record the reason in _aggregator_error
+# and bind `aggregator` to a placeholder pointed at a non-existent root —
+# the startup event refuses to serve before any request can use it, so the
+# placeholder is never read. This keeps `aggregator` a plain Aggregator for
+# every endpoint instead of an Optional that each would have to None-check.
+_aggregator_error: Optional[str] = None
+
 if _extra_marcus_roots:
     aggregator = Aggregator(
         marcus_roots=_extra_marcus_roots, history_cutoff_date=_history_cutoff_date
@@ -173,15 +182,18 @@ else:
 
     _live_root = marcus_root or marcus_data_path_root or _discover("data")
     if _live_root is None:
-        raise RuntimeError(
+        _aggregator_error = (
             "Cato could not locate the Marcus installation. Set the "
             "MARCUS_ROOT environment variable, or run `./cato` to configure "
             "it (this writes config.local.json)."
         )
-    logger.info(f"Live-mode aggregator using Marcus root: {_live_root}")
-    aggregator = Aggregator(
-        marcus_root=_live_root, history_cutoff_date=_history_cutoff_date
-    )
+        logger.error(_aggregator_error)
+        aggregator = Aggregator(marcus_root=Path("/nonexistent/marcus-not-configured"))
+    else:
+        logger.info(f"Live-mode aggregator using Marcus root: {_live_root}")
+        aggregator = Aggregator(
+            marcus_root=_live_root, history_cutoff_date=_history_cutoff_date
+        )
 
 # Simple in-memory cache for snapshots (60s TTL for better performance)
 snapshot_cache: Dict[str, tuple[Dict[str, Any], datetime]] = {}
@@ -297,7 +309,16 @@ def background_cache_refresh() -> None:
 
 @app.on_event("startup")  # type: ignore[misc]
 async def startup_event() -> None:
-    """Run background tasks on startup."""
+    """Run background tasks on startup.
+
+    Fails loudly if the Marcus installation could not be located: an
+    observability dashboard with no data source should refuse to start,
+    not serve an empty UI. Import-time resolution stays non-fatal so the
+    test suite can import this module without Marcus present.
+    """
+    if _aggregator_error is not None:
+        raise RuntimeError(_aggregator_error)
+
     import threading
 
     # DISABLED: Pre-warming was causing slow startup with many projects
@@ -519,13 +540,20 @@ async def update_settings(body: Dict[str, Any]) -> Dict[str, Any]:
         with open(config_path, "w") as f:
             json.dump(cfg, f, indent=2)
 
-        # Reinitialize aggregator with new cutoff
+        # Reinitialize aggregator with new cutoff, reusing the Marcus
+        # root(s) already resolved at startup so we don't re-run discovery.
+        if _aggregator_error is not None:
+            raise HTTPException(status_code=503, detail=_aggregator_error)
+
         new_cutoff: Optional[str] = cfg.get("history_cutoff_date")
-        aggregator = (
-            Aggregator(marcus_roots=_extra_marcus_roots, history_cutoff_date=new_cutoff)
-            if _extra_marcus_roots
-            else Aggregator(marcus_root=marcus_root, history_cutoff_date=new_cutoff)
-        )
+        if _extra_marcus_roots:
+            aggregator = Aggregator(
+                marcus_roots=_extra_marcus_roots, history_cutoff_date=new_cutoff
+            )
+        else:
+            aggregator = Aggregator(
+                marcus_root=aggregator.marcus_root, history_cutoff_date=new_cutoff
+            )
 
         # Invalidate snapshot cache so next request re-reads with new cutoff
         snapshot_cache.clear()
@@ -533,6 +561,8 @@ async def update_settings(body: Dict[str, Any]) -> Dict[str, Any]:
         logger.info(f"Settings updated: history_cutoff_date={new_cutoff}")
         return {"history_cutoff_date": new_cutoff}
 
+    except HTTPException:
+        raise  # propagate 503 (Marcus missing) without masking it as 500
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -43,18 +43,10 @@ ProjectHistoryQuery = None
 PostProjectAnalyzer = None
 
 try:
-    # Find Marcus root directory
-    possible_marcus_roots = [
-        Path(__file__).parent.parent.parent / "marcus",  # Sibling to cato
-        Path.home() / "dev" / "marcus",  # Common dev location
-        Path("/Users/lwgray/dev/marcus"),  # Absolute path
-    ]
+    # Find Marcus root directory (MARCUS_ROOT / config / auto-detect)
+    from cato_src.core.marcus_paths import discover_marcus_root  # noqa: E402
 
-    for possible_root in possible_marcus_roots:
-        if (possible_root / "src" / "analysis").exists():
-            marcus_root = possible_root
-            break
-
+    marcus_root = discover_marcus_root("src/analysis")
     if not marcus_root:
         raise ImportError("Marcus root directory not found")
 
@@ -99,37 +91,49 @@ if HISTORICAL_MODE_AVAILABLE and ProjectHistoryAggregator and ProjectHistoryQuer
         logger.error(f"Failed to initialize historical analysis components: {e}")
         HISTORICAL_MODE_AVAILABLE = False
 
-# Load Marcus data path(s) and settings from config (for live mode aggregator)
+# Load Marcus data path(s) and settings from config (for live mode aggregator).
+# config.local.json (gitignored, written by the `cato` CLI) overrides config.json.
+# config_path points at the shared config.json — the /api/settings endpoints
+# read and write history_cutoff_date there.
 config_path = Path(__file__).parent.parent / "config.json"
 marcus_data_path_root = None
 _extra_marcus_roots: list[Path] = []
 _history_cutoff_date: Optional[str] = None
 try:
-    with open(config_path, "r") as f:
-        config = json.load(f)
-        # Multi-path support: marcus_data_paths overrides marcus_data_path
-        multi_paths = config.get("marcus_data_paths")
-        if multi_paths:
-            _extra_marcus_roots = [Path(p).parent for p in multi_paths]
-            marcus_data_path_root = _extra_marcus_roots[0]
-            logger.info(
-                f"Using {len(_extra_marcus_roots)} Marcus data paths from config"
-            )
+    from cato_src.core.marcus_paths import load_merged_config  # noqa: E402
+
+    config = load_merged_config()
+    # Multi-path support: marcus_data_paths overrides marcus_data_path
+    multi_paths = config.get("marcus_data_paths")
+    if multi_paths:
+        _extra_marcus_roots = [Path(p).expanduser().parent for p in multi_paths]
+        marcus_data_path_root = _extra_marcus_roots[0]
+        logger.info(f"Using {len(_extra_marcus_roots)} Marcus data paths from config")
+    else:
+        marcus_data_path = config.get("marcus_data_path")
+        if marcus_data_path:
+            marcus_data_path_root = Path(marcus_data_path).expanduser().parent
+            _extra_marcus_roots = [marcus_data_path_root]
+            logger.info(f"Using Marcus data path from config: {marcus_data_path_root}")
         else:
-            marcus_data_path = config.get("marcus_data_path")
-            if marcus_data_path:
-                marcus_data_path_root = Path(marcus_data_path).parent
-                _extra_marcus_roots = [marcus_data_path_root]
-                logger.info(
-                    f"Using Marcus data path from config: {marcus_data_path_root}"
-                )
-            else:
-                logger.info("No Marcus data path in config, using auto-detection")
-        _history_cutoff_date = config.get("history_cutoff_date")
-        if _history_cutoff_date:
-            logger.info(f"History cutoff date: {_history_cutoff_date}")
+            logger.info("No Marcus data path in config, using auto-detection")
+    _history_cutoff_date = config.get("history_cutoff_date")
+    if _history_cutoff_date:
+        logger.info(f"History cutoff date: {_history_cutoff_date}")
 except Exception as e:
-    logger.warning(f"Could not load config.json: {e}, using auto-detection")
+    logger.warning(f"Could not load config: {e}, using auto-detection")
+
+
+def _project_history_dir() -> Optional[Path]:
+    """Resolve Marcus's ``data/project_history`` directory.
+
+    Uses the discovered Marcus root, falling back to the config-derived
+    data path root. Returns None when Marcus's location is unknown — no
+    machine-specific path is assumed.
+    """
+    root = marcus_root or marcus_data_path_root
+    return (root / "data" / "project_history") if root else None
+
 
 # Initialize FastAPI app
 app = FastAPI(
@@ -1197,13 +1201,10 @@ async def list_historical_projects() -> Any:
                 )
 
         # Find all project IDs from persistence layer
-        if marcus_root:
-            history_dir = marcus_root / "data" / "project_history"
-        else:
-            history_dir = Path.home() / "dev" / "marcus" / "data" / "project_history"
+        history_dir = _project_history_dir()
 
         active_projects_data = []
-        if history_dir.exists():
+        if history_dir and history_dir.exists():
             logger.info(f"Scanning for historical projects in {history_dir}")
 
             # OPTIMIZATION: Only load summaries for active projects
@@ -1320,13 +1321,10 @@ async def list_all_historical_projects(
                 logger.warning(f"Could not load project registry: {e}")
 
         # Find all historical projects
-        if marcus_root:
-            history_dir = marcus_root / "data" / "project_history"
-        else:
-            history_dir = Path.home() / "dev" / "marcus" / "data" / "project_history"
+        history_dir = _project_history_dir()
 
         all_projects = []
-        if history_dir.exists():
+        if history_dir and history_dir.exists():
             logger.info(f"Scanning for all historical projects in {history_dir}")
             for project_dir in history_dir.iterdir():
                 if project_dir.is_dir():
@@ -1399,14 +1397,9 @@ async def stream_historical_projects_list() -> StreamingResponse:
             yield f"data: {event_data}\n\n"
             await asyncio.sleep(0.1)
 
-            if marcus_root:
-                history_dir = marcus_root / "data" / "project_history"
-            else:
-                history_dir = (
-                    Path.home() / "dev" / "marcus" / "data" / "project_history"
-                )
+            history_dir = _project_history_dir()
 
-            if not history_dir.exists():
+            if not history_dir or not history_dir.exists():
                 event_data = json.dumps(
                     {
                         "type": "error",

--- a/backend/cost_routes.py
+++ b/backend/cost_routes.py
@@ -63,18 +63,12 @@ _marcus_all_operations: Any = None
 try:
     import sys
 
-    # Mirror the historical-mode discovery in backend/api.py: search a few
-    # well-known Marcus locations and add its root to sys.path.
-    _possible_roots = [
-        Path(__file__).parent.parent.parent / "marcus",  # sibling
-        Path.home() / "dev" / "marcus",
-        Path("/Users/lwgray/dev/marcus"),
-    ]
-    _marcus_root: Optional[Path] = None
-    for _root in _possible_roots:
-        if (_root / "src" / "cost_tracking").exists():
-            _marcus_root = _root
-            break
+    # Locate Marcus the same way backend/api.py does — MARCUS_ROOT env var,
+    # config.json/config.local.json, then auto-detection — and add its
+    # root to sys.path.
+    from cato_src.core.marcus_paths import discover_marcus_root
+
+    _marcus_root: Optional[Path] = discover_marcus_root("src/cost_tracking")
     if _marcus_root is not None:
         if str(_marcus_root) not in sys.path:
             sys.path.insert(0, str(_marcus_root))

--- a/cato
+++ b/cato
@@ -26,12 +26,77 @@ BACKEND_PORT=$(python3 -c "import json; print(json.load(open('config.json'))['ba
 BACKEND_HOST=$(python3 -c "import json; print(json.load(open('config.json'))['backend']['host'])" 2>/dev/null || echo "localhost")
 FRONTEND_PORT=$(python3 -c "import json; print(json.load(open('config.json'))['frontend']['port'])" 2>/dev/null || echo "5173")
 
+# Ensure Cato knows where the Marcus installation lives.
+# Prompts once on first run; the answer is saved to config.local.json
+# (gitignored). Skipped when already configured or MARCUS_ROOT is set.
+ensure_marcus_config() {
+    # MARCUS_ROOT env var overrides everything — no prompt.
+    if [ -n "$MARCUS_ROOT" ]; then
+        if [ -d "$MARCUS_ROOT/data" ]; then
+            return 0
+        fi
+        echo -e "${YELLOW}Warning: MARCUS_ROOT set but '$MARCUS_ROOT/data' not found${NC}"
+    fi
+
+    # Already configured locally and still valid?
+    if [ -f "config.local.json" ]; then
+        local ok
+        ok=$(python3 - <<'PY' 2>/dev/null || echo BAD
+import json
+from pathlib import Path
+try:
+    p = json.load(open("config.local.json")).get("marcus_data_path")
+    print("OK" if p and Path(p).expanduser().is_dir() else "BAD")
+except Exception:
+    print("BAD")
+PY
+)
+        [ "$ok" = "OK" ] && return 0
+        echo -e "${YELLOW}Saved Marcus data path is missing — reconfiguring.${NC}"
+    fi
+
+    # Need to prompt — but only if we have an interactive terminal.
+    if [ ! -t 0 ]; then
+        echo -e "${RED}Error: Marcus path not configured and no terminal to prompt.${NC}"
+        echo "Set the MARCUS_ROOT env var, or create config.local.json with a"
+        echo '"marcus_data_path" key pointing at your Marcus data directory.'
+        exit 1
+    fi
+
+    echo -e "${BLUE}Cato needs to know where your Marcus installation lives.${NC}"
+    while true; do
+        read -r -p "Path to your Marcus root directory: " marcus_root
+        marcus_root="${marcus_root/#\~/$HOME}"
+        if [ -z "$marcus_root" ]; then
+            echo -e "${RED}No path entered. Aborting.${NC}"
+            exit 1
+        fi
+        if [ -d "$marcus_root/data" ]; then
+            python3 - "$marcus_root" <<'PY'
+import json, sys
+from pathlib import Path
+root = Path(sys.argv[1]).expanduser().resolve()
+with open("config.local.json", "w") as f:
+    json.dump({"marcus_data_path": str(root / "data")}, f, indent=2)
+    f.write("\n")
+PY
+            echo -e "${GREEN}✓ Saved Marcus path to config.local.json${NC}"
+            return 0
+        fi
+        echo -e "${RED}No 'data/' directory inside: $marcus_root${NC}"
+        echo "Enter the Marcus root — the folder containing 'data/' and 'src/'."
+    done
+}
+
 # Functions
 start_backend() {
     if lsof -Pi :${BACKEND_PORT} -sTCP:LISTEN -t >/dev/null 2>&1; then
         echo -e "${YELLOW}Backend already running on port ${BACKEND_PORT}${NC}"
         return 0
     fi
+
+    # Make sure the Marcus path is configured before the backend imports it.
+    ensure_marcus_config
 
     echo -e "${BLUE}Starting backend on port ${BACKEND_PORT}...${NC}"
     cd "$SCRIPT_DIR"
@@ -169,7 +234,9 @@ Examples:
   cato logs          # View all logs
 
 Configuration:
-  Edit config.json to change ports
+  Edit config.json to change ports.
+  The Marcus install path is asked for on first start and saved to
+  config.local.json. Override anytime with the MARCUS_ROOT env var.
 
 EOF
 }

--- a/cato
+++ b/cato
@@ -32,10 +32,10 @@ FRONTEND_PORT=$(python3 -c "import json; print(json.load(open('config.json'))['f
 ensure_marcus_config() {
     # MARCUS_ROOT env var overrides everything — no prompt.
     if [ -n "$MARCUS_ROOT" ]; then
-        if [ -d "$MARCUS_ROOT/data" ]; then
+        if [ -d "$MARCUS_ROOT/data" ] && [ -d "$MARCUS_ROOT/src" ]; then
             return 0
         fi
-        echo -e "${YELLOW}Warning: MARCUS_ROOT set but '$MARCUS_ROOT/data' not found${NC}"
+        echo -e "${YELLOW}Warning: MARCUS_ROOT set but '$MARCUS_ROOT' is missing 'data/' or 'src/'${NC}"
     fi
 
     # Already configured locally and still valid?
@@ -71,7 +71,7 @@ PY
             echo -e "${RED}No path entered. Aborting.${NC}"
             exit 1
         fi
-        if [ -d "$marcus_root/data" ]; then
+        if [ -d "$marcus_root/data" ] && [ -d "$marcus_root/src" ]; then
             python3 - "$marcus_root" <<'PY'
 import json, sys
 from pathlib import Path
@@ -83,8 +83,8 @@ PY
             echo -e "${GREEN}✓ Saved Marcus path to config.local.json${NC}"
             return 0
         fi
-        echo -e "${RED}No 'data/' directory inside: $marcus_root${NC}"
-        echo "Enter the Marcus root — the folder containing 'data/' and 'src/'."
+        echo -e "${RED}'$marcus_root' is missing a 'data/' or 'src/' directory.${NC}"
+        echo "Enter the Marcus root — the folder containing both 'data/' and 'src/'."
     done
 }
 

--- a/cato_src/core/aggregator.py
+++ b/cato_src/core/aggregator.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Literal, Optional, Set, Tuple
 
+from cato_src.core.marcus_paths import discover_marcus_root
 from cato_src.core.store import (
     Agent,
     Artifact,
@@ -158,8 +159,16 @@ class Aggregator:
         elif marcus_root is not None:
             self.marcus_roots = [Path(marcus_root)]
         else:
-            # Auto-detect: assumes viz is a subdirectory of Marcus
-            auto_root = Path(__file__).parent.parent.parent
+            # Auto-detect via the shared resolver (MARCUS_ROOT env var,
+            # config.json/config.local.json, then well-known locations).
+            # Single source of truth — see cato_src/core/marcus_paths.py.
+            auto_root = discover_marcus_root("data")
+            if auto_root is None:
+                raise RuntimeError(
+                    "Could not locate the Marcus installation. Set the "
+                    "MARCUS_ROOT environment variable, run `./cato` to "
+                    "configure it, or pass marcus_root= explicitly."
+                )
             self.marcus_roots = [auto_root]
 
         # Primary root (backward compat attribute)

--- a/cato_src/core/marcus_paths.py
+++ b/cato_src/core/marcus_paths.py
@@ -1,0 +1,102 @@
+"""Marcus root directory discovery for Cato.
+
+Single source of truth for locating the Marcus installation so Cato is
+usable on any machine — no developer-specific absolute paths are baked
+into the code.
+
+Configuration is layered: ``config.json`` holds shared settings (ports,
+cutoff date) and is committed; ``config.local.json`` holds the
+machine-specific Marcus path and is gitignored. The ``cato`` CLI writes
+``config.local.json`` after prompting the user on first start.
+
+Marcus-root resolution order (first match wins):
+
+1. ``MARCUS_ROOT`` environment variable.
+2. ``marcus_data_path`` / ``marcus_data_paths`` from the merged config
+   (``config.local.json`` overrides ``config.json``).
+3. Auto-detection of well-known locations: Marcus checked out as a
+   sibling of Cato, or ``~/dev/marcus``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# cato_src/core/marcus_paths.py -> parents[2] is the Cato project root.
+_CATO_ROOT = Path(__file__).resolve().parents[2]
+_CONFIG_PATH = _CATO_ROOT / "config.json"
+_LOCAL_CONFIG_PATH = _CATO_ROOT / "config.local.json"
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    """Return a parsed JSON object, or an empty dict if absent/invalid."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def load_merged_config() -> Dict[str, Any]:
+    """Load ``config.json`` overlaid with ``config.local.json``.
+
+    ``config.local.json`` is gitignored and holds machine-specific
+    settings (the Marcus path); its keys win over the committed
+    ``config.json``.
+    """
+    config = _read_json(_CONFIG_PATH)
+    config.update(_read_json(_LOCAL_CONFIG_PATH))
+    return config
+
+
+def _config_marcus_root() -> Optional[Path]:
+    """Marcus root derived from the merged config, or None if unconfigured.
+
+    The config stores the Marcus *data* directory (``marcus_data_path``);
+    the Marcus root is its parent.
+    """
+    config = load_merged_config()
+    multi = config.get("marcus_data_paths")
+    data_path = multi[0] if multi else config.get("marcus_data_path")
+    if not data_path:
+        return None
+    return Path(data_path).expanduser().parent
+
+
+def discover_marcus_root(marker: str = "src") -> Optional[Path]:
+    """Locate the Marcus root directory.
+
+    Parameters
+    ----------
+    marker:
+        Relative path that must exist under a candidate for it to be
+        accepted (e.g. ``"src/analysis"`` or ``"src/cost_tracking"``).
+        Lets callers require the specific Marcus subpackage they import.
+
+    Returns
+    -------
+    Optional[Path]
+        The first candidate containing ``marker``, or None if none match.
+    """
+    candidates: list[Path] = []
+
+    env_root = os.environ.get("MARCUS_ROOT")
+    if env_root:
+        candidates.append(Path(env_root).expanduser())
+
+    config_root = _config_marcus_root()
+    if config_root:
+        candidates.append(config_root)
+
+    # Auto-detection fallbacks — no machine-specific absolute paths.
+    candidates.append(_CATO_ROOT.parent / "marcus")  # sibling of Cato
+    candidates.append(Path.home() / "dev" / "marcus")
+
+    for candidate in candidates:
+        if (candidate / marker).exists():
+            return candidate
+    return None

--- a/config.json
+++ b/config.json
@@ -6,12 +6,13 @@
   "frontend": {
     "port": 5173
   },
-  "marcus_data_path": "/Users/lwgray/dev/marcus/data",
+  "marcus_data_path": null,
+  "_comment_marcus_data_path": "Machine-specific Marcus data dir. Leave null — `./cato start` prompts for it on first run and writes the answer to config.local.json (gitignored). You may also set the MARCUS_ROOT env var.",
   "history_cutoff_date": "2026-04-14",
   "_comment_history_cutoff_date": "Only show projects and load logs on/after this date (YYYY-MM-DD). Leave null to show all.",
-  "_comment_marcus_data_paths": "Uncomment to watch multiple parallel Marcus instances (overrides marcus_data_path)",
+  "_comment_marcus_data_paths": "To watch multiple parallel Marcus instances, set marcus_data_paths in config.local.json (overrides marcus_data_path)",
   "_marcus_data_paths_example": [
-    "/Users/lwgray/dev/marcus/data",
+    "/path/to/marcus/data",
     "/tmp/parallel_exp_1/data",
     "/tmp/parallel_exp_2/data"
   ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,9 @@ dev = [
     "pre-commit>=3.5.0",
     "types-aiofiles",
     "types-requests",
-    "httpx>=0.24.0",
+    # Capped <0.28: httpx 0.28 dropped the `app=` shortcut that
+    # starlette 0.27's TestClient relies on (breaks the test suite).
+    "httpx>=0.24.0,<0.28",
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,9 @@ pytest>=7.0.0
 pytest-cov>=4.0.0
 pytest-asyncio>=0.21.0
 pytest-mock>=3.10.0
+# httpx capped <0.28: 0.28 dropped the `app=` shortcut that
+# starlette 0.27's TestClient relies on (breaks the test suite).
+httpx>=0.25.0,<0.28
 
 # Additional development tools
 types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 # Core dependencies
 mcp==1.10.0
 anthropic>=0.18.0,<1.0.0
-httpx>=0.25.0
+# Capped <0.28: httpx 0.28 dropped the `app=` shortcut that
+# starlette 0.27's TestClient relies on (breaks the test suite).
+httpx>=0.25.0,<0.28
 aiofiles>=0.8.0
 psutil>=5.9.0
 structlog>=24.0.0

--- a/tests/test_bundled_design_display.py
+++ b/tests/test_bundled_design_display.py
@@ -124,7 +124,10 @@ def test_filter_tasks_includes_bundled_design_tasks(
     """
     from cato_src.core.aggregator import Aggregator
 
-    aggregator = Aggregator()
+    # Explicit root: these tests exercise pure filter logic and never read
+    # the filesystem, so any existing dir works — and passing it keeps the
+    # test independent of whether Marcus is installed.
+    aggregator = Aggregator(marcus_root=Path(__file__).parent)
     all_tasks = sample_bundled_design_tasks + sample_regular_tasks
 
     # Test subtasks view mode
@@ -167,7 +170,10 @@ def test_filter_tasks_includes_parents_without_children(sample_regular_tasks):
     """
     from cato_src.core.aggregator import Aggregator
 
-    aggregator = Aggregator()
+    # Explicit root: these tests exercise pure filter logic and never read
+    # the filesystem, so any existing dir works — and passing it keeps the
+    # test independent of whether Marcus is installed.
+    aggregator = Aggregator(marcus_root=Path(__file__).parent)
 
     filtered = aggregator._filter_tasks_by_view(
         sample_regular_tasks, view_mode="subtasks"
@@ -195,7 +201,10 @@ def test_filter_tasks_includes_design_tasks_in_dependency_chain(
     """
     from cato_src.core.aggregator import Aggregator
 
-    aggregator = Aggregator()
+    # Explicit root: these tests exercise pure filter logic and never read
+    # the filesystem, so any existing dir works — and passing it keeps the
+    # test independent of whether Marcus is installed.
+    aggregator = Aggregator(marcus_root=Path(__file__).parent)
 
     # Add a task that depends on the design task
     tasks = sample_bundled_design_tasks + [
@@ -224,7 +233,10 @@ def test_all_view_mode_shows_everything():
     """Test that 'all' view mode shows all tasks."""
     from cato_src.core.aggregator import Aggregator
 
-    aggregator = Aggregator()
+    # Explicit root: these tests exercise pure filter logic and never read
+    # the filesystem, so any existing dir works — and passing it keeps the
+    # test independent of whether Marcus is installed.
+    aggregator = Aggregator(marcus_root=Path(__file__).parent)
 
     tasks = [
         {"id": "task1", "is_subtask": True, "parent_task_id": "parent1"},
@@ -246,7 +258,10 @@ def test_parents_view_mode_excludes_subtasks():
     """Test that 'parents' view mode only shows parent tasks."""
     from cato_src.core.aggregator import Aggregator
 
-    aggregator = Aggregator()
+    # Explicit root: these tests exercise pure filter logic and never read
+    # the filesystem, so any existing dir works — and passing it keeps the
+    # test independent of whether Marcus is installed.
+    aggregator = Aggregator(marcus_root=Path(__file__).parent)
 
     tasks = [
         {"id": "task1", "is_subtask": True, "parent_task_id": "parent1"},

--- a/tests/test_marcus_paths.py
+++ b/tests/test_marcus_paths.py
@@ -1,0 +1,174 @@
+"""Unit tests for Marcus-root discovery and layered config.
+
+Covers ``cato_src/core/marcus_paths.py``: the ``config.local.json``
+overlay on ``config.json`` and the ``discover_marcus_root`` resolution
+order (MARCUS_ROOT env var → merged config → auto-detection).
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cato_src.core import marcus_paths
+
+
+@pytest.fixture
+def isolated_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point marcus_paths at a tmp Cato root with tmp config files.
+
+    Returns the fake Cato root (``tmp_path/cato``); ``config.json`` /
+    ``config.local.json`` live inside it. The root is nested under the
+    per-test ``tmp_path`` so the sibling-of-Cato auto-detection probes
+    ``tmp_path/marcus`` — a location no other test can pollute.
+    """
+    cato_root = tmp_path / "cato"
+    cato_root.mkdir()
+    monkeypatch.setattr(marcus_paths, "_CATO_ROOT", cato_root)
+    monkeypatch.setattr(marcus_paths, "_CONFIG_PATH", cato_root / "config.json")
+    monkeypatch.setattr(
+        marcus_paths, "_LOCAL_CONFIG_PATH", cato_root / "config.local.json"
+    )
+    # Redirect $HOME so the real ~/dev/marcus can't satisfy auto-detection.
+    monkeypatch.setattr(marcus_paths.Path, "home", staticmethod(lambda: tmp_path))
+    return cato_root
+
+
+def _write(path: Path, data: Any) -> None:
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+def _make_marcus_root(base: Path, name: str, marker: str = "src/analysis") -> Path:
+    """Create a fake Marcus tree at base/name with the given marker path."""
+    root = base / name
+    (root / marker).mkdir(parents=True)
+    (root / "data").mkdir()
+    return root
+
+
+# ---------------------------------------------------------------------------
+# load_merged_config
+# ---------------------------------------------------------------------------
+
+
+def test_merged_config_empty_when_no_files(isolated_config: Path) -> None:
+    """Missing config files yield an empty dict, not an error."""
+    assert marcus_paths.load_merged_config() == {}
+
+
+def test_merged_config_reads_config_json(isolated_config: Path) -> None:
+    """config.json is loaded when config.local.json is absent."""
+    _write(isolated_config / "config.json", {"marcus_data_path": "/a/data"})
+    assert marcus_paths.load_merged_config()["marcus_data_path"] == "/a/data"
+
+
+def test_local_config_overrides_config_json(isolated_config: Path) -> None:
+    """config.local.json keys win over config.json keys."""
+    _write(
+        isolated_config / "config.json",
+        {"marcus_data_path": "/shared/data", "history_cutoff_date": "2026-01-01"},
+    )
+    _write(
+        isolated_config / "config.local.json",
+        {"marcus_data_path": "/local/data"},
+    )
+    merged = marcus_paths.load_merged_config()
+    # Overridden by the local file...
+    assert merged["marcus_data_path"] == "/local/data"
+    # ...but shared keys from config.json survive.
+    assert merged["history_cutoff_date"] == "2026-01-01"
+
+
+def test_merged_config_tolerates_invalid_json(isolated_config: Path) -> None:
+    """Malformed config files are ignored rather than crashing."""
+    (isolated_config / "config.json").write_text("{not json")
+    assert marcus_paths.load_merged_config() == {}
+
+
+# ---------------------------------------------------------------------------
+# discover_marcus_root
+# ---------------------------------------------------------------------------
+
+
+def test_discover_from_config_local(
+    isolated_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """config.local.json's marcus_data_path resolves to its parent root."""
+    monkeypatch.delenv("MARCUS_ROOT", raising=False)
+    root = _make_marcus_root(isolated_config, "marcus_install")
+    _write(
+        isolated_config / "config.local.json",
+        {"marcus_data_path": str(root / "data")},
+    )
+    assert marcus_paths.discover_marcus_root("src/analysis") == root
+
+
+def test_env_var_overrides_config(
+    isolated_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MARCUS_ROOT takes precedence over the configured path."""
+    config_root = _make_marcus_root(isolated_config, "configured")
+    env_root = _make_marcus_root(isolated_config, "from_env")
+    _write(
+        isolated_config / "config.local.json",
+        {"marcus_data_path": str(config_root / "data")},
+    )
+    monkeypatch.setenv("MARCUS_ROOT", str(env_root))
+    assert marcus_paths.discover_marcus_root("src/analysis") == env_root
+
+
+def test_marcus_data_paths_plural_resolves_first(
+    isolated_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """marcus_data_paths (plural) resolves to the parent of its first entry."""
+    monkeypatch.delenv("MARCUS_ROOT", raising=False)
+    root = _make_marcus_root(isolated_config, "primary")
+    _write(
+        isolated_config / "config.local.json",
+        {
+            "marcus_data_paths": [
+                str(root / "data"),
+                str(isolated_config / "second" / "data"),
+            ]
+        },
+    )
+    assert marcus_paths.discover_marcus_root("src/analysis") == root
+
+
+def test_marker_must_exist(
+    isolated_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A configured root missing the requested marker is rejected."""
+    monkeypatch.delenv("MARCUS_ROOT", raising=False)
+    # Has src/analysis but not src/cost_tracking.
+    root = _make_marcus_root(isolated_config, "marcus", marker="src/analysis")
+    _write(
+        isolated_config / "config.local.json",
+        {"marcus_data_path": str(root / "data")},
+    )
+    assert marcus_paths.discover_marcus_root("src/analysis") == root
+    assert marcus_paths.discover_marcus_root("src/cost_tracking") is None
+
+
+def test_auto_detect_sibling_of_cato(
+    isolated_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no env var or config, a Marcus sibling of Cato is found."""
+    monkeypatch.delenv("MARCUS_ROOT", raising=False)
+    # _CATO_ROOT is isolated_config; its sibling "marcus" should be detected.
+    root = _make_marcus_root(isolated_config.parent, "marcus")
+    assert marcus_paths.discover_marcus_root("src/analysis") == root
+
+
+def test_discover_returns_none_when_nothing_found(
+    isolated_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns None when Marcus cannot be located anywhere.
+
+    No MARCUS_ROOT, no config, no sibling, and $HOME is redirected by
+    the fixture so the real ~/dev/marcus cannot be found.
+    """
+    monkeypatch.delenv("MARCUS_ROOT", raising=False)
+    assert marcus_paths.discover_marcus_root("src/analysis") is None

--- a/tests/test_marcus_paths.py
+++ b/tests/test_marcus_paths.py
@@ -172,3 +172,33 @@ def test_discover_returns_none_when_nothing_found(
     """
     monkeypatch.delenv("MARCUS_ROOT", raising=False)
     assert marcus_paths.discover_marcus_root("src/analysis") is None
+
+
+# ---------------------------------------------------------------------------
+# Aggregator auto-detection (no-arg construction)
+# ---------------------------------------------------------------------------
+
+
+def test_aggregator_auto_detect_uses_resolver(
+    isolated_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A no-arg Aggregator() resolves its root via the shared resolver."""
+    from cato_src.core.aggregator import Aggregator
+
+    root = _make_marcus_root(isolated_config, "marcus")
+    monkeypatch.setenv("MARCUS_ROOT", str(root))
+    assert Aggregator().marcus_root == root
+
+
+def test_aggregator_raises_when_marcus_not_found(
+    isolated_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A no-arg Aggregator() fails loudly when Marcus cannot be located.
+
+    Replaces the old silent fallback that pointed at the Cato root.
+    """
+    from cato_src.core.aggregator import Aggregator
+
+    monkeypatch.delenv("MARCUS_ROOT", raising=False)
+    with pytest.raises(RuntimeError, match="Marcus"):
+        Aggregator()


### PR DESCRIPTION
## Problem

Cato hardcoded `/Users/lwgray/dev/marcus` in seven places, making it unusable by anyone else. The most dangerous one was a fossil in `Aggregator.__init__` that assumed Cato was a subdirectory of Marcus (`viz/`) — now that Cato is a standalone sibling repo, it silently pointed at the Cato root and served an empty dashboard with no error.

## Changes

- **New `cato_src/core/marcus_paths.py`** — single resolver. Resolution order: `MARCUS_ROOT` env var → merged config → auto-detection (Marcus as a sibling of Cato, or `~/dev/marcus`). `load_merged_config()` overlays gitignored `config.local.json` on the tracked `config.json`.
- **`backend/api.py` / `backend/cost_routes.py`** — discovery via the resolver instead of baked-in absolute paths. `_project_history_dir()` replaces three `~/dev/marcus/.../project_history` fallbacks. Backend resolves a concrete live-mode root up front and **fails loudly** at startup when none is found.
- **`cato_src/core/aggregator.py`** — `Aggregator()` auto-detect now routes through the resolver and raises `RuntimeError` when Marcus can't be located, instead of silently misdirecting at the Cato root.
- **`config.json`** — `marcus_data_path` nulled, example genericized; no personal path is committed.
- **`./cato`** — prompts for the Marcus root on first start, validates it contains both `data/` and `src/`, saves to `config.local.json` (gitignored). Skipped when `MARCUS_ROOT` is set or already configured; errors cleanly with no TTY.
- **`requirements*.txt` / `pyproject.toml`** — capped `httpx <0.28`; 0.28 dropped the `app=` shortcut starlette 0.27's `TestClient` relies on, which was erroring out the entire test suite.

## First-run flow

`./cato start` on a new machine prompts once for the Marcus location → saved to `config.local.json` → reused silently thereafter.

## Tests

- New `tests/test_marcus_paths.py` (12 tests): config overlay, resolution order, marker requirement, sibling auto-detect, Aggregator auto-detect (resolver hit + loud failure).
- `tests/test_bundled_design_display.py` passes an explicit `marcus_root` so its pure-logic tests no longer depend on a Marcus install.
- Full suite: **82 passed, 7 skipped** (skips pre-existing).

Reviewed by Dr. Kaia Chen — the Aggregator fossil was caught during architecture review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)